### PR TITLE
add WeightedOceanMSE to criterion

### DIFF
--- a/modulus/metrics/climate/healpix_loss.py
+++ b/modulus/metrics/climate/healpix_loss.py
@@ -189,3 +189,68 @@ class OceanMSE(th.nn.MSELoss):
             return th.sum(ocean_mean_err) / self.lsm_sum
         else:
             return ocean_mean_err / self.lsm_var_sum
+
+
+class WeightedOceanMSE( th.nn.MSELoss ):
+    """
+    Ocean MSE class offers impementaion for MSE loss with: 
+    1) weighted by a land-sea-mask field. 
+    2) weighted by channel (e.g. sic more than sst)
+    """
+    def __init__(
+        self,
+        lsm_file: str,
+        open_dict: dict = {
+            'engine':'zarr'},
+        selection_dict: dict = {
+            'channel_c':'lsm'},
+        weights: Sequence = [],
+    ):
+        """
+        """
+        super().__init__()
+        self.device = None
+        self.lsm_file = lsm_file
+        self.lsm_ds = None
+        self.open_dict = open_dict
+        self.selection_dict = selection_dict
+        self.lsm_tensor = None 
+        self.lsm_sum_calculated = False
+        self.lsm_sum = None
+        self.lsm_var_sum = None
+        self.loss_weights = th.tensor(weights)
+
+    def setup(self, trainer):
+        """
+        reshape lsm and put on device 
+        pushes weights to cuda device 
+        """
+        ### 1. OCEAN PREP ###
+        self.lsm_ds = xr.open_dataset(self.lsm_file,**self.open_dict).constants.sel(self.selection_dict)
+        # 1-lsm gives the percentage of pixel that has ocean
+        self.lsm_tensor = 1 - th.tensor(np.expand_dims(self.lsm_ds.values,(0,2,3))).to(trainer.device)
+
+        ### 2. WEIGHTS PREP ###
+        try:
+            assert len(trainer.output_variables) == len(self.loss_weights)
+        except AssertionError:
+            raise ValueError('Length of outputs and loss_weights is not the same!')
+
+        self.loss_weights = self.loss_weights.to(device=trainer.device)
+        
+    def forward(self, prediction, target, average_channels=True ):
+         
+        if not self.lsm_sum_calculated:
+            self.lsm_sum = th.broadcast_to(self.lsm_tensor,target.shape).sum()
+            self.lsm_var_sum = th.broadcast_to(self.lsm_tensor,target.shape).sum(dim=(0,1,2,4,5))
+            self.lsm_sum_calculated = True
+        # average weighted 
+        ocean_err = (((target-prediction)**2)*self.lsm_tensor)
+        ocean_mean_err = ocean_err.sum(dim=(0, 1, 2, 4, 5))
+        ocean_mean_err = ocean_mean_err*self.loss_weights
+        
+        if average_channels: 
+            return th.sum(ocean_mean_err)/self.lsm_sum
+        else: 
+            return ocean_mean_err/self.lsm_var_sum
+


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description

I added a new loss function to the criterion module that allows for channel weighting and LSM weighting. This allows us to train a multi-channel DLOM while applying the LSM.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->