### PR TITLE
Gaussian Noise to Coupled Training

### DIFF
--- a/modulus/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/modulus/datapipes/healpix/coupledtimeseries_dataset.py
@@ -310,6 +310,7 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
 
         logger.log(5, "Adding gaussian noise to inputs and integrated_couplings")
         if not self.forecast_mode and self.add_train_noise:
+            print("Adding noise to inputs and integrated_couplings")
             # Iterate over C: inputs.shape = [B, T, C, F, H, W]
             for i in range(inputs.shape[2]):
                 inputs[:, :, i] += self.rng.normal(

--- a/modulus/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/modulus/datapipes/healpix/coupledtimeseries_dataset.py
@@ -308,9 +308,8 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
                     else sol[self._input_indices[sample] + self._output_indices[sample]]
                 )
 
-        logger.log(5, "Adding gaussian noise to inputs and integrated_couplings")
         if not self.forecast_mode and self.add_train_noise:
-            print("Adding noise to inputs and integrated_couplings")
+            logger.log(5, "Adding gaussian noise to inputs and integrated_couplings")
             # Iterate over C: inputs.shape = [B, T, C, F, H, W]
             for i in range(inputs.shape[2]):
                 inputs[:, :, i] += self.rng.normal(

--- a/modulus/datapipes/healpix/data_modules.py
+++ b/modulus/datapipes/healpix/data_modules.py
@@ -832,6 +832,8 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
         prebuilt_dataset: bool = True,
         forecast_init_times: Optional[Sequence] = None,
         couplings: Sequence = None,
+        add_train_noise: Optional[bool] = False,
+        train_noise_params: Optional[DictConfig] = None,
     ):
         """
         Parameters
@@ -907,6 +909,9 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
             components. default None
         """
         self.couplings = couplings
+        self.add_train_noise = add_train_noise
+        self.train_noise_params = train_noise_params
+
         super().__init__(
             src_directory,
             dst_directory,
@@ -1052,6 +1057,8 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
                 drop_last=self.drop_last,
                 add_insolation=self.add_insolation,
                 couplings=self.couplings,
+                add_train_noise=self.add_train_noise,
+                train_noise_params=self.train_noise_params,
             )
             self.val_dataset = CoupledTimeSeriesDataset(
                 dataset.sel(

--- a/modulus/datapipes/healpix/data_modules.py
+++ b/modulus/datapipes/healpix/data_modules.py
@@ -834,6 +834,7 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
         couplings: Sequence = None,
         add_train_noise: Optional[bool] = False,
         train_noise_params: Optional[DictConfig] = None,
+        train_noise_seed: Optional[int] = 42,
     ):
         """
         Parameters
@@ -907,10 +908,17 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
         couplings: Sequence, optional
             a Sequence of dictionaries that define the mechanics of couplings with other earth system
             components. default None
+        add_train_noise: bool, optional
+            Add noise to the training data to inputs and integrated couplings to improve generalization, default False
+        train_noise_params: DictConfig, optional
+            Dictionary containing parameters for adding noise to the training data
+        train_noise_seed: int, optional
+            Seed for the random number generator for adding noise to the training data, default 42
         """
         self.couplings = couplings
         self.add_train_noise = add_train_noise
         self.train_noise_params = train_noise_params
+        self.train_noise_seed = train_noise_seed
 
         super().__init__(
             src_directory,
@@ -1059,6 +1067,7 @@ class CoupledTimeSeriesDataModule(TimeSeriesDataModule):
                 couplings=self.couplings,
                 add_train_noise=self.add_train_noise,
                 train_noise_params=self.train_noise_params,
+                train_noise_seed=self.train_noise_seed + int(dist.rank),
             )
             self.val_dataset = CoupledTimeSeriesDataset(
                 dataset.sel(


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->

Here I add the ability to apply gaussian noise to inputs and coupled variables during training of coupled models. This should improve the stability of coupled rollouts. As it's written, this is not a breaking change - i.e. this code can be merged and no changes to anyones configs are necessary (defaults to applying no noise). I have tested this for training coupled DLWP and DLOM models. Here are examples of the new variables to be added to data/module yaml: 

![Screenshot 2024-11-26 at 2 56 40 PM](https://github.com/user-attachments/assets/bddf411c-d3cd-4961-af7e-f5a5a8be8fcf)


<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->