### PR TITLE
Support arbitrary batch dim in inference

### DIFF
--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -196,23 +196,18 @@ class ConstantCoupler:
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        if coupled_fields.shape[0] != self.batch_size:
-            raise ValueError(
-                f"Batch size of coupled field {coupled_fields.shape[0]} doesn't "
-                f" match configured batch size {self.batch_size}"
-            )
         # create buffer for coupling
         coupled_fields = coupled_fields[
             :, :, :, self.coupled_channel_indices, :, :
         ].permute(2, 0, 3, 1, 4, 5)
         self.preset_coupled_fields = th.empty(
-            [self.coupled_integration_dim, self.batch_size, self.timevar_dim]
+            [self.coupled_integration_dim, coupled_fields.shape[1], self.timevar_dim]
             + list(self.spatial_dims)
         )
         # we use a constant set of values so we just copy time 0
         for i in range(len(self.preset_coupled_fields)):
             self.preset_coupled_fields[i, :, :, :, :, :] = coupled_fields[
-                0, :, -1, :, :, :
+                0, :, -1:, :, :, :
             ]
         # flag for construct integrated coupling method to use this array
         self.coupled_mode = True
@@ -477,12 +472,6 @@ class TrailingAverageCoupler:
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        if coupled_fields.shape[0] != self.batch_size:
-            raise ValueError(
-                f"Batch size of coupled field {coupled_fields.shape[0]} doesn't "
-                f" match configured batch size {self.batch_size}"
-            )
-
         coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
         # TODO: Now support output_time_dim =/= input_time_dim, but presteps need to be 0, will add support for presteps>0
         coupled_averaging_periods = []


### PR DESCRIPTION
Adds support for couplers to prepare couplings during inference for arbitrary batch dim. As far as I can tell this change maintains correct behavior, but allows the coupler to run `set_coupled_fields` on tensors generated during inference with a batch size different than what was prescribed in the coupler config. Supports the needed behavior for using bred vectors and batched perturbations in the NV-dlesm inferencer setup.
