### PR TITLE
 Add conditional loss for precip training and option to disable skip connection in Symmetric ConvNeXt block

### DIFF
--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -141,16 +141,40 @@ class ConditionalWeightLoss( th.nn.MSELoss ):
         b=None,
         w=1,
         ):
+        """
+        Parameters
+        -----------
+        weight: tuple of floats
+            weight[0] is used when the target precipitation value is zero
+            weight[1] is used for all non-zero precipitation
+        b: float
+            Exponential scaling factor used to define weighting curve for non-zero precip. weights
+        w: float
+            Final scaling factor applied to loss.
+        """
+
         super().__init__()
         self.weight_zero = weight[0]
         self.weight_nonzero = weight[1]
         self.b = b
         self.device = None
         self.w = w
+
     def setup(self, trainer):
         self.b = th.tensor(self.b, device=trainer.device)
         self.w = th.tensor(self.w, device=trainer.device)
-    def forward(self, prediction, target, average_channels=True ):
+
+    def forward(self, prediction, target):
+        """
+        Computes the MSE of model prediction and applies weights for zero and non-zero precipitation cases.
+
+        Parameters
+        -----------
+        prediction: torch.tensor
+            The prediction tensor
+        target: torch.Tensor
+            The target tensor
+        """
         weights_for_zero = th.ones_like(target) * self.weight_zero
         weights_for_nonzero = (th.ones_like(target) * self.weight_nonzero) * th.exp(self.b*target)
         weights = th.where(target > 0, weights_for_nonzero, weights_for_zero)

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -129,6 +129,33 @@ class WeightedMSE(th.nn.MSELoss):
         else:
             return d
 
+class ConditionalWeightLoss( th.nn.MSELoss ):
+    """
+    Conditional loss for precipitation diagnostic model.
+    (Total 6hr precipitation is the only output field.)
+    """
+
+    def __init__(
+        self,
+        weight=(0.01,1.0),
+        b=None,
+        w=1,
+        ):
+        super().__init__()
+        self.weight_zero = weight[0]
+        self.weight_nonzero = weight[1]
+        self.b = b
+        self.device = None
+        self.w = w
+    def setup(self, trainer):
+        self.b = th.tensor(self.b, device=trainer.device)
+        self.w = th.tensor(self.w, device=trainer.device)
+    def forward(self, prediction, target, average_channels=True ):
+        weights_for_zero = th.ones_like(target) * self.weight_zero
+        weights_for_nonzero = (th.ones_like(target) * self.weight_nonzero) * th.exp(self.b*target)
+        weights = th.where(target > 0, weights_for_nonzero, weights_for_zero)
+        loss = (th.mean(weights * (prediction - target) ** 2))*self.w
+        return loss
 
 class OceanMSE(th.nn.MSELoss):
     """

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -595,7 +595,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         enable_healpixpad: bool, optional
             If HEALPixPadding should be enabled, passed to wrapper
         use_block_skip_connection: bool, optional
-            If training a diagnostic model, set to False
+            Whether or not to use block-level skip connection
         """
         super().__init__()
 

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -569,6 +569,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         activation: th.nn.Module = None,
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
+        use_block_skip_connection: bool = True,
     ):
         """
         Parameters
@@ -593,20 +594,26 @@ class SymmetricConvNeXtBlock(th.nn.Module):
             Enable nhwc format, passed to wrapper
         enable_healpixpad: bool, optional
             If HEALPixPadding should be enabled, passed to wrapper
+        use_block_skip_connection: bool, optional
+            If training a diagnostic model, set to False
         """
         super().__init__()
 
-        if in_channels == int(latent_channels):
-            self.skip_module = lambda x: x  # Identity-function required in forward pass
-        else:
-            self.skip_module = geometry_layer(
-                layer=torch.nn.Conv2d,
-                in_channels=in_channels,
-                out_channels=out_channels,
-                kernel_size=1,
-                enable_nhwc=enable_nhwc,
-                enable_healpixpad=enable_healpixpad,
-            )
+        self.use_block_skip_connection = use_block_skip_connection
+
+        if use_block_skip_connection:
+
+            if in_channels == int(latent_channels):
+                self.skip_module = lambda x: x  # Identity-function required in forward pass
+            else:
+                self.skip_module = geometry_layer(
+                    layer=torch.nn.Conv2d,
+                    in_channels=in_channels,
+                    out_channels=out_channels,
+                    kernel_size=1,
+                    enable_nhwc=enable_nhwc,
+                    enable_healpixpad=enable_healpixpad,
+                )
 
         # 1st ConvNeXt block, the output of this one remains internal
         convblock = []
@@ -682,7 +689,10 @@ class SymmetricConvNeXtBlock(th.nn.Module):
             result of the forward pass
         """
         # residual connection with reshaped inpute and output of conv block
-        return self.skip_module(x) + self.convblock(x)
+        if self.use_block_skip_connection:
+            return self.skip_module(x) + self.convblock(x)
+        else:
+            return self.convblock(x)
 
 
 #


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Precipitation model PR

This pull request incorporates two features necessary for training a precipitation diagnostic model with the physicsnemo framework.
1. addition of a conditional loss function in healpix_loss.py that weights cases of zero precipitation less than cases of non-zero precipitation
2. functionality to remove the skip connection in the Symmetric ConvNeXt block via config argument, which is necessary for training the diagnostic model

@pzharrington - Please review when you have a moment. Thanks!

p.s. apologies for putting this in the wrong physicsnemo version at first, I forgot to switch to AtmosSci-DLESM!