### PR TITLE
Update indices in constant coupler. 

### DIFF
--- a/modulus/datapipes/healpix/couplers.py
+++ b/modulus/datapipes/healpix/couplers.py
@@ -180,7 +180,7 @@ class ConstantCoupler:
         )
         for i in range(len(self.preset_coupled_fields)):
             self.preset_coupled_fields[i, :, :, :, :, :] = coupled_fields[
-                0, 0, -1, :, :, :
+                0, -1, :, :, :, :
             ]
         # flag for construct integrated coupling method to use this array
         self.coupled_mode = True


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Fix indices in constant coupler to select last output time step from coupled input data 
<!-- This will also fix unexpected behavior in ocean models with more than one variable  

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.