### PR TITLE
fix memory leak in coupled timeseries

### DIFF
--- a/modulus/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/modulus/datapipes/healpix/coupledtimeseries_dataset.py
@@ -16,6 +16,7 @@
 
 import logging
 import time
+import gc
 from dataclasses import dataclass
 from typing import Optional, Sequence, Union
 
@@ -197,7 +198,7 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
             self.ds["inputs"]
             .sel(channel_in=self.input_variables)
             .isel(**batch)
-            .to_numpy()
+            .values.copy()
         )
         # retrieve coupled inputs
         if len(self.couplings) > 0:
@@ -220,7 +221,7 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
                 self.ds["targets"]
                 .sel(channel_out=self.output_variables)
                 .isel(**batch)
-                .to_numpy()
+                .values.copy()
             )
             target_array = (
                 target_array - self.target_scaling["mean"]
@@ -290,6 +291,12 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
                         scale=self.train_noise_params["couplings"][v]["std"],
                         size=integrated_couplings[i, :, :].shape
                     )
+
+        # Explicitly delete large temporary arrays so they can be garbage-collected
+        del input_array
+        if not self.forecast_mode:
+            del target_array
+        gc.collect()
 
         inputs_result = [inputs]
         if self.add_insolation:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
The following PR is fixing a memory leak observed in training coupled models. This leak is a blocker for training large models (20+ channels) on nodes with <0.5TB of CPU memory (Perlmutter). 
At hpx128 26ch training, the current code (before the fix) arrives at 100% of the CPU memory in 12min 
```
Process RSS 53874.16 MB, Percent used: 98.6%
After to_numpy: Available memory 1004.59 MB,
Process RSS 53911.06 MB, Percent used: 99.6%
Before to_numpy: Available memory 2442.05 MB, 
Process RSS 53739.00 MB, Percent used: 99.1%
After to_numpy: Available memory 242.00 MB,
Process RSS 54205.14 MB, Percent used: 99.9%
Before to_numpy: Available memory 1663.72 MB, 
Process RSS 54345.10 MB, Percent used: 99.4%
After to_numpy: Available memory 0.00 MB,
Process RSS 54513.23 MB, Percent used: 100.0%
Before to_numpy: Available memory 151.45 MB, 
Process RSS 54336.79 MB, Percent used: 99.9%
After to_numpy: Available memory 0.00 MB,
Process RSS 54800.34 MB, Percent used: 100.0%
```
A typical error message is 
```
RuntimeError: DataLoader worker (pid 342310) is killed by signal: Killed. 
slurmstepd: error: Detected 1 oom_kill event in StepId=36395462.0. Some of the step tasks have been OOM Killed.
```


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [x] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->