### PR TITLE
Fix the coupler indexing for ocean data

### DIFF
--- a/modulus/datapipes/healpix/couplers.py
+++ b/modulus/datapipes/healpix/couplers.py
@@ -394,7 +394,7 @@ class TrailingAverageCoupler:
         #
         # for example 'z1000' is in 'z1000-48H'
         channel_indices = [
-            i for i, oc in enumerate(output_channels) for v in self.variables if oc in v
+            i for i, oc in enumerate(output_channels) for v in self.variables if oc == v.split('-')[0]
         ]
         self.coupled_channel_indices = channel_indices
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The indexing in `TrailingAverageCoupler` has problem for large dataset. The [line](https://github.com/AtmosSci-DLESM/modulus-uw/blob/afb4e63c213ea5d68a1e1e16e6ed6c090b86e2ab/modulus/datapipes/healpix/couplers.py#L396) in `setup_coupling` :
`channel_indices = [ i for i, oc in enumerate(output_channels) for v in self.variables if oc in v ]`

 self.variables  is `[z1000-48H, ws10m-48H]`  and output_channels  is `['tcwv', 'z1000', 'z850', 'z700', 'z500', 'z250', 'z100', 'z50', 't2m', 't850', 't700', 't500', 't250', 't100', 't50', 'ws10m', 'ws850', 'ws700', 'ws500', 'ws250', 'ws100', 'ws50', 'q850', 'q700', 'q500', 'q
2m']`

So the logic is to find  `output_channels`  variable which is inside the string of `self.variables`. As a result, `z1000`  in `z1000-48H`  and `ws10m` in `ws10m-48H`  but we will get a unwanted `z100`  in `z1000-48H` . Therefore the error shows one more input is added in coupler. 

To solve it, I suggest to check `output_channels` variable is exactly the same as self.variables  name without `-48H` :
`channel_indices = [ i for i, oc in enumerate(output_channels) for v in self.variables if oc == v.split('-')[0] ]`
There are two assumptions: 
the variable name format must be `xxx-yyH` , where `yy` is the averaging windows
`output_channels`  name must not include `- `.
## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
- [X] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [X] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->