### PR TITLE
Add drop out and normalization to blocks

### DIFF
--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -196,23 +196,19 @@ class ConstantCoupler:
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        if coupled_fields.shape[0] != self.batch_size:
-            raise ValueError(
-                f"Batch size of coupled field {coupled_fields.shape[0]} doesn't "
-                f" match configured batch size {self.batch_size}"
-            )
+
         # create buffer for coupling
         coupled_fields = coupled_fields[
             :, :, :, self.coupled_channel_indices, :, :
         ].permute(2, 0, 3, 1, 4, 5)
         self.preset_coupled_fields = th.empty(
-            [self.coupled_integration_dim, self.batch_size, self.timevar_dim]
+            [self.coupled_integration_dim, coupled_fields.shape[1], self.timevar_dim]
             + list(self.spatial_dims)
         )
         # we use a constant set of values so we just copy time 0
         for i in range(len(self.preset_coupled_fields)):
             self.preset_coupled_fields[i, :, :, :, :, :] = coupled_fields[
-                0, :, -1, :, :, :
+                0, :, -1:, :, :, :
             ]
         # flag for construct integrated coupling method to use this array
         self.coupled_mode = True
@@ -477,11 +473,6 @@ class TrailingAverageCoupler:
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        if coupled_fields.shape[0] != self.batch_size:
-            raise ValueError(
-                f"Batch size of coupled field {coupled_fields.shape[0]} doesn't "
-                f" match configured batch size {self.batch_size}"
-            )
 
         coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
         # TODO: Now support output_time_dim =/= input_time_dim, but presteps need to be 0, will add support for presteps>0

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -352,7 +352,6 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             raise ValueError("Length of outputs and loss_weights is not the same!")
 
         self.loss_weights = self.loss_weights.to(device=trainer.device)
-        self.n_members = th.tensor(self.n_members, device=trainer.device)
         self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
         self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
 
@@ -371,25 +370,18 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         average_channels: bool, optional
             whether the mean of the channels should be taken
         """
+        
+        # Unfold ensemble dimension from batch dimension to have shape [N, B, F, T, C, H, W]
+        b = target.shape[0]
+        prediction = prediction.view(self.n_members, b, *prediction.shape[1:])
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
             raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
-        if not prediction.shape[0] == self.n_members:
+    
+        if not prediction.shape[0] % self.n_members == 0:
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
         
-        # # initialize crps field with zeros
-        # crps = th.zeros_like(prediction[0,...])
-        # # loop over all ensemble members
-        # for j in range(self.n_members):
-        #     xj = prediction[j,...]
-        #     for k in range(self.n_members):
-        #         xk = prediction[k,...]
-        #         if j != k:
-        #             # this is the crps as defined in https://arxiv.org/html/2412.15832v1 equation 4
-        #             crps += th.abs(xj - target) + th.abs(xk - target) - self.coeff_eps * th.abs(xj - xk)
-        # "fair" averaging using triangle inequality
-        # crps = crps * self.averaging_coeff
         crps_terms = []
         for j in range(self.n_members):
             xj = prediction[j,...]

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -358,21 +358,20 @@ class WeightedCRPSLoss(th.nn.MSELoss):
     def forward(self, prediction, target, average_channels=True):
         """
         Forward pass of the WeightedCRPSLoss 
-        Prediction tensor is expected to be in the shape [N, B, F, C, H, W, M] where M is the number of ensemble members.
-        Target tensor is expected to be in the shape [N, B, F, C, H, W]. No ensemble dimension is expected.
+        Computes the CRPS loss for the model prediction and target.
 
         Parameters
         ----------
         prediction: torch.Tensor
-            The prediction tensor
+            The prediction tensor shape [Cond*B, F, T, C, H, W] where Cond is the number of ensemble members
         target: torch.Tensor
-            The target tensor
+            The target tensor shape [B, F, T, C, H, W]
         average_channels: bool, optional
             whether the mean of the channels should be taken
         """
         
-        # Unfold ensemble dimension from batch dimension to have shape [N, B, F, T, C, H, W]
-        b = target.shape[0]
+        # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
+        b = target.shape[0] # get batch shape from target
         prediction = prediction.view(self.n_members, b, *prediction.shape[1:])
 
         # checks for dimensions 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -343,6 +343,9 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.coeff_eps = 1 - ((1-alpha) / (n_members))
         self.averaging_coeff = 1 / (n_members * (n_members - 1))
 
+        # Static indices to idnex unique pairs of ensemble members (CUDA graph capture safe)
+        self.i, self.j = th.triu_indices(self.n_members, self.n_members, offset=1)
+
     def setup(self, trainer):
         """
         pushes constants to cuda device
@@ -354,6 +357,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.loss_weights = self.loss_weights.to(device=trainer.device)
         self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
         self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
+        self.i = self.i.to(device=trainer.device)
+        self.j = self.j.to(device=trainer.device)
 
     def forward(self, prediction, target, average_channels=True):
         """
@@ -371,8 +376,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
-        b = target.shape[0] # get batch shape from target
-        prediction = prediction.view(self.n_members, b, *prediction.shape[1:])
+        b, f, t, c, h, w = target.shape # get batch shape from target
+        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
@@ -380,24 +385,24 @@ class WeightedCRPSLoss(th.nn.MSELoss):
     
         if not prediction.shape[0] % self.n_members == 0:
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
-        
-        crps_terms = []
-        for j in range(self.n_members):
-            xj = prediction[j,...]
-            for k in range(self.n_members):
-                xk = prediction[k,...]
-                if j != k:
-                    term = th.abs(xj - target) + th.abs(xk - target) - self.coeff_eps * th.abs(xj - xk)
-                    crps_terms.append(term)
 
-        crps = th.stack(crps_terms).sum(dim=0) * self.averaging_coeff
-        # ToDo: speed up CRPS calculation?
-        # I could permute array to apply operations exclusively on tensors
-        # This would involve reshaping the tensors and using indexing to avoid the double loop
-        crps = crps.mean(dim=(0, 1, 2, 4, 5)) * self.loss_weights
+        # Compute first term of the afCRPS formula
+        diff_target = th.abs(prediction - target.unsqueeze(0)).mean(dim=0) # [B, F, T, C, H, W]
+
+        # Compute the last term of the afCRPS formula (pairwise L1 distance matrix)
+        # Index only the upper triangular part of the matrix for unique pairs
+        dist_matrix = th.abs(prediction.unsqueeze(1) - prediction.unsqueeze(0)) # [Cond, Cond, B, F, T, C, H, W]
+        diff_ensemble = dist_matrix[self.i, self.j] # [num_unique_pairs, B, F, T, C, H, W]
+        diff_ensemble = diff_ensemble.sum(dim=0) # [B, F, T, C, H, W]
+
+        # afCRPS formula
+        crps = diff_target - self.coeff_eps * self.averaging_coeff * diff_ensemble # [B, F, T, C, H, W]
+
+        crps *= self.loss_weights[None, None, None, :, None, None] # [B, F, T, C, H, W]
+
         if average_channels:
-            return th.mean(crps)
+            return crps.mean()
         else:
-            return crps
+            return crps.mean(dim=(0, 1, 2, 4, 5))
 
 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -341,6 +341,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
 
         # parameter for almost fair CRPS loss. See https://arxiv.org/html/2412.15832v1
         self.coeff_eps = 1 - ((1-alpha) / (n_members))
+        self.averaging_coeff = 1 / (n_members * (n_members - 1))
 
     def setup(self, trainer):
         """
@@ -353,7 +354,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.loss_weights = self.loss_weights.to(device=trainer.device)
         self.n_members = th.tensor(self.n_members, device=trainer.device)
         self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
-        
+        self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
 
     def forward(self, prediction, target, average_channels=True):
         """
@@ -370,22 +371,38 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         average_channels: bool, optional
             whether the mean of the channels should be taken
         """
-        if not (prediction.ndim == 7 and target.ndim == 7):
-            raise AssertionError("Probabilistic loss expects predictions to have 7 dimensions (last corresponds to ensemble members)")
 
-        # initialize crps field with zeros
-        crps = th.zeros_like(prediction[..., 0])
-        # loop over all ensemble members
-        for j in range(self.n_members):
-            xj = prediction[..., j]
-            for k in range(self.n_members):
-                xk = prediction[..., k]
-                if j != k:
-                    # this is the crps as defined in https://arxiv.org/html/2412.15832v1 equation 4
-                    crps += th.abs(xj - prediction) + th.abs(xk - prediction) - self.coeff_eps * th.abs(xj - xk)
+        # checks for dimensions 
+        if not prediction.shape[1:] == target.shape:
+            raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
+        if not prediction.shape[0] == self.n_members:
+            raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
         
+        # # initialize crps field with zeros
+        # crps = th.zeros_like(prediction[0,...])
+        # # loop over all ensemble members
+        # for j in range(self.n_members):
+        #     xj = prediction[j,...]
+        #     for k in range(self.n_members):
+        #         xk = prediction[k,...]
+        #         if j != k:
+        #             # this is the crps as defined in https://arxiv.org/html/2412.15832v1 equation 4
+        #             crps += th.abs(xj - target) + th.abs(xk - target) - self.coeff_eps * th.abs(xj - xk)
+        # "fair" averaging using triangle inequality
+        # crps = crps * self.averaging_coeff
+        crps_terms = []
+        for j in range(self.n_members):
+            xj = prediction[j,...]
+            for k in range(self.n_members):
+                xk = prediction[k,...]
+                if j != k:
+                    term = th.abs(xj - target) + th.abs(xk - target) - self.coeff_eps * th.abs(xj - xk)
+                    crps_terms.append(term)
 
-
+        crps = th.stack(crps_terms).sum(dim=0) * self.averaging_coeff
+        # ToDo: speed up CRPS calculation?
+        # I could permute array to apply operations exclusively on tensors
+        # This would involve reshaping the tensors and using indexing to avoid the double loop
         crps = crps.mean(dim=(0, 1, 2, 4, 5)) * self.loss_weights
         if average_channels:
             return th.mean(crps)

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -307,3 +307,89 @@ class WeightedOceanMSE(th.nn.MSELoss):
             return th.sum(ocean_mean_err) / self.lsm_sum
         else:
             return ocean_mean_err / self.lsm_var_sum
+        
+class WeightedCRPSLoss(th.nn.MSELoss):
+
+    """
+    Probabilistic loss function that allows for user defined weighting of variables when calculating CRPS.
+    """
+
+    def __init__(
+        self,
+        weights: Sequence = [],
+        n_members: int = 2,
+        alpha: float = 0.95
+    ):
+        """
+        Parameters
+        ----------
+        weights: Sequence
+            list of floats that determine weighting of variable loss, assumed to be
+            in order consistent with order of model output channels
+        n_members: int
+            number of ensemble members in the model output
+        alpha: float
+            hyperparamter for approximating fair CRPS loss. between 0 and 1, 1 corresponds to a fair CRPS loss.
+        """
+        super().__init__()
+        self.loss_weights = th.tensor(weights)
+        if n_members < 2:
+            raise ValueError("n_members must be at least 2 for CRPS loss to be defined")
+        else:    
+            self.n_members = n_members
+        self.device = None
+
+        # parameter for almost fair CRPS loss. See https://arxiv.org/html/2412.15832v1
+        self.coeff_eps = 1 - ((1-alpha) / (n_members))
+
+    def setup(self, trainer):
+        """
+        pushes constants to cuda device
+        """
+
+        if len(trainer.output_variables) != len(self.loss_weights):
+            raise ValueError("Length of outputs and loss_weights is not the same!")
+
+        self.loss_weights = self.loss_weights.to(device=trainer.device)
+        self.n_members = th.tensor(self.n_members, device=trainer.device)
+        self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
+        
+
+    def forward(self, prediction, target, average_channels=True):
+        """
+        Forward pass of the WeightedCRPSLoss 
+        Prediction tensor is expected to be in the shape [N, B, F, C, H, W, M] where M is the number of ensemble members.
+        Target tensor is expected to be in the shape [N, B, F, C, H, W]. No ensemble dimension is expected.
+
+        Parameters
+        ----------
+        prediction: torch.Tensor
+            The prediction tensor
+        target: torch.Tensor
+            The target tensor
+        average_channels: bool, optional
+            whether the mean of the channels should be taken
+        """
+        if not (prediction.ndim == 7 and target.ndim == 7):
+            raise AssertionError("Probabilistic loss expects predictions to have 7 dimensions (last corresponds to ensemble members)")
+
+        # initialize crps field with zeros
+        crps = th.zeros_like(prediction[..., 0])
+        # loop over all ensemble members
+        for j in range(self.n_members):
+            xj = prediction[..., j]
+            for k in range(self.n_members):
+                xk = prediction[..., k]
+                if j != k:
+                    # this is the crps as defined in https://arxiv.org/html/2412.15832v1 equation 4
+                    crps += th.abs(xj - prediction) + th.abs(xk - prediction) - self.coeff_eps * th.abs(xj - xk)
+        
+
+
+        crps = crps.mean(dim=(0, 1, 2, 4, 5)) * self.loss_weights
+        if average_channels:
+            return th.mean(crps)
+        else:
+            return crps
+
+

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -307,7 +307,7 @@ class WeightedOceanMSE(th.nn.MSELoss):
             return th.sum(ocean_mean_err) / self.lsm_sum
         else:
             return ocean_mean_err / self.lsm_var_sum
-        
+
 class WeightedCRPSLoss(th.nn.MSELoss):
 
     """
@@ -339,12 +339,14 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             self.n_members = n_members
         self.device = None
 
-        # parameter for almost fair CRPS loss. See https://arxiv.org/html/2412.15832v1
+        # Parameters for "almost fair CRPS" loss. See https://arxiv.org/html/2412.15832v1
         self.coeff_eps = 1 - ((1-alpha) / (n_members))
-        self.averaging_coeff = 1 / (n_members * (n_members - 1))
+        self.averaging_coeff = 1 / (2* n_members * (n_members - 1))
 
-        # Static indices to idnex unique pairs of ensemble members (CUDA graph capture safe)
-        self.i, self.j = th.triu_indices(self.n_members, self.n_members, offset=1)
+        # For n>2, will use pairwise distance to copmute [NxN] distance matrix
+        # Diagonal elements of (prediciton - target) matrix are zeroed out to avoid double counting
+        self.pdist = th.nn.PairwiseDistance(p=1)
+        self.diag_mask = th.ones(self.n_members, self.n_members) - th.eye(self.n_members) # Mask to zero out diagonal elements
 
     def setup(self, trainer):
         """
@@ -355,10 +357,10 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             raise ValueError("Length of outputs and loss_weights is not the same!")
 
         self.loss_weights = self.loss_weights.to(device=trainer.device)
-        self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
         self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
-        self.i = self.i.to(device=trainer.device)
-        self.j = self.j.to(device=trainer.device)
+        self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
+        self.pdist = self.pdist.to(device=trainer.device)
+        self.diag_mask = self.diag_mask.to(device=trainer.device)
 
     def forward(self, prediction, target, average_channels=True):
         """
@@ -376,33 +378,54 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
-        b, f, t, c, h, w = target.shape # get batch shape from target
+        b, f, t, c, h, w = target.shape
         prediction = prediction.view(self.n_members, b, f, t, c, h, w)
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
             raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
     
-        if not prediction.shape[0] % self.n_members == 0:
+        if not prediction.shape[0] == self.n_members:
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
 
-        # Compute first term of the afCRPS formula
-        diff_target = th.abs(prediction - target.unsqueeze(0)).mean(dim=0) # [B, F, T, C, H, W]
+        n = self.n_members
 
-        # Compute the last term of the afCRPS formula (pairwise L1 distance matrix)
-        # Index only the upper triangular part of the matrix for unique pairs
-        dist_matrix = th.abs(prediction.unsqueeze(1) - prediction.unsqueeze(0)) # [Cond, Cond, B, F, T, C, H, W]
-        diff_ensemble = dist_matrix[self.i, self.j] # [num_unique_pairs, B, F, T, C, H, W]
-        diff_ensemble = diff_ensemble.sum(dim=0) # [B, F, T, C, H, W]
+        # Apply channel weights across channel dims
+        prediction *= self.loss_weights[None, None, None, None, :, None, None]
+        target *= self.loss_weights[None, None, None, :, None, None]
 
-        # afCRPS formula
-        crps = diff_target - self.coeff_eps * self.averaging_coeff * diff_ensemble # [B, F, T, C, H, W]
+        if n == 2:
+            # Use faster explicit implementation
+            diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
+            diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
+            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
-        crps *= self.loss_weights[None, None, None, :, None, None] # [B, F, T, C, H, W]
-
-        if average_channels:
-            return crps.mean()
+            if average_channels:
+                return crps.mean()
+            else:
+                return crps.mean(dim=(0, 1, 2, 4, 5))
         else:
-            return crps.mean(dim=(0, 1, 2, 4, 5))
+            # Use pairwise distance method
+            if not average_channels:
+                # Move channels to first dimension and exclude that dimension from the reductions           
+                prediction = prediction.permute(4, 0, 1, 2, 3, 5, 6) # [C, Cond, B, F, T, H, W]
+                target = target.permute(3, 0, 1, 2, 4, 5) # [C, B, F, T, H, W]
 
+                prediction = prediction.reshape(c, n, -1) # [C, Cond, ...]
+                target = target.unsqueeze(1).reshape(c, 1, -1) # [C, 1, ...] (second dim will broadcast across ensemble)
 
+                diff = self.pdist(prediction, target) # [C, Cond]
+                dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(2))  # [C, Cond, Cond]
+                
+                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
+            else:
+                prediction = prediction.reshape(n, -1)
+                target = target.unsqueeze(0).reshape(1, -1) # [1, ...] (first dim will broadcast across ensemble)
+                diff = self.pdist(prediction, target) # [Cond]
+                dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(0))  # [Cond, Cond] 
+
+                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
+
+            return crps

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -328,7 +328,7 @@ class HEALPixRecUNet(Module):
         return res
 
     def _initialize_hidden(
-        self, inputs: Sequence, outputs: Sequence, step: int
+        self, inputs: Sequence, outputs: Sequence, step: int, conditions_cln: Sequence = None
     ) -> None:
         """Initialize the hidden layers
 
@@ -340,6 +340,8 @@ class HEALPixRecUNet(Module):
             Outputs to use to initialize the hideen layers
         step: int
             Current step number of the initialization
+        conditions_cln: Sequence, optional
+            Conditional inputs for the normalization layers.
         """
         self.reset()
         for prestep in range(self.presteps):
@@ -384,9 +386,9 @@ class HEALPixRecUNet(Module):
                         inputs=[outputs[s - 1]] + list(inputs[1:]), step=s + 1
                     )
             # Forward the data through the model to initialize hidden states
-            self.decoder(self.encoder(input_tensor))
+            self.decoder(self.encoder(input_tensor, conditions_cln=conditions_cln), conditions_cln=conditions_cln)
 
-    def forward(self, inputs: Sequence, output_only_last=False) -> th.Tensor:
+    def forward(self, inputs: Sequence, output_only_last=False, conditions_cln=None) -> th.Tensor:
         """
         Forward pass of the HEALPixUnet
 
@@ -398,17 +400,22 @@ class HEALPixRecUNet(Module):
             [F, C, H, W] is the format for constants
         output_only_last: bool, optional
             If only the last dimension of the outputs should be returned
+        conditions_cln: Sequence, optional
+            If the model is using conditional normalization, this is a sequence of tensors
+            that will be used to condition the normalization layers. The shape of the tensors
+            should be [N], where N is the size of the condition.
 
         Returns
         -------
         th.Tensor: Predicted outputs
         """
+
         self.reset()
         outputs = []
         for step in range(self.integration_steps):
             # (Re-)initialize recurrent hidden states
             if (step * (self.delta_t * self.input_time_dim)) % self.reset_cycle == 0:
-                self._initialize_hidden(inputs=inputs, outputs=outputs, step=step)
+                self._initialize_hidden(inputs=inputs, outputs=outputs, step=step, conditions_cln=conditions_cln)
 
             # Construct concatenated input: [prognostics|TISR|constants]
             if step == 0:
@@ -452,9 +459,19 @@ class HEALPixRecUNet(Module):
                         step=step + self.presteps,
                     )
 
-            # Forward through model
-            encodings = self.encoder(input_tensor)
-            decodings = self.decoder(encodings)
+            # Forward through model, with or without conditions
+            # print('=========================================================================================')
+            # print('Inside HPXRecUnet forward pass')
+            # print(f'conditions_cln: {conditions_cln}')
+            # print(f'conditions_cln shape: {conditions_cln.shape if conditions_cln is not None else "None"}')
+            # print('=========================================================================================')
+            # exit()
+            if conditions_cln is not None:
+                encodings = self.encoder(input_tensor, conditions_cln=conditions_cln)
+                decodings = self.decoder(encodings, conditions_cln=conditions_cln)
+            else:
+                encodings = self.encoder(input_tensor)
+                decodings = self.decoder(encodings)
 
             # Residual prediction
             reshaped = self._reshape_outputs(

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -209,7 +209,7 @@ class HEALPixRecUNet(Module):
 
         Returns
         -------
-        torch.Tensor: reshaped Tensor in expected shape for model encoder
+        torch.Tensor: reshaped Tensor in expected shape for model encoder [F*B, T*C+n_constants+(coupled_channels*coupled_input_times), H, W]
         """
 
         if len(self.couplings) > 0:
@@ -395,21 +395,24 @@ class HEALPixRecUNet(Module):
         Parameters
         ----------
         inputs: Sequence
-            Inputs to the model, of the form [prognostics|TISR|constants]
-            [B, F, T, C, H, W] is the format for prognostics and TISR
+            Inputs to the model, of the form [prognostics|TISR|constants|coupled inputs].
+            [B*Cond, F, T, C, H, W] is the format for prognostics and TISR. Cond is the number of (optional) conditional inputs.
+                Note the time dimension in prognostics is for initialization and hidden state priming (input_time_dim*2) while
+                the T dimension in TISR is for initialization and hidden state priming as well as roll-out. There are 2 additional 
+                time steps provided to TISR that are apparently not used. 
             [F, C, H, W] is the format for constants
+            [T, B*Cond, C, F, H, W] is the format for coupled inputs. Here time is for initialization and roll-out (one per model step).
         output_only_last: bool, optional
             If only the last dimension of the outputs should be returned
         conditions_cln: Sequence, optional
-            If the model is using conditional normalization, this is a sequence of tensors
-            that will be used to condition the normalization layers. The shape of the tensors
-            should be [N], where N is the size of the condition.
+            If the model is using conditional normalization, this is a sequence of tensors that will be used to condition the 
+            normalization layers. The shape of the tensors should be [Cond*B, N], where N is the size of the conditions, Cond is the 
+            number of conditions, and B is the batch size.
 
         Returns
         -------
         th.Tensor: Predicted outputs
         """
-
         self.reset()
         outputs = []
         for step in range(self.integration_steps):
@@ -460,19 +463,12 @@ class HEALPixRecUNet(Module):
                     )
 
             # Forward through model, with or without conditions
-            # print('=========================================================================================')
-            # print('Inside HPXRecUnet forward pass')
-            # print(f'conditions_cln: {conditions_cln}')
-            # print(f'conditions_cln shape: {conditions_cln.shape if conditions_cln is not None else "None"}')
-            # print('=========================================================================================')
-            # exit()
             if conditions_cln is not None:
                 encodings = self.encoder(input_tensor, conditions_cln=conditions_cln)
                 decodings = self.decoder(encodings, conditions_cln=conditions_cln)
             else:
                 encodings = self.encoder(input_tensor)
                 decodings = self.decoder(encodings)
-
             # Residual prediction
             reshaped = self._reshape_outputs(
                 input_tensor[:, : self.input_channels * self.input_time_dim] + decodings

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -18,8 +18,12 @@ from typing import Sequence, Tuple, Union
 
 import torch
 import torch as th
-
 from .healpix_layers import HEALPixLayer
+from .normalization import ConditionalLayerNorm
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from omegaconf import OmegaConf
 #
 # RECURRENT BLOCKS
 #
@@ -494,7 +498,7 @@ class DoubleConvNeXtBlock(th.nn.Module):
 
 class Multi_SymmetricConvNeXtBlock(th.nn.Module):
     """
-    Class for creating multi-block SymmetricConvNeXtBlock. Defaults to all SymmetricConvNeXtBlocks having same parameters
+    Wrapper for SymmetricConvNeXtBlock that allows serial linking of blocks. 
     """
 
     def __init__(
@@ -512,43 +516,70 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
         enable_healpixpad: bool = False,
         batch_norm: bool = False,
         dropout: float = 0.0,
+        conditional_layer_norm: DictConfig = None,
     ):
         """
         Parameters
         ----------
         n_layers: int, optional
             The number of SymmetricConvNeXt Blocks
+        conditional_layer_norm: DictConfig, optional
+            Configuration for conditional layer normalization. If None, 
+            no conditional layer normalization is applied.
         """
         super().__init__()
 
         # Create a ModuleList to store complete blocks
         self.blocks = th.nn.ModuleList()
+        # flag for conditional layer normalization
+        self.cln_enabled = conditional_layer_norm is not None
 
         for i in range(n_layers):
             curr_in = in_channels if i == 0 else out_channels
 
+            # collect context dependent parameters into a config
+            conv_block = {
+                # we have to add target format to support recursive instantiation
+                '_target_': 'physicsnemo.models.dlwp_healpix_layers.healpix_blocks.SymmetricConvNeXtBlock',
+                "geometry_layer": geometry_layer,
+                "in_channels": curr_in,
+                "latent_channels": latent_channels,
+                "out_channels": out_channels,
+                "kernel_size": kernel_size,
+                "dilation": dilation,
+                "n_layers": n_layers,  # not used, but required for hydra instantiation
+                "upscale_factor": upscale_factor,
+                "activation": activation,
+                "enable_nhwc": enable_nhwc,
+                "enable_healpixpad": enable_healpixpad,
+                "batch_norm": batch_norm,
+                "dropout": dropout,
+                "conditional_layer_norm": conditional_layer_norm if conditional_layer_norm is not None else None,
+            }
             # Create a single block as a separate Module
-            self.blocks.append(
-                SymmetricConvNeXtBlock(
-                    geometry_layer=geometry_layer,
-                    in_channels=curr_in,
-                    latent_channels=latent_channels,
-                    out_channels=out_channels,
-                    kernel_size=kernel_size,
-                    dilation=dilation,
-                    upscale_factor=upscale_factor,
-                    activation=activation,
-                    enable_nhwc=enable_nhwc,
-                    enable_healpixpad=enable_healpixpad,
-                    batch_norm=batch_norm,
-                    dropout=dropout,
-                )
-            )
+            self.blocks.append(instantiate(conv_block))
+            # self.blocks.append(
+            #     SymmetricConvNeXtBlock(
+            #         geometry_layer=geometry_layer,
+            #         in_channels=curr_in,
+            #         latent_channels=latent_channels,
+            #         out_channels=out_channels,
+            #         kernel_size=kernel_size,
+            #         dilation=dilation,
+            #         upscale_factor=upscale_factor,
+            #         activation=activation,
+            #         enable_nhwc=enable_nhwc,
+            #         enable_healpixpad=enable_healpixpad,
+            #         batch_norm=batch_norm,
+            #         dropout=dropout,
+            #         conditional_layer_norm=conditional_layer_norm if conditional_layer_norm is not None else None,
+            #     ),
+            # )
 
-    def forward(self, x):
+    def forward(self, x, conditions_cln=None):
         out = x
         for block in self.blocks:
-            out = block(out)
+            out = block(out, conditions_cln=conditions_cln)
         return out
 
 
@@ -574,6 +605,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         enable_healpixpad: bool = False,
         batch_norm: bool = False,
         dropout: float = 0.0,
+        conditional_layer_norm: th.nn.Module = None,
     ):
         """
         Parameters
@@ -600,18 +632,28 @@ class SymmetricConvNeXtBlock(th.nn.Module):
             If HEALPixPadding should be enabled, passed to wrapper
         use_block_skip_connection: bool, optional
             Whether or not to use block-level skip connection
+        batch_norm: bool, optional
+            Whether or not to use batch normalization after the first convolution
+        dropout: float, optional
+            Dropout probability to apply after the first convolution
+        conditional_layer_norm: th.nn.Module, optional
+            conditional layer normalization. If None,
+            no conditional layer normalization is applied.
         """
+
         super().__init__()
 
         self.use_block_skip_connection = use_block_skip_connection
+        self.activation = activation
+        self.dropout = dropout > 0.0
+        self.cln_enabled = conditional_layer_norm is not None
 
         if use_block_skip_connection:
-
             if in_channels == int(latent_channels):
-                self.skip_module = lambda x: x  # Identity-function required in forward pass
+                self.skip_module = lambda x: x
             else:
                 self.skip_module = geometry_layer(
-                    layer=torch.nn.Conv2d,
+                    layer=th.nn.Conv2d,
                     in_channels=in_channels,
                     out_channels=out_channels,
                     kernel_size=1,
@@ -619,95 +661,125 @@ class SymmetricConvNeXtBlock(th.nn.Module):
                     enable_healpixpad=enable_healpixpad,
                 )
 
-        # 1st ConvNeXt block, the output of this one remains internal
-        convblock = []
-        # 3x3 convolution establishing latent channels channels
-        convblock.append(
-            geometry_layer(
-                layer=torch.nn.Conv2d,
-                in_channels=in_channels,
-                out_channels=int(latent_channels),
-                kernel_size=kernel_size,
-                dilation=dilation,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-            )
+        # 3x3: in → latent
+        self.initial_conv = geometry_layer(
+            layer=th.nn.Conv2d,
+            in_channels=in_channels,
+            out_channels=int(latent_channels),
+            kernel_size=kernel_size,
+            dilation=dilation,
+            enable_nhwc=enable_nhwc,
+            enable_healpixpad=enable_healpixpad,
         )
-        # Apply BatchNorm or LayerNorm here
-        if batch_norm:
-            convblock.append(
-                th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False)
-            )
-        
-        if activation is not None:
-            convblock.append(activation)
 
-        # Apply Dropout 
-        if dropout: 
-            convblock.append(th.nn.Dropout2d(p=dropout))
-
-        # 1x1 convolution establishing increased channels
-        convblock.append(
-            geometry_layer(
-                layer=torch.nn.Conv2d,
-                in_channels=int(latent_channels),
-                out_channels=int(latent_channels * upscale_factor),
-                kernel_size=1,
-                dilation=dilation,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-            )
+        self.batch_norm = (
+            th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False)
+            if batch_norm else None
         )
-        if activation is not None:
-            convblock.append(activation)
-        # 1x1 convolution returning to latent channels
-        convblock.append(
-            geometry_layer(
-                layer=torch.nn.Conv2d,
-                in_channels=int(latent_channels * upscale_factor),
-                out_channels=int(latent_channels),
-                kernel_size=1,
-                dilation=dilation,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-            )
-        )
-        if activation is not None:
-            convblock.append(activation)
-        # 3x3 convolution from latent channels to latent channels
-        convblock.append(
-            geometry_layer(
-                layer=torch.nn.Conv2d,
-                in_channels=int(latent_channels),
-                out_channels=out_channels,  # int(latent_channels),
-                kernel_size=kernel_size,
-                dilation=dilation,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-            )
-        )
-        if activation is not None:
-            convblock.append(activation)
-        self.convblock = th.nn.Sequential(*convblock)
+        # Conditional Layer Normalization
+        if conditional_layer_norm is not None:
+            # resolve context-dependent parameters
+            self.cln = conditional_layer_norm
+            self.cln.setup_cln(channel_depth=int(latent_channels))
+        else:
+            self.cln = None
+        # self.cln = conditional_layer_norm if conditional_layer_norm is not None else None
 
-    def forward(self, x):
-        """Forward pass of the SymmetricConvNextBlock
+        self.dropout_layer = (
+            th.nn.Dropout2d(p=dropout)
+            if self.dropout else None
+        )
 
+        # 1x1: latent → latent * upscale
+        self.expand_conv = geometry_layer(
+            layer=th.nn.Conv2d,
+            in_channels=int(latent_channels),
+            out_channels=int(latent_channels * upscale_factor),
+            kernel_size=1,
+            dilation=dilation,
+            enable_nhwc=enable_nhwc,
+            enable_healpixpad=enable_healpixpad,
+        )
+
+        # 1x1: upscale → latent
+        self.reduce_conv = geometry_layer(
+            layer=th.nn.Conv2d,
+            in_channels=int(latent_channels * upscale_factor),
+            out_channels=int(latent_channels),
+            kernel_size=1,
+            dilation=dilation,
+            enable_nhwc=enable_nhwc,
+            enable_healpixpad=enable_healpixpad,
+        )
+
+        # 3x3: latent → out
+        self.output_conv = geometry_layer(
+            layer=th.nn.Conv2d,
+            in_channels=int(latent_channels),
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            enable_nhwc=enable_nhwc,
+            enable_healpixpad=enable_healpixpad,
+        )
+
+    def forward(self, x, conditions_cln=None):
+        """
+        Forward pass of the SymmetricConvNextBlock, broken into steps for support of conditional layer normalization
         Parameters
         ----------
         x: torch.Tensor
             inputs to the forward pass
-
+        conditions_cln: torch.Tensor, optional
+            Condition for the conditional layer normalization, if applicable
         Returns
         -------
         torch.Tensor
             result of the forward pass
         """
-        # residual connection with reshaped inpute and output of conv block
-        if self.use_block_skip_connection:
-            return self.skip_module(x) + self.convblock(x)
-        else:
-            return self.convblock(x)
+
+        # Save residual
+        residual = self.skip_module(x) if self.use_block_skip_connection else 0
+
+        # Initial 3x3 convolution
+        x = self.initial_conv(x)
+
+        # Optional BatchNorm
+        if self.batch_norm:
+            x = self.batch_norm(x)
+
+        # Optional activation
+        if self.activation:
+            x = self.activation(x)
+
+        # Optional Conditional LayerNorm
+        if self.cln:
+            # Expecting input format: (N, C, H, W) → permute to (N, H, W, C)
+            x = x.permute(0, 2, 3, 1) 
+            x = self.cln(x, conditions=conditions_cln)
+            x = x.permute(0, 3, 1, 2)
+
+        # Optional dropout
+        if self.dropout_layer:
+            x = self.dropout_layer(x)
+
+        # 1x1 conv to expand channels
+        x = self.expand_conv(x)
+        if self.activation:
+            x = self.activation(x)
+
+        # 1x1 conv to reduce channels
+        x = self.reduce_conv(x)
+        if self.activation:
+            x = self.activation(x)
+
+        # Final 3x3 convolution
+        x = self.output_conv(x)
+        if self.activation:
+            x = self.activation(x)
+
+        # Apply residual connection (if enabled)
+        return x + residual
 
 
 #

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple, Union, Callable
 
 import torch
 import torch as th
@@ -23,7 +23,7 @@ from .normalization import ConditionalLayerNorm
 
 from hydra.utils import instantiate
 from omegaconf import DictConfig
-from omegaconf import OmegaConf
+
 #
 # RECURRENT BLOCKS
 #
@@ -516,16 +516,17 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
         enable_healpixpad: bool = False,
         batch_norm: bool = False,
         dropout: float = 0.0,
-        conditional_layer_norm: DictConfig = None,
+        conditional_layer_norm: Callable = None,
     ):
         """
         Parameters
         ----------
         n_layers: int, optional
             The number of SymmetricConvNeXt Blocks
-        conditional_layer_norm: DictConfig, optional
-            Configuration for conditional layer normalization. If None, 
-            no conditional layer normalization is applied.
+        conditional_layer_norm: Callable, optional
+            Callable for physicsnemo.models.dlwp_healpix_layers.normalization.ConditionalLayerNorm. 
+            Callable can be passed in by setting _partial_ to True in hydra config. If None,
+            conditional layer normalization is not applied.
         """
         super().__init__()
 
@@ -533,47 +534,26 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
         self.blocks = th.nn.ModuleList()
         # flag for conditional layer normalization
         self.cln_enabled = conditional_layer_norm is not None
+
         for i in range(n_layers):
             curr_in = in_channels if i == 0 else out_channels
-
-            # collect context dependent parameters into a config
-            conv_block = {
-                # we have to add target format to support recursive instantiation
-                '_target_': 'physicsnemo.models.dlwp_healpix_layers.healpix_blocks.SymmetricConvNeXtBlock',
-                "geometry_layer": geometry_layer,
-                "in_channels": curr_in,
-                "latent_channels": latent_channels,
-                "out_channels": out_channels,
-                "kernel_size": kernel_size,
-                "dilation": dilation,
-                "n_layers": n_layers,  # not used, but required for hydra instantiation
-                "upscale_factor": upscale_factor,
-                "activation": activation,
-                "enable_nhwc": enable_nhwc,
-                "enable_healpixpad": enable_healpixpad,
-                "batch_norm": batch_norm,
-                "dropout": dropout,
-                "conditional_layer_norm": conditional_layer_norm if conditional_layer_norm is not None else None,
-            }
-            # Create a single block as a separate Module
-            self.blocks.append(instantiate(conv_block))
-            # self.blocks.append(
-            #     SymmetricConvNeXtBlock(
-            #         geometry_layer=geometry_layer,
-            #         in_channels=curr_in,
-            #         latent_channels=latent_channels,
-            #         out_channels=out_channels,
-            #         kernel_size=kernel_size,
-            #         dilation=dilation,
-            #         upscale_factor=upscale_factor,
-            #         activation=activation,
-            #         enable_nhwc=enable_nhwc,
-            #         enable_healpixpad=enable_healpixpad,
-            #         batch_norm=batch_norm,
-            #         dropout=dropout,
-            #         conditional_layer_norm=conditional_layer_norm if conditional_layer_norm is not None else None,
-            #     ),
-            # )
+            self.blocks.append(
+                SymmetricConvNeXtBlock(
+                    geometry_layer=geometry_layer,
+                    in_channels=curr_in,
+                    latent_channels=latent_channels,
+                    out_channels=out_channels,
+                    kernel_size=kernel_size,
+                    dilation=dilation,
+                    upscale_factor=upscale_factor,
+                    activation=activation,
+                    enable_nhwc=enable_nhwc,
+                    enable_healpixpad=enable_healpixpad,
+                    batch_norm=batch_norm,
+                    dropout=dropout,
+                    conditional_layer_norm=conditional_layer_norm if conditional_layer_norm is not None else None,
+                ),
+            )
 
     def forward(self, x, conditions_cln=None):
         out = x
@@ -660,67 +640,97 @@ class SymmetricConvNeXtBlock(th.nn.Module):
                     enable_healpixpad=enable_healpixpad,
                 )
 
-        # 3x3: in → latent
-        self.initial_conv = geometry_layer(
-            layer=th.nn.Conv2d,
-            in_channels=in_channels,
-            out_channels=int(latent_channels),
-            kernel_size=kernel_size,
-            dilation=dilation,
-            enable_nhwc=enable_nhwc,
-            enable_healpixpad=enable_healpixpad,
-        )
+        # Collect conv->norm->activation->dropout operations in list for sequential execution
+        convblock = []
 
-        self.batch_norm = (
-            th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False)
-            if batch_norm else None
+        # 3x3: in → latent
+        convblock.append(
+            geometry_layer(
+                layer=th.nn.Conv2d,
+                in_channels=in_channels,
+                out_channels=int(latent_channels),
+                kernel_size=kernel_size,
+                dilation=dilation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            )
         )
+        if batch_norm:
+            convblock.append(th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False))
         # Conditional Layer Normalization
         if conditional_layer_norm is not None:
-            # resolve context-dependent parameters
-            self.cln = conditional_layer_norm
-            self.cln.setup_cln(channel_depth=int(latent_channels))
-        else:
-            self.cln = None
-        # self.cln = conditional_layer_norm if conditional_layer_norm is not None else None
-
-        self.dropout_layer = (
-            th.nn.Dropout2d(p=dropout)
-            if self.dropout else None
-        )
+            # resolve context-dependent parameters (channel depth)
+            cln = conditional_layer_norm(channel_depth=int(latent_channels))
+            convblock.append(cln)
+        if activation is not None:
+            convblock.append(activation)
+        if dropout > 0.0:
+            convblock.append(th.nn.Dropout2d(p=dropout))
 
         # 1x1: latent → latent * upscale
-        self.expand_conv = geometry_layer(
-            layer=th.nn.Conv2d,
-            in_channels=int(latent_channels),
-            out_channels=int(latent_channels * upscale_factor),
-            kernel_size=1,
-            dilation=dilation,
-            enable_nhwc=enable_nhwc,
-            enable_healpixpad=enable_healpixpad,
+        convblock.append(
+            geometry_layer(
+                layer=th.nn.Conv2d,
+                in_channels=int(latent_channels),
+                out_channels=int(latent_channels * upscale_factor),
+                kernel_size=1,
+                dilation=dilation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            )
         )
+        if batch_norm:
+            convblock.append(th.nn.BatchNorm2d(int(latent_channels * upscale_factor), track_running_stats=False, affine=False))
+        if conditional_layer_norm is not None:
+            cln = conditional_layer_norm(channel_depth=int(latent_channels * upscale_factor))
+            convblock.append(cln)
+        if activation is not None:
+            convblock.append(activation)
+        if dropout > 0.0:
+            convblock.append(th.nn.Dropout2d(p=dropout))
 
+        
         # 1x1: upscale → latent
-        self.reduce_conv = geometry_layer(
-            layer=th.nn.Conv2d,
-            in_channels=int(latent_channels * upscale_factor),
-            out_channels=int(latent_channels),
-            kernel_size=1,
-            dilation=dilation,
-            enable_nhwc=enable_nhwc,
-            enable_healpixpad=enable_healpixpad,
+        convblock.append(
+            geometry_layer(
+                layer=th.nn.Conv2d,
+                in_channels=int(latent_channels * upscale_factor),
+                out_channels=int(latent_channels),
+                kernel_size=1,
+                dilation=dilation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            )
         )
+        if batch_norm:
+            convblock.append(th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False))
+        if conditional_layer_norm is not None:
+            cln = conditional_layer_norm(channel_depth=int(latent_channels))
+            convblock.append(cln)
+        if activation is not None:
+            convblock.append(activation)
+        if dropout > 0.0:
+            convblock.append(th.nn.Dropout2d(p=dropout))
 
-        # 3x3: latent → out
-        self.output_conv = geometry_layer(
-            layer=th.nn.Conv2d,
-            in_channels=int(latent_channels),
-            out_channels=out_channels,
-            kernel_size=kernel_size,
-            dilation=dilation,
-            enable_nhwc=enable_nhwc,
-            enable_healpixpad=enable_healpixpad,
+        # 3x3: latent → out (no norm on this one, following convnext)
+        convblock.append(
+            geometry_layer(
+                layer=th.nn.Conv2d,
+                in_channels=int(latent_channels),
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+                dilation=dilation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            )
         )
+        if activation is not None:
+            convblock.append(activation)
+        if dropout > 0.0:
+            convblock.append(th.nn.Dropout2d(p=dropout))
+
+        self.convblock = th.nn.ModuleList(convblock)
+
 
     def forward(self, x, conditions_cln=None):
         """
@@ -740,44 +750,12 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         # Save residual
         residual = self.skip_module(x) if self.use_block_skip_connection else 0
 
-        # Initial 3x3 convolution
-        x = self.initial_conv(x)
+        for layer in self.convblock:
+            if isinstance(layer, ConditionalLayerNorm):
+                x = layer(x, conditions=conditions_cln)
+            else:
+                x = layer(x)
 
-        # Optional BatchNorm
-        if self.batch_norm:
-            x = self.batch_norm(x)
-
-        # Optional activation
-        if self.activation:
-            x = self.activation(x)
-
-        # Optional Conditional LayerNorm
-        if self.cln:
-            # Expecting input format: (N, C, H, W) → permute to (N, H, W, C)
-            x = x.permute(0, 2, 3, 1) 
-            x = self.cln(x, conditions=conditions_cln)
-            x = x.permute(0, 3, 1, 2)
-
-        # Optional dropout
-        if self.dropout_layer:
-            x = self.dropout_layer(x)
-
-        # 1x1 conv to expand channels
-        x = self.expand_conv(x)
-        if self.activation:
-            x = self.activation(x)
-
-        # 1x1 conv to reduce channels
-        x = self.reduce_conv(x)
-        if self.activation:
-            x = self.activation(x)
-
-        # Final 3x3 convolution
-        x = self.output_conv(x)
-        if self.activation:
-            x = self.activation(x)
-
-        # Apply residual connection (if enabled)
         return x + residual
 
 

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -496,63 +496,6 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
     """
     Class for creating multi-block SymmetricConvNeXtBlock. Defaults to all SymmetricConvNeXtBlocks having same parameters
     """
-    def __init__(
-            self,
-            geometry_layer: th.nn.Module = HEALPixLayer,
-            in_channels: int = 3,
-            latent_channels: int = 1,
-            out_channels: int = 1,
-            kernel_size: int = 3,
-            dilation: int = 1,
-            upscale_factor: int = 4,
-            n_layers: int = 1,
-            activation: th.nn.Module = None,
-            enable_nhwc: bool = False,
-            enable_healpixpad: bool = False,
-            batch_norm: bool = True,
-            dropout: float = 0.0,
-            ):
-        """
-        Parameters
-        ----------
-        n_layers: int, optional
-            The number of SymmetricConvNeXt Blocks
-        """
-        super().__init__()
-    
-        # Create a ModuleList to store complete blocks
-        self.blocks = th.nn.ModuleList()
-        
-        for i in range(n_layers):
-            curr_in = in_channels if i == 0 else out_channels
-            
-            # Create a single block as a separate Module
-            self.blocks.append(SymmetricConvNeXtBlock(
-                geometry_layer=geometry_layer,
-                in_channels=curr_in,
-                latent_channels=latent_channels,
-                out_channels=out_channels,
-                kernel_size=kernel_size,
-                dilation=dilation,
-                upscale_factor=upscale_factor,
-                activation=activation,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-                batch_norm=batch_norm,
-                dropout=dropout,
-            ))
-
-    def forward(self, x):
-        out = x
-        for block in self.blocks:
-            out = block(out)
-        return out
-
-
-class Multi_SymmetricConvNeXtBlock(th.nn.Module):
-    """
-    Class for creating multi-block SymmetricConvNeXtBlock. Defaults to all SymmetricConvNeXtBlocks having same parameters
-    """
 
     def __init__(
         self,
@@ -567,6 +510,8 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
         activation: th.nn.Module = None,
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
+        batch_norm: bool = False,
+        dropout: float = 0.0,
     ):
         """
         Parameters
@@ -595,6 +540,8 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
                     activation=activation,
                     enable_nhwc=enable_nhwc,
                     enable_healpixpad=enable_healpixpad,
+                    batch_norm=batch_norm,
+                    dropout=dropout,
                 )
             )
 
@@ -623,6 +570,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         upscale_factor: int = 4,
         activation: th.nn.Module = None,
         enable_nhwc: bool = False,
+        use_block_skip_connection: bool = True,
         enable_healpixpad: bool = False,
         batch_norm: bool = False,
         dropout: float = 0.0,

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -20,7 +20,6 @@ import torch
 import torch as th
 
 from .healpix_layers import HEALPixLayer
-
 #
 # RECURRENT BLOCKS
 #
@@ -493,6 +492,62 @@ class DoubleConvNeXtBlock(th.nn.Module):
         # return second convnext result
         return self.skip_module2(x1) + self.convblock2(x1)
 
+class Multi_SymmetricConvNeXtBlock(th.nn.Module):
+    """
+    Class for creating multi-block SymmetricConvNeXtBlock. Defaults to all SymmetricConvNeXtBlocks having same parameters
+    """
+    def __init__(
+            self,
+            geometry_layer: th.nn.Module = HEALPixLayer,
+            in_channels: int = 3,
+            latent_channels: int = 1,
+            out_channels: int = 1,
+            kernel_size: int = 3,
+            dilation: int = 1,
+            upscale_factor: int = 4,
+            n_layers: int = 1,
+            activation: th.nn.Module = None,
+            enable_nhwc: bool = False,
+            enable_healpixpad: bool = False,
+            batch_norm: bool = True,
+            dropout: float = 0.0,
+            ):
+        """
+        Parameters
+        ----------
+        n_layers: int, optional
+            The number of SymmetricConvNeXt Blocks
+        """
+        super().__init__()
+    
+        # Create a ModuleList to store complete blocks
+        self.blocks = th.nn.ModuleList()
+        
+        for i in range(n_layers):
+            curr_in = in_channels if i == 0 else out_channels
+            
+            # Create a single block as a separate Module
+            self.blocks.append(SymmetricConvNeXtBlock(
+                geometry_layer=geometry_layer,
+                in_channels=curr_in,
+                latent_channels=latent_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+                dilation=dilation,
+                upscale_factor=upscale_factor,
+                activation=activation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+                batch_norm=batch_norm,
+                dropout=dropout,
+            ))
+
+    def forward(self, x):
+        out = x
+        for block in self.blocks:
+            out = block(out)
+        return out
+
 
 class Multi_SymmetricConvNeXtBlock(th.nn.Module):
     """
@@ -569,7 +624,8 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         activation: th.nn.Module = None,
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
-        use_block_skip_connection: bool = True,
+        batch_norm: bool = False,
+        dropout: float = 0.0,
     ):
         """
         Parameters
@@ -629,8 +685,19 @@ class SymmetricConvNeXtBlock(th.nn.Module):
                 enable_healpixpad=enable_healpixpad,
             )
         )
+        # Apply BatchNorm or LayerNorm here
+        if batch_norm:
+            convblock.append(
+                th.nn.BatchNorm2d(int(latent_channels), track_running_stats=False, affine=False)
+            )
+        
         if activation is not None:
             convblock.append(activation)
+
+        # Apply Dropout 
+        if dropout: 
+            convblock.append(th.nn.Dropout2d(p=dropout))
+
         # 1x1 convolution establishing increased channels
         convblock.append(
             geometry_layer(

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -533,7 +533,6 @@ class Multi_SymmetricConvNeXtBlock(th.nn.Module):
         self.blocks = th.nn.ModuleList()
         # flag for conditional layer normalization
         self.cln_enabled = conditional_layer_norm is not None
-
         for i in range(n_layers):
             curr_in = in_channels if i == 0 else out_channels
 
@@ -649,7 +648,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         self.cln_enabled = conditional_layer_norm is not None
 
         if use_block_skip_connection:
-            if in_channels == int(latent_channels):
+            if in_channels == int(out_channels):
                 self.skip_module = lambda x: x
             else:
                 self.skip_module = geometry_layer(

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
@@ -19,6 +19,7 @@ from typing import Sequence
 import torch as th
 from hydra.utils import instantiate
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 
 
 class UNetDecoder(th.nn.Module):
@@ -132,7 +133,7 @@ class UNetDecoder(th.nn.Module):
             enable_healpixpad=enable_healpixpad,
         )
 
-    def forward(self, inputs: Sequence) -> th.Tensor:
+    def forward(self, inputs: Sequence, conditions_cln: Sequence = None) -> th.Tensor:
         """
         Forward pass of the HEALPix Unet decoder
 
@@ -140,17 +141,36 @@ class UNetDecoder(th.nn.Module):
         ----------
         inputs: Sequence
             The inputs to decode
+        conditions_cln: Sequence, optional
+            The conditional inputs for the normalization layers.
 
         Returns
         -------
         torch.Tensor: The decoded values
         """
+        # print(f"=======================================================================")
+        # print(f"Shape of inputs: {len(inputs)}")
+        # print(f'Shape of inputs[0]: {inputs[0].shape if inputs else "No inputs"}')
+        # print(f"Shape of inputs[1]: {inputs[1].shape if inputs else 'No inputs'}")
+        # print(f"Shape of inputs[2]: {inputs[2].shape if inputs else 'No inputs'}")
+        # print(f"Shape of inputs[3]: {inputs[3].shape if inputs else 'No inputs'}")
+        # print(f"Shape of inputs[4]: {inputs[4].shape if inputs else 'No inputs'}")
+        # print(f'conditions_cln: {conditions_cln.shape if conditions_cln is not None else "No conditions"}') 
         x = inputs[-1]
         for n, layer in enumerate(self.decoder):
+            # print(f'shape of x in layer {n}: {x.shape}')
+            # print(f'layer: {layer}')
             if layer["upsamp"] is not None:
                 up = layer["upsamp"](x)
                 x = th.cat([up, inputs[-1 - n]], dim=self.channel_dim)
-            x = layer["conv"](x)
+            # apply the conv block, check if the layer accepts conditional inputs
+            if conditions_cln is not None:
+                # print(f"Applying Conditional Layer Normalization with conditions shape: {conditions_cln.shape}")
+                # print(f"=======================================================================")
+                x = layer["conv"](x, conditions_cln=conditions_cln)
+            else:
+                x = layer["conv"](x)
+            # apply the recurrent block if it exists
             if layer["recurrent"] is not None:
                 x = layer["recurrent"](x)
         return self.output_layer(x)

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
@@ -122,7 +122,6 @@ class UNetDecoder(th.nn.Module):
             )
 
         self.decoder = th.nn.ModuleList(self.decoder)
-
         # (Linear) Output layer
         self.output_layer = instantiate(
             config=output_layer,
@@ -148,25 +147,13 @@ class UNetDecoder(th.nn.Module):
         -------
         torch.Tensor: The decoded values
         """
-        # print(f"=======================================================================")
-        # print(f"Shape of inputs: {len(inputs)}")
-        # print(f'Shape of inputs[0]: {inputs[0].shape if inputs else "No inputs"}')
-        # print(f"Shape of inputs[1]: {inputs[1].shape if inputs else 'No inputs'}")
-        # print(f"Shape of inputs[2]: {inputs[2].shape if inputs else 'No inputs'}")
-        # print(f"Shape of inputs[3]: {inputs[3].shape if inputs else 'No inputs'}")
-        # print(f"Shape of inputs[4]: {inputs[4].shape if inputs else 'No inputs'}")
-        # print(f'conditions_cln: {conditions_cln.shape if conditions_cln is not None else "No conditions"}') 
         x = inputs[-1]
         for n, layer in enumerate(self.decoder):
-            # print(f'shape of x in layer {n}: {x.shape}')
-            # print(f'layer: {layer}')
             if layer["upsamp"] is not None:
                 up = layer["upsamp"](x)
                 x = th.cat([up, inputs[-1 - n]], dim=self.channel_dim)
             # apply the conv block, check if the layer accepts conditional inputs
             if conditions_cln is not None:
-                # print(f"Applying Conditional Layer Normalization with conditions shape: {conditions_cln.shape}")
-                # print(f"=======================================================================")
                 x = layer["conv"](x, conditions_cln=conditions_cln)
             else:
                 x = layer["conv"](x)

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
@@ -19,7 +19,7 @@ from typing import Sequence
 import torch as th
 from hydra.utils import instantiate
 from omegaconf import DictConfig
-from omegaconf import OmegaConf
+
 
 
 class UNetDecoder(th.nn.Module):
@@ -154,7 +154,10 @@ class UNetDecoder(th.nn.Module):
                 x = th.cat([up, inputs[-1 - n]], dim=self.channel_dim)
             # apply the conv block, check if the layer accepts conditional inputs
             if conditions_cln is not None:
-                x = layer["conv"](x, conditions_cln=conditions_cln)
+                if hasattr(layer["conv"], "cln_enabled") and layer["conv"].cln_enabled:
+                    x = layer["conv"](x, conditions_cln=conditions_cln)
+                else:
+                    raise ValueError("Conditional input passed but conv block does not support conditional inputs.")
             else:
                 x = layer["conv"](x)
             # apply the recurrent block if it exists

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
@@ -19,7 +19,6 @@ from typing import Sequence
 import torch as th
 from hydra.utils import instantiate
 from omegaconf import DictConfig
-from omegaconf import OmegaConf
 
 
 class UNetEncoder(th.nn.Module):

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
@@ -35,6 +35,7 @@ class UNetEncoder(th.nn.Module):
         dilations: list = None,
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
+        dropout: float = 0.0,
     ):
         """
         Parameters
@@ -58,6 +59,8 @@ class UNetEncoder(th.nn.Module):
             If channel last format should be used
         enable_healpixpad, bool, optional
             If the healpixpad library should be used (if installed)
+        dropout, float, optional
+            Probability to use in dropout (if 0, don't use dropout)
         """
         super().__init__()
         self.n_channels = n_channels
@@ -90,6 +93,7 @@ class UNetEncoder(th.nn.Module):
                     n_layers=n_layers[n],
                     enable_nhwc=enable_nhwc,
                     enable_healpixpad=enable_healpixpad,
+                    dropout=dropout,
                 )
             )
             old_channels = curr_channel

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
@@ -36,7 +36,6 @@ class UNetEncoder(th.nn.Module):
         dilations: list = None,
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
-        dropout: float = 0.0,
     ):
         """
         Parameters
@@ -60,8 +59,6 @@ class UNetEncoder(th.nn.Module):
             If channel last format should be used
         enable_healpixpad, bool, optional
             If the healpixpad library should be used (if installed)
-        dropout, float, optional
-            Probability to use in dropout (if 0, don't use dropout)
         """
         super().__init__()
         self.n_channels = n_channels
@@ -83,11 +80,6 @@ class UNetEncoder(th.nn.Module):
                         enable_healpixpad=enable_healpixpad,
                     )
                 )
-            # print(f'======================================================================')
-            # print(f'Initializing ConvNeXtBlock with parameters:')
-            # print(f'Using config: {conv_block}')
-            # print(f'======================================================================')
-            # exit()
             modules.append(
                 instantiate(
                     config=conv_block,
@@ -98,7 +90,6 @@ class UNetEncoder(th.nn.Module):
                     n_layers=n_layers[n],
                     enable_nhwc=enable_nhwc,
                     enable_healpixpad=enable_healpixpad,
-                    dropout=dropout,
                 )
             )
             old_channels = curr_channel
@@ -114,7 +105,7 @@ class UNetEncoder(th.nn.Module):
         Parameters
         ----------
         inputs: Sequence
-            The inputs to enccode
+            The inputs to encode
         conditions_cln: th.Tensor: optional
             The conditional inputs for the normalization layers.
 
@@ -122,11 +113,7 @@ class UNetEncoder(th.nn.Module):
         -------
         Sequence: The encoded values
         """
-       
         outputs = []
-        # for layer in self.encoder:
-        #     outputs.append(layer(inputs,))
-        #     inputs = outputs[-1]
         for layer_group in self.encoder:
             interim_output = inputs
             for layer in layer_group:
@@ -139,16 +126,6 @@ class UNetEncoder(th.nn.Module):
                     interim_output = layer(interim_output)
             outputs.append(interim_output)
             inputs = outputs[-1]
-        # print(f"=======================================================================")
-        # print(f'last layer: {layer}')
-        # print(f"Shape of output: {len(outputs)}")
-        # print(f'Shape of outputs[0]: {outputs[0].shape if outputs else "No outputs"}')
-        # print(f"Shape of outputs[1]: {outputs[1].shape if len(outputs) > 1 else 'No outputs'}")
-        # print(f"Shape of outputs[2]: {outputs[2].shape if len(outputs) > 2 else 'No outputs'}")
-        # # print(f"Shape of outputs[3]: {outputs[3].shape if len(outputs) > 3 else 'No outputs'}")
-        # # print(f"Shape of outputs[4]: {outputs[4].shape if len(outputs) > 4 else 'No outputs'}")
-        # print(f"=======================================================================")
-        # exit()
         # Return the outputs of the last layer
         return outputs
 

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_encoder.py
@@ -19,6 +19,7 @@ from typing import Sequence
 import torch as th
 from hydra.utils import instantiate
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 
 
 class UNetEncoder(th.nn.Module):
@@ -82,7 +83,11 @@ class UNetEncoder(th.nn.Module):
                         enable_healpixpad=enable_healpixpad,
                     )
                 )
-
+            # print(f'======================================================================')
+            # print(f'Initializing ConvNeXtBlock with parameters:')
+            # print(f'Using config: {conv_block}')
+            # print(f'======================================================================')
+            # exit()
             modules.append(
                 instantiate(
                     config=conv_block,
@@ -102,7 +107,7 @@ class UNetEncoder(th.nn.Module):
 
         self.encoder = th.nn.ModuleList(self.encoder)
 
-    def forward(self, inputs: Sequence) -> Sequence:
+    def forward(self, inputs: Sequence, conditions_cln: th.Tensor=None) -> Sequence:
         """
         Forward pass of the HEALPix Unet encoder
 
@@ -110,15 +115,41 @@ class UNetEncoder(th.nn.Module):
         ----------
         inputs: Sequence
             The inputs to enccode
+        conditions_cln: th.Tensor: optional
+            The conditional inputs for the normalization layers.
 
         Returns
         -------
         Sequence: The encoded values
         """
+       
         outputs = []
-        for layer in self.encoder:
-            outputs.append(layer(inputs))
+        # for layer in self.encoder:
+        #     outputs.append(layer(inputs,))
+        #     inputs = outputs[-1]
+        for layer_group in self.encoder:
+            interim_output = inputs
+            for layer in layer_group:
+                # check if class accepts cln inputs
+                if getattr(layer, 'cln_enabled', False):
+                    if conditions_cln is None:
+                        raise ValueError("Conditional inputs are required for layers with cln_enabled=True")
+                    interim_output = layer(interim_output, conditions_cln=conditions_cln)
+                else:
+                    interim_output = layer(interim_output)
+            outputs.append(interim_output)
             inputs = outputs[-1]
+        # print(f"=======================================================================")
+        # print(f'last layer: {layer}')
+        # print(f"Shape of output: {len(outputs)}")
+        # print(f'Shape of outputs[0]: {outputs[0].shape if outputs else "No outputs"}')
+        # print(f"Shape of outputs[1]: {outputs[1].shape if len(outputs) > 1 else 'No outputs'}")
+        # print(f"Shape of outputs[2]: {outputs[2].shape if len(outputs) > 2 else 'No outputs'}")
+        # # print(f"Shape of outputs[3]: {outputs[3].shape if len(outputs) > 3 else 'No outputs'}")
+        # # print(f"Shape of outputs[4]: {outputs[4].shape if len(outputs) > 4 else 'No outputs'}")
+        # print(f"=======================================================================")
+        # exit()
+        # Return the outputs of the last layer
         return outputs
 
     def reset(self):

--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -114,10 +114,5 @@ class ConditionalLayerNorm(th.nn.Module):
         gamma = gamma.repeat_interleave(self.n_faces, dim=0)
         beta = beta.repeat_interleave(self.n_faces, dim=0)
 
-        # # add singleton dimensions for H, W, repeat batch dimesnsion n_faces times: these two
-        # # dimensions are folded together
-        # gamma = th.stack(gammas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
-        # beta = th.stack(betas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
-
         # now gamma and beta are clean tensors that participate in autograd safely
         return gamma * x_norm + beta

--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -36,18 +36,34 @@ class ConditionalLayerNorm(th.nn.Module):
         eps: float = 1e-5,
         n_faces: int = 12,
         norm_op:str = "torch",
+        init_cln_to_zero: bool = False,
+        scale_center: float = 0.0,
     ):
         """
         Conditional LayerNorm with MLP-based conditioning.
 
-        Args:
-            condition_shape (int): Shape of the conditioning input.
-            batch_size (int): Size of the batch.
-            mlp_hidden_dims (List[int]): Hidden layer sizes for MLPs predicting gamma and beta.
-            activation (DictConfig): Activation function configuration for the MLPs.
-            eps (float): Numerical stability constant.
-            n_faces (int): Number of faces in the Healpix grid, used for reshaping.
-            norm_op (str): "torch" for torch.nn.LayerNorm, "apex" for apex FusedLayerNorm.
+        Parameters
+        ----------
+        condition_shape : int
+            Shape of the conditioning input.
+        channel_depth : int
+            Number of channels in the input tensor.
+        mlp_hidden_dims : List[int]
+            Hidden layer sizes for MLPs predicting gamma and beta.
+        activation : DictConfig
+            Activation function configuration for the MLPs.
+        eps : float
+            Numerical stability constant.
+        n_faces : int
+            Number of faces in the Healpix grid, used for reshaping.
+        norm_op : str
+            "torch" for torch.nn.LayerNorm, "apex" for apex FusedLayerNorm.
+        init_cln_to_zero : bool = False
+            If True, initialize the last layer of the MLPs to zero.
+            At the start of training, the noise will be ignored
+        scale_center : float = 0.0
+            Center of the scale parameter. Set to 1.0 and use `init_cln_to_zero=True`
+            to make CLN behave like standard LayerNorm at initialization.
         """
         super().__init__()
         self.eps = eps
@@ -58,6 +74,13 @@ class ConditionalLayerNorm(th.nn.Module):
         self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
         self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
         self.n_faces = n_faces
+        self.scale_center = scale_center
+
+        if init_cln_to_zero:
+            self.gamma_mlp[-1].weight.data.zero_()
+            self.beta_mlp[-1].weight.data.zero_()
+            self.gamma_mlp[-1].bias.data.zero_()
+            self.beta_mlp[-1].bias.data.zero_()
 
         if norm_op == "torch":
             self.norm = th.nn.LayerNorm(channel_depth, elementwise_affine=False)
@@ -80,10 +103,16 @@ class ConditionalLayerNorm(th.nn.Module):
 
     def forward(self, x: th.Tensor, conditions: th.Tensor) -> th.Tensor:
         """
-        Args:
-            x: Input tensor of shape: (B, C, H, W)
-            conditions: Conditioning tensor of shape (B*n_cond, cond_dim)
-        Returns:
+        Parameters
+        ----------
+        x : th.Tensor
+            Input tensor of shape: (B, C, H, W)
+        conditions : th.Tensor
+            Conditioning tensor of shape (B*n_cond, cond_dim)
+
+        Returns
+        -------
+        th.Tensor
             Normalized and conditioned tensor of shape: (B, C, H, W)
         """
 
@@ -92,7 +121,7 @@ class ConditionalLayerNorm(th.nn.Module):
         x_norm = self.norm(x)
     
         # Compute gamma and beta from conditions
-        gamma = self.gamma_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
+        gamma = self.scale_center + self.gamma_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
         beta = self.beta_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
 
         # Repeat for the number of faces(which has been folded into the batch dimension)

--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -19,15 +19,23 @@ from typing import Sequence, List
 import torch as th
 from omegaconf import DictConfig
 
+try:
+    from apex.normalization import FusedLayerNorm
+    _APEX_AVAILABLE = True
+except ImportError:
+    _APEX_AVAILABLE = False
+
+
 class ConditionalLayerNorm(th.nn.Module):
     def __init__(
         self,
         condition_shape: int,
-        batch_size: int,
+        channel_depth: int,
         mlp_hidden_dims: List[int] = [128, 128],
         activation: th.nn.Module = None,
         eps: float = 1e-5,
         n_faces: int = 12,
+        norm_op:str = "torch",
     ):
         """
         Conditional LayerNorm with MLP-based conditioning.
@@ -39,32 +47,25 @@ class ConditionalLayerNorm(th.nn.Module):
             activation (DictConfig): Activation function configuration for the MLPs.
             eps (float): Numerical stability constant.
             n_faces (int): Number of faces in the Healpix grid, used for reshaping.
+            norm_op (str): "torch" for torch.nn.LayerNorm, "apex" for apex FusedLayerNorm.
         """
         super().__init__()
         self.eps = eps
         self.condition_shape = condition_shape
+        self.channel_depth = channel_depth
         self.hidden_dims = mlp_hidden_dims
-        self.batch_size = batch_size
         self.activation = activation if activation is not None else th.nn.Identity()
-        self.gamma_mlp = None
-        self.beta_mlp = None
-        self.gamma = None
-        self.beta = None
+        self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
+        self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
         self.n_faces = n_faces
-        # 
-        self.initialized = False
 
-    def setup_cln(self, channel_depth):
-        """
-        Set up the Conditional Layer Normalization with MLPs. Uses context dependent parameters.
+        if norm_op == "torch":
+            self.norm = th.nn.LayerNorm(channel_depth, elementwise_affine=False)
+        elif norm_op == "apex":
+            if not _APEX_AVAILABLE:
+                raise ImportError("Apex FusedLayerNorm requested but apex is not available, please install it from https://github.com/NVIDIA/apex")
+            self.norm = FusedLayerNorm(channel_depth, elementwise_affine=False)
 
-        Args:
-            normalized_shape (int): The number of channels (C) to normalize across.
-        """
-        # Create MLPs to produce gamma and beta from the cond input
-        self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, channel_depth, self.activation)
-        self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, channel_depth, self.activation)
-    
     def _make_mlp(self, in_dim: int, hidden_dims: List[int], out_dim: int, activation: th.nn.Module) -> th.nn.Sequential:
 
         layers = []
@@ -76,43 +77,28 @@ class ConditionalLayerNorm(th.nn.Module):
         layers.append(th.nn.Linear(in_dim, out_dim))
         return th.nn.Sequential(*layers)
 
-    def _initialze(self, device):
-
-        """
-        Initialize the Conditional LayerNorm by moving MLPs to the specified device.
-
-        Args:
-            device (torch.device): The device to which the MLPs should be moved.
-        """
-        self.gamma_mlp.to(device)
-        self.beta_mlp.to(device)
-        self.initialized = True
 
     def forward(self, x: th.Tensor, conditions: th.Tensor) -> th.Tensor:
         """
         Args:
-            x: Input tensor of shape: 
-            conditions: Conditioning tensor of shape (B, N, cond_dim)
+            x: Input tensor of shape: (B, C, H, W)
+            conditions: Conditioning tensor of shape (B*n_cond, cond_dim)
         Returns:
-            Normalized and conditioned tensor of shape: 
+            Normalized and conditioned tensor of shape: (B, C, H, W)
         """
 
-        # check if the layer is initialized
-        if not self.initialized:
-            self._initialze(x.device)
-
-        # normal layer norm, assumes channel-last format
-        mean = x.mean(dim=-1, keepdim=True)
-        var = x.var(dim=-1, keepdim=True, unbiased=False)
-        x_norm = (x - mean) / th.sqrt(var + self.eps)
+        # normal layer norm without default scale, bias applied (permute to channels_last)
+        x = x.permute(0, 2, 3, 1)
+        x_norm = self.norm(x)
     
-        # dynamically build gamma and beta, don't store in self
-        gamma = self.gamma_mlp(conditions)[:, None, None, :]
-        beta = self.beta_mlp(conditions)[:, None, None, :]
+        # Compute gamma and beta from conditions
+        gamma = self.gamma_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
+        beta = self.beta_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
 
         # Repeat for the number of faces(which has been folded into the batch dimension)
         gamma = gamma.repeat_interleave(self.n_faces, dim=0)
         beta = beta.repeat_interleave(self.n_faces, dim=0)
 
-        # now gamma and beta are clean tensors that participate in autograd safely
-        return gamma * x_norm + beta
+        # Apply and reshape to channels first
+        x = gamma * x_norm + beta
+        return x.permute(0, 3, 1, 2)

--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -107,19 +107,17 @@ class ConditionalLayerNorm(th.nn.Module):
         x_norm = (x - mean) / th.sqrt(var + self.eps)
     
         # dynamically build gamma and beta, don't store in self
-        gammas = []
-        betas = []
+        gamma = self.gamma_mlp(conditions)[:, None, None, :]
+        beta = self.beta_mlp(conditions)[:, None, None, :]
 
-        for i in range(self.batch_size):
-            gamma = self.gamma_mlp(conditions[i])
-            beta = self.beta_mlp(conditions[i])
-            gammas.append(gamma)
-            betas.append(beta)
+        # Repeat for the number of faces(which has been folded into the batch dimension)
+        gamma = gamma.repeat_interleave(self.n_faces, dim=0)
+        beta = beta.repeat_interleave(self.n_faces, dim=0)
 
-        # add singleton dimensions for H, W, repeat batch dimesnsion n_faces times: these two
-        # dimensions are folded together
-        gamma = th.stack(gammas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
-        beta = th.stack(betas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
+        # # add singleton dimensions for H, W, repeat batch dimesnsion n_faces times: these two
+        # # dimensions are folded together
+        # gamma = th.stack(gammas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
+        # beta = th.stack(betas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
 
         # now gamma and beta are clean tensors that participate in autograd safely
         return gamma * x_norm + beta

--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Sequence, List
+
+import torch as th
+from omegaconf import DictConfig
+
+class ConditionalLayerNorm(th.nn.Module):
+    def __init__(
+        self,
+        condition_shape: int,
+        batch_size: int,
+        mlp_hidden_dims: List[int] = [128, 128],
+        activation: th.nn.Module = None,
+        eps: float = 1e-5,
+        n_faces: int = 12,
+    ):
+        """
+        Conditional LayerNorm with MLP-based conditioning.
+
+        Args:
+            condition_shape (int): Shape of the conditioning input.
+            batch_size (int): Size of the batch.
+            mlp_hidden_dims (List[int]): Hidden layer sizes for MLPs predicting gamma and beta.
+            activation (DictConfig): Activation function configuration for the MLPs.
+            eps (float): Numerical stability constant.
+            n_faces (int): Number of faces in the Healpix grid, used for reshaping.
+        """
+        super().__init__()
+        self.eps = eps
+        self.condition_shape = condition_shape
+        self.hidden_dims = mlp_hidden_dims
+        self.batch_size = batch_size
+        self.activation = activation if activation is not None else th.nn.Identity()
+        self.gamma_mlp = None
+        self.beta_mlp = None
+        self.gamma = None
+        self.beta = None
+        self.n_faces = n_faces
+        # 
+        self.initialized = False
+
+    def setup_cln(self, channel_depth):
+        """
+        Set up the Conditional Layer Normalization with MLPs. Uses context dependent parameters.
+
+        Args:
+            normalized_shape (int): The number of channels (C) to normalize across.
+        """
+        # Create MLPs to produce gamma and beta from the cond input
+        self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, channel_depth, self.activation)
+        self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, channel_depth, self.activation)
+    
+    def _make_mlp(self, in_dim: int, hidden_dims: List[int], out_dim: int, activation: th.nn.Module) -> th.nn.Sequential:
+
+        layers = []
+        for hdim in hidden_dims:
+            layers.append(th.nn.Linear(in_dim, hdim))
+            if activation:
+                layers.append(activation)
+            in_dim = hdim
+        layers.append(th.nn.Linear(in_dim, out_dim))
+        return th.nn.Sequential(*layers)
+
+    def _initialze(self, device):
+
+        """
+        Initialize the Conditional LayerNorm by moving MLPs to the specified device.
+
+        Args:
+            device (torch.device): The device to which the MLPs should be moved.
+        """
+        self.gamma_mlp.to(device)
+        self.beta_mlp.to(device)
+        self.initialized = True
+
+    def forward(self, x: th.Tensor, conditions: th.Tensor) -> th.Tensor:
+        """
+        Args:
+            x: Input tensor of shape: 
+            conditions: Conditioning tensor of shape (B, N, cond_dim)
+        Returns:
+            Normalized and conditioned tensor of shape: 
+        """
+
+        # check if the layer is initialized
+        if not self.initialized:
+            self._initialze(x.device)
+
+        # normal layer norm, assumes channel-last format
+        mean = x.mean(dim=-1, keepdim=True)
+        var = x.var(dim=-1, keepdim=True, unbiased=False)
+        x_norm = (x - mean) / th.sqrt(var + self.eps)
+    
+        # dynamically build gamma and beta, don't store in self
+        gammas = []
+        betas = []
+
+        for i in range(self.batch_size):
+            gamma = self.gamma_mlp(conditions[i])
+            beta = self.beta_mlp(conditions[i])
+            gammas.append(gamma)
+            betas.append(beta)
+
+        # add singleton dimensions for H, W, repeat batch dimesnsion n_faces times: these two
+        # dimensions are folded together
+        gamma = th.stack(gammas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
+        beta = th.stack(betas, dim=0)[:,None,None,:].repeat_interleave(self.n_faces, dim=0)
+
+        # now gamma and beta are clean tensors that participate in autograd safely
+        return gamma * x_norm + beta


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

Here's an example of how I added dropout and batch norm in the Multi_SymmetricConvNeXtBlock. I expect we're going to do a few experiments before converging on a specific normalization technique / code version. This is intended to be a reference to ensure we're implementing normalization similarly. 


## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->