### PR TITLE
Coupled spectral CRPS updates

### DIFF
--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -170,12 +170,16 @@ class ConstantCoupler:
         # we check if the coupled model output var is in self.variables.
         #
         # for example 'z1000' is in 'z1000-48H'
-        channel_indices = [
-            i
-            for i, oc in enumerate(output_channels)
-            for v in self.variables
-            if oc == v.split("-")[0]
-        ]
+        channel_indices = []
+        for v in self.variables:
+            if v == "ttr-3h-48H":
+                # Special case for ttr-3h-48H
+                channel_indices.append(list(output_channels).index("ttr-3h"))
+            else:
+                for i, oc in enumerate(output_channels):
+                    if oc == v.split("-")[0]:
+                        channel_indices.append(i)
+                
         self.coupled_channel_indices = channel_indices
 
     def reset_coupler(self):
@@ -428,12 +432,16 @@ class TrailingAverageCoupler:
         # we check if the coupled model output var is in self.variables.
         #
         # for example 'z1000' is in 'z1000-48H'
-        channel_indices = [
-            i
-            for i, oc in enumerate(output_channels)
-            for v in self.variables
-            if oc == v.split("-")[0]
-        ]
+        channel_indices = []
+        for v in self.variables:
+            if v == "ttr-3h-48H":
+                # Special case for ttr-3h-48H
+                channel_indices.append(list(output_channels).index("ttr-3h"))
+            else:
+                for i, oc in enumerate(output_channels):
+                    if oc == v.split("-")[0]:
+                        channel_indices.append(i)
+
         self.coupled_channel_indices = channel_indices
 
         # find averaging periods from componenet output

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -20,6 +20,10 @@ import numpy as np
 import torch as th
 import xarray as xr
 
+import earth2grid
+from cuhpx import SHTCUDA, iSHTCUDA
+from earth2grid.healpix import HEALPIX_PAD_XY, PixelOrder
+
 """
 Custom dlwp compatible loss classes that allow for more sophisticated training optimization.
 
@@ -318,7 +322,12 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self,
         weights: Sequence = [],
         n_members: int = 2,
-        alpha: float = 0.95
+        alpha: float = 0.95,
+        mean_penalty: float = 0.0,
+        lsm_file: str = None,
+        open_dict: dict = {"engine": "zarr"},
+        selection_dict: dict = {"channel_c": "land_sea_mask"},
+        multiscale: float = 0.0,
     ):
         """
         Parameters
@@ -330,6 +339,17 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             number of ensemble members in the model output
         alpha: float
             hyperparamter for approximating fair CRPS loss. between 0 and 1, 1 corresponds to a fair CRPS loss.
+        mean_penalty: float
+            weight for the penalty constraining the global mean of the ensemble to be close to the target mean
+            if 0, no penalty is applied
+        lsm_file: str
+            land-sea-mask file
+        open_dict: dict, optional
+            dictionary that store land-sea-mask file information
+        selection_dict: dict, optional
+            dictionary that store channel selection information
+        multiscale: float, optional
+            weight for the multiscale CRPS loss. Default is 0, no multiscale loss is applied.
         """
         super().__init__()
         self.loss_weights = th.tensor(weights)
@@ -338,6 +358,15 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         else:    
             self.n_members = n_members
         self.device = None
+        self.mean_penalty = mean_penalty
+        self.multiscale = multiscale
+        self.scales = [4, 16, 32]
+
+        if lsm_file is not None:
+            self.lsm_ds = xr.open_dataset(lsm_file, **open_dict).constants.sel(selection_dict)
+            self.lsm_tensor = 1 - th.tensor(np.expand_dims(self.lsm_ds.values, (0, 2, 3)))
+        else:
+            self.lsm_tensor = th.ones(1, 1, 1, 1, 1, 1) # Spoof the tensor dimensions for broadcasting
 
         # Parameters for "almost fair CRPS" loss. See https://arxiv.org/html/2412.15832v1
         self.coeff_eps = 1 - ((1-alpha) / (n_members))
@@ -360,7 +389,21 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
         self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
         self.pdist = self.pdist.to(device=trainer.device)
-        self.diag_mask = self.diag_mask.to(device=trainer.device)
+        self.diag_mask = self.diag_mask.to(device=trainer.device)   
+        self.lsm_tensor = self.lsm_tensor.to(device=trainer.device)
+
+    def _2member_crps(self, prediction, target, lsm_tensor):
+        diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
+        diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
+        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+        crps *= lsm_tensor
+        return crps
+
+    def _pool(self, tensor, scale):
+        shape = tensor.shape
+        h, w = shape[-2:]
+        pooled = th.nn.functional.avg_pool2d(tensor.reshape(shape[0], -1, h, w), scale, scale)
+        return pooled.reshape(*shape[:-2], h//scale, w//scale)
 
     def forward(self, prediction, target, average_channels=True):
         """
@@ -396,14 +439,37 @@ class WeightedCRPSLoss(th.nn.MSELoss):
 
         if n == 2:
             # Use faster explicit implementation
-            diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
-            diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+            crps = self._2member_crps(prediction, target, self.lsm_tensor)
 
             if average_channels:
-                return crps.mean()
+                loss = crps.mean()
             else:
-                return crps.mean(dim=(0, 1, 2, 4, 5))
+                loss = crps.mean(dim=(0, 1, 2, 4, 5))
+
+            if self.mean_penalty > 0:
+                ens_global_means = prediction.mean(dim=(0, 1, 2, 3, 5, 6)) # [C]
+                target_global_means = target.mean(dim=(0, 1, 2, 4, 5)) # [C]
+                bias_penalty = self.mean_penalty * th.abs(ens_global_means - target_global_means)
+                if average_channels:
+                    loss += bias_penalty.mean()
+                else:
+                    loss += bias_penalty
+
+            if self.multiscale > 0.:
+                crps_scales = 0
+                for scale in self.scales:
+                    pred, tar, lsm = self._pool(prediction, scale), self._pool(target, scale), self._pool(self.lsm_tensor, scale)
+                    crps_scale = self._2member_crps(pred, tar, lsm)
+                    if average_channels:
+                        crps_scale = crps_scale.mean()
+                    else:
+                        crps_scale = crps_scale.mean(dim=(0, 1, 2, 4, 5))
+                    crps_scales += crps_scale
+
+                crps_scales = crps_scales / len(self.scales)
+                loss += self.multiscale * crps_scales
+                
+            return loss
         else:
             # Use pairwise distance method
             if not average_channels:
@@ -429,3 +495,329 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
 
             return crps
+
+
+class WeightedCRPSLossSpectral(th.nn.MSELoss):
+
+    """
+    Probabilistic loss function that allows for user defined weighting of variables when calculating CRPS.
+    """
+
+    def __init__(
+        self,
+        weights: Sequence = [],
+        n_members: int = 2,
+        alpha: float = 0.95,
+        lambda_spec: float = 0.1,
+        nside: int = 64,
+        lmax: int = 3*64 - 1,
+        mmax: int = 3*64 - 1,
+        multiscale: float = 0.0,
+        lsm_file: str = None,
+        open_dict: dict = {"engine": "zarr"},
+        selection_dict: dict = {"channel_c": "land_sea_mask"},
+    ):
+        """
+        Parameters
+        ----------
+        weights: Sequence
+            list of floats that determine weighting of variable loss, assumed to be
+            in order consistent with order of model output channels
+        n_members: int
+            number of ensemble members in the model output
+        alpha: float
+            hyperparamter for approximating fair CRPS loss. between 0 and 1, 1 corresponds to a fair CRPS loss.
+        lambda_spec: float
+            weight for the spectral loss. Default is 0, no spectral loss is applied.
+        nside: int
+            nside for the HEALPix grid. Default is 64.
+        lmax: int
+            lmax for the SHT. Default is 3*nside - 1.
+        mmax: int
+            mmax for the SHT. Default is 3*nside - 1.
+        multiscale: float, optional
+            weight for the multiscale loss. Default is 0, no multiscale loss is applied.
+        lsm_file: str
+            path to the lsm file. Default is None, no lsm is applied.
+        open_dict: dict
+            dictionary of keyword arguments for xarray.open_dataset. Default is {"engine": "zarr"}.
+        selection_dict: dict
+            dictionary of keyword arguments for xarray.open_dataset. Default is {"channel_c": "land_sea_mask"}.
+        """
+        super().__init__()
+        self.loss_weights = th.tensor(weights)
+        self.n_members = n_members
+        self.device = None
+        self.lambda_spec = lambda_spec
+        self.multiscale = multiscale
+
+        # Parameters for "almost fair CRPS" loss. See https://arxiv.org/html/2412.15832v1
+        self.coeff_eps = 1 - ((1-alpha) / (n_members))
+        self.averaging_coeff = 1 / (2* n_members * (n_members - 1))
+
+        # SHT utils: transform, grid reordering, output indexing
+        self.lmax = lmax
+        self.mmax = mmax
+        self.nside = nside
+        self.sht = SHTCUDA(nside=nside, lmax=lmax, mmax=mmax, quad_weights='ring')
+        src_grid = earth2grid.healpix.Grid(level=int(np.log2(nside)), pixel_order=HEALPIX_PAD_XY)
+        tar_grid = earth2grid.healpix.Grid(level=int(np.log2(nside)), pixel_order=PixelOrder.RING)
+        self.reorder_to_ring = earth2grid.get_regridder(src_grid, tar_grid).to(th.float32)
+        if self.multiscale > 0:
+            self.scales = [200, 400, 800, 1600] # in units of km
+            self.isht = iSHTCUDA(nside=nside, lmax=lmax, mmax=mmax, quad_weights='ring')
+            self.reorder_from_ring = earth2grid.get_regridder(tar_grid, src_grid).to(th.float32)
+
+        self.lsm_file = lsm_file
+        if lsm_file is not None:
+            self.lsm_ds = xr.open_dataset(lsm_file, **open_dict).constants.sel(selection_dict)
+            self.lsm_tensor = 1 - th.tensor(np.expand_dims(self.lsm_ds.values, (0, 2, 3)))
+        else:
+            self.lsm_tensor = th.ones(1, 1, 1, 1, 1, 1) # Spoof the tensor dimensions for broadcasting
+
+        # For n>2, will use pairwise distance to copmute [NxN] distance matrix
+        # Diagonal elements of (prediciton - target) matrix are zeroed out to avoid double counting
+        self.pdist = th.nn.PairwiseDistance(p=1)
+        self.diag_mask = th.ones(self.n_members, self.n_members) - th.eye(self.n_members) # Mask to zero out diagonal elements
+
+
+    def setup(self, trainer):
+        """
+        pushes constants to cuda device
+        """
+
+        if len(trainer.output_variables) != len(self.loss_weights):
+            raise ValueError("Length of outputs and loss_weights is not the same!")
+
+        self.loss_weights = self.loss_weights.to(device=trainer.device)
+        self.averaging_coeff = th.tensor(self.averaging_coeff, device=trainer.device)
+        self.coeff_eps = th.tensor(self.coeff_eps, device=trainer.device)
+        self.reorder_to_ring = self.reorder_to_ring.to(device=trainer.device)
+        self.sht = self.sht.to(device=trainer.device)
+        self.pdist = self.pdist.to(device=trainer.device)
+        self.diag_mask = self.diag_mask.to(device=trainer.device)
+
+        if self.multiscale > 0:
+            self.isht = self.isht.to(device=trainer.device)
+            self.reorder_from_ring = self.reorder_from_ring.to(device=trainer.device)
+        if self.lsm_file is not None:
+            self.lsm_tensor = self.lsm_tensor.to(device=trainer.device)
+
+    def _apply_sht(self, x, face_dim, return_abs=True):
+        """Apply SHT to a tensor
+        Reshape to [..., F*H*W], reorder to ring, apply SHT
+        If return_abs is True, return the absolute value of the SHT (real**2 + imag**2)
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            The tensor to apply SHT to
+        face_dim: int
+            The dimension of the tensor corrsponding to HEALPix faces
+        return_abs: bool, optional
+            Whether to return the absolute value of the SHT (real**2 + imag**2)
+        """
+        x = th.movedim(x, face_dim, -3)
+        if x.shape[-3:] != (12, self.nside, self.nside):
+            raise ValueError(f"Shape of input tensor should be [..., F, ..., H, W] with F in position {face_dim}, got {x.shape}")
+        
+        x = x.reshape(*x.shape[:-3], -1)
+        x = self.reorder_to_ring(x.contiguous()) # contiguous needed for channels first format in validation loop
+        x = self.sht(x)
+        if return_abs:
+            x = x.real ** 2 + x.imag ** 2
+        return x
+
+    def _apply_isht(self, x, face_dim):
+        """Apply inverse SHT to a tensor shape [..., l, m]
+        Inverse transform, reorder from ring, Reshape to [..., F, H, W], move face dim appropriately
+        """
+
+        x = self.isht(x) # [..., l, m] -> [..., F*H*W]
+        x = self.reorder_from_ring(x)
+        x = x.reshape(*x.shape[:-1], 12, self.nside, self.nside) # [..., F*H*W] -> [..., F, H, W]
+        x = th.movedim(x, -3, face_dim) # [..., F, H, W] -> [..., F, ..., H, W]
+        return x
+
+    def _l_filter(self, scale, device="cuda"):
+        """Return a spherical gaussian filter of scale `scale` (in units of km)
+        """
+        scale_radians  = scale / 6371.0
+        ell = th.arange(self.lmax, device=device, dtype=th.float32)
+        return th.exp(-0.5* ell * (ell + 1) * (scale_radians ** 2))
+
+    def forward(self, prediction, target, average_channels=True):
+        """
+        Forward pass of the WeightedCRPSLoss 
+        Computes the CRPS loss for the model prediction and target.
+
+        Parameters
+        ----------
+        prediction: torch.Tensor
+            The prediction tensor shape [Cond*B, F, T, C, H, W] where Cond is the number of ensemble members
+        target: torch.Tensor
+            The target tensor shape [B, F, T, C, H, W]
+        average_channels: bool, optional
+            whether the mean of the channels should be taken
+        """
+        
+        # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
+        b, f, t, c, h, w = target.shape
+        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
+
+        # checks for dimensions 
+        if not prediction.shape[1:] == target.shape:
+            raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
+    
+        if not prediction.shape[0] == self.n_members:
+            raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
+
+        n = self.n_members
+
+        # Manual cast
+        prediction = prediction.to(th.float32)
+        target = target.to(th.float32)
+
+        # Apply channel weights across channel dims
+        prediction *= self.loss_weights[None, None, None, None, :, None, None]
+        target *= self.loss_weights[None, None, None, :, None, None]
+
+        if n == 2:
+            # Use faster explicit implementation
+            diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
+            diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
+            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+
+            if average_channels:
+                loss = crps.mean()
+            else:
+                loss = crps.mean(dim=(0, 1, 2, 4, 5))
+
+            if self.lambda_spec > 0:
+
+                with th.cuda.amp.autocast(enabled=False):
+                    # # Reorder predictions: [N, B, F, T, C, H, W] -> [N, B, T, C, F*H*W]
+                    # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 3, 4, 2, 5, 6).reshape(n, b, t, c, f*h*w))
+
+                    # # Reorder targets: [B, F, T, C, H, W] -> [B, T, C, F*H*W]
+                    # tar_ring = self.reorder_to_ring(target.permute(0, 2, 3, 1, 4, 5).reshape(b, t, c, f*h*w))
+
+                    # # Compute SHT of predictions and targets
+                    # sht_pred = self.sht(pred_ring) # [N, B, T, C, l, m]
+                    # sht_tar = self.sht(tar_ring) # [B, T, C, l, m]
+                    # sht_pred = sht_pred.real ** 2 + sht_pred.imag ** 2
+                    # sht_tar = sht_tar.real ** 2 + sht_tar.imag ** 2
+
+                    sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True)
+                    sht_tar = self._apply_sht(target, face_dim=1, return_abs=True)
+
+                    diff_sht_target = th.abs(sht_pred - sht_tar.unsqueeze(0)).sum(dim=(0, 4, 5)) # [B, T, C]
+                    diff_sht_ensemble = th.abs(sht_pred[0] - sht_pred[1]).sum(dim=(-1,-2)) # [B, T, C] 
+                    crps_sht = self.averaging_coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble) # [B, T, C]
+
+                    # Compute spectral afCRPS
+                    if average_channels:
+                        spec_loss = crps_sht.mean()
+                    else:
+                        spec_loss = crps_sht.mean(dim=(0, 1))
+
+                loss += self.lambda_spec * spec_loss
+            
+            if self.multiscale > 0:
+                for scale in self.scales:
+                    l_filter = self._l_filter(scale, device=prediction.device)
+                    with th.cuda.amp.autocast(enabled=False):
+                        sht_pred= self._apply_sht(prediction, face_dim=2, return_abs=False)
+                        sht_tar = self._apply_sht(target, face_dim=1, return_abs=False)
+
+                        l_filter_pred = l_filter[None, None, None, None, :, None] # [1, 1, 1, 1, lmax, 1]
+                        l_filter_tar = l_filter[None, None, None, :, None] # [1, 1, 1, lmax, 1]
+
+                        pred_smooth = self._apply_isht(l_filter_pred * sht_pred, face_dim=2)
+                        tar_smooth = self._apply_isht(l_filter_tar * sht_tar, face_dim=1)
+
+                        diff_target = th.abs(pred_smooth - tar_smooth.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
+                        diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
+                        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+
+                        crps *= self.lsm_tensor
+
+                        if average_channels:
+                            loss += self.multiscale * crps.mean()
+                        else:
+                            loss += self.multiscale * crps.mean(dim=(0, 1, 2, 4, 5))
+                        
+            return loss
+        
+        else:
+            # Use pairwise distance method
+            if not average_channels:
+                # Move channels to first dimension and exclude that dimension from the reductions           
+                prediction = prediction.permute(4, 0, 1, 2, 3, 5, 6) # [C, Cond, B, F, T, H, W]
+                target = target.permute(3, 0, 1, 2, 4, 5) # [C, B, F, T, H, W]
+
+                pred = prediction.reshape(c, n, -1) # [C, Cond, ...]
+                tar = target.unsqueeze(1).reshape(c, 1, -1) # [C, 1, ...] (second dim will broadcast across ensemble)
+
+                diff = self.pdist(pred, tar) # [C, Cond]
+                dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(2))  # [C, Cond, Cond]
+                
+                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
+
+                if self.lambda_spec > 0:
+                    with th.cuda.amp.autocast(enabled=False):
+                        # # Reorder predictions: [C, Cond, B, F, T, H, W] -> [C, Cond, B, T, F*H*W]
+                        # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 2, 4, 3, 5, 6).reshape(c, n, b, t, f*h*w))
+
+                        # # Reorder targets: [C, B, F, T, H, W] -> [C, B, T, F*H*W]
+                        # tar_ring = self.reorder_to_ring(target.permute(0, 1, 3, 2, 4, 5).reshape(c, b, t, f*h*w))
+
+                        # # Compute SHT of predictions and targets
+                        # sht_pred = self.sht(pred_ring).reshape(c, n, -1) # [C, Cond, B, T, l, m] -> [C, Cond, ...]
+                        # sht_tar = self.sht(tar_ring).unsqueeze(1).reshape(c, 1, -1) # [C, B, T, l, m] -> [C, 1, ...] (second dim will broadcast across ensemble)
+                        # sht_pred = sht_pred.real ** 2 + sht_pred.imag ** 2
+                        # sht_tar = sht_tar.real ** 2 + sht_tar.imag ** 2
+
+                        sht_pred = self._apply_sht(prediction, face_dim=3, return_abs=True).reshape(c, n, -1)
+                        sht_tar = self._apply_sht(target, face_dim=2, return_abs=True).unsqueeze(1).reshape(c, 1, -1)
+
+                        diff = self.pdist(sht_pred, sht_tar) # [C, Cond]
+                        dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(2))  # [C, Cond, Cond]
+                        
+                        diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*t*self.lmax*self.mmax)
+
+            else:
+                pred = prediction.reshape(n, -1)
+                tar = target.unsqueeze(0).reshape(1, -1) # [1, ...] (first dim will broadcast across ensemble)
+                diff = self.pdist(pred, tar) # [Cond]
+                dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(0))  # [Cond, Cond] 
+
+                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
+
+                if self.lambda_spec > 0:
+                    with th.cuda.amp.autocast(enabled=False):
+                        # # Reorder predictions: [Cond, B, F, T, C, H, W] -> [Cond, B, T, C, F*H*W]
+                        # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 3, 4, 2, 5, 6).reshape(n, b, t, c, f*h*w))
+
+                        # # Reorder targets: [B, F, T, C, H, W] -> [B, T, C, F*H*W]
+                        # tar_ring = self.reorder_to_ring(target.permute(0, 2, 3, 1, 4, 5).reshape(b, t, c, f*h*w))
+
+                        # # Compute SHT of predictions and targets
+                        # sht_pred = self.sht(pred_ring).reshape(n, -1) # [Cond, B, T, C, l, m] -> [Cond, ...]
+                        # sht_tar = self.sht(tar_ring).unsqueeze(0).reshape(1, -1) # [B, T, C, l, m] -> [1, ...] (first dim will broadcast across ensemble)
+                        # sht_pred = sht_pred.real ** 2 + sht_pred.imag ** 2
+                        # sht_tar = sht_tar.real ** 2 + sht_tar.imag ** 2
+                        sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).reshape(n, -1)
+                        sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).unsqueeze(0).reshape(1, -1)
+
+                        diff = self.pdist(sht_pred, sht_tar) # [Cond]
+                        dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(0))  # [Cond, Cond] 
+                        
+                        diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
+
+            return loss
+        

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -67,6 +67,7 @@ class HEALPixRecUNet(Module):
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
         couplings: list = [],
+        residual_prediction: bool = True,
     ):
         """
         Parameters
@@ -103,6 +104,8 @@ class HEALPixRecUNet(Module):
             Enable CUDA HEALPixPadding if installed
         couplings: list, optional
             sequence of dictionaries that describe coupling mechanisms
+        residual_prediction: bool, optional
+            If the model should predict the residual between the input and the output. Default: True
         """
         super().__init__()
         self.channel_dim = 2  # Now 2 with [B, F, T*C, H, W]. Was 1 in old data format with [B, T*C, F, H, W]
@@ -137,6 +140,7 @@ class HEALPixRecUNet(Module):
         self.presteps = presteps
         self.enable_nhwc = enable_nhwc
         self.enable_healpixpad = enable_healpixpad
+        self.residual_prediction = residual_prediction
 
         # Number of passes through the model, or a diagnostic model with only one output time
         self.is_diagnostic = self.output_time_dim == 1 and self.input_time_dim > 1
@@ -407,7 +411,9 @@ class HEALPixRecUNet(Module):
         conditions_cln: Sequence, optional
             If the model is using conditional normalization, this is a sequence of tensors that will be used to condition the 
             normalization layers. The shape of the tensors should be [Cond*B, N], where N is the size of the conditions, Cond is the 
-            number of conditions, and B is the batch size.
+            number of conditions, and B is the batch size. It is expected that the inputs have a leading dimension of Cond*B (e.g., data
+            for different ensmble members/conditions has been duplicated along this dimension). The sequence should have length equal to
+            the model's `n_integration_steps` attribute.
 
         Returns
         -------
@@ -418,7 +424,10 @@ class HEALPixRecUNet(Module):
         for step in range(self.integration_steps):
             # (Re-)initialize recurrent hidden states
             if (step * (self.delta_t * self.input_time_dim)) % self.reset_cycle == 0:
-                self._initialize_hidden(inputs=inputs, outputs=outputs, step=step, conditions_cln=conditions_cln)
+                if conditions_cln is not None:
+                    self._initialize_hidden(inputs=inputs, outputs=outputs, step=step, conditions_cln=conditions_cln[step])
+                else:
+                    self._initialize_hidden(inputs=inputs, outputs=outputs, step=step)
 
             # Construct concatenated input: [prognostics|TISR|constants]
             if step == 0:
@@ -464,14 +473,19 @@ class HEALPixRecUNet(Module):
 
             # Forward through model, with or without conditions
             if conditions_cln is not None:
-                encodings = self.encoder(input_tensor, conditions_cln=conditions_cln)
-                decodings = self.decoder(encodings, conditions_cln=conditions_cln)
+                kwargs = {"conditions_cln": conditions_cln[step]}
             else:
-                encodings = self.encoder(input_tensor)
-                decodings = self.decoder(encodings)
+                kwargs = {}
+
+            encodings = self.encoder(input_tensor, **kwargs)
+            decodings = self.decoder(encodings, **kwargs)
             # Residual prediction
+            if self.residual_prediction:
+                prediction = input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
+            else:
+                prediction = decodings
             reshaped = self._reshape_outputs(
-                input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
+                prediction
             )
             outputs.append(reshaped)
 

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -64,6 +64,7 @@ class HEALPixUNet(Module):
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
         couplings: list = [],
+        residual_prediction: bool = False,
     ):
         """
         Parameters
@@ -95,6 +96,8 @@ class HEALPixUNet(Module):
             Enable CUDA HEALPixPadding if installed. default: False
         couplings: list, optional
             sequence of dictionaries that describe coupling mechanisms
+        residual_prediction: bool, optional
+            If the model should predict the residual between the input and the output. Default: False
         """
         super().__init__()
 
@@ -121,6 +124,7 @@ class HEALPixUNet(Module):
         self.channel_dim = 2  # Now 2 with [B, F, C*T, H, W]. Was 1 in old data format with [B, T*C, F, H, W]
         self.enable_nhwc = enable_nhwc
         self.enable_healpixpad = enable_healpixpad
+        self.residual_prediction = residual_prediction
 
         # Number of passes through the model, or a diagnostic model with only one output time
         self.is_diagnostic = self.output_time_dim == 1 and self.input_time_dim > 1
@@ -311,7 +315,7 @@ class HEALPixUNet(Module):
 
         return res
 
-    def forward(self, inputs: Sequence, output_only_last=False) -> th.Tensor:
+    def forward(self, inputs: Sequence, output_only_last=False, conditions_cln: Sequence=None) -> th.Tensor:
         """
         Forward pass of the HEALPixUnet
 
@@ -323,7 +327,12 @@ class HEALPixUNet(Module):
             [F, C, H, W] is the format for constants
         output_only_last: bool, optional
             If only the last dimension of the outputs should be returned. default: False
-
+        conditions_cln: Sequence, optional
+            If the model is using conditional normalization, this is a sequence of tensors that will be used to condition the 
+            normalization layers. The shape of the tensors should be [Cond*B, N], where N is the size of the conditions, Cond is the 
+            number of conditions, and B is the batch size. It is expected that the inputs have a leading dimension of Cond*B (e.g., data
+            for different ensmble members/conditions has been duplicated along this dimension). The sequence should have length equal to
+            the model's `n_integration_steps` attribute.
         Returns
         -------
         th.Tensor: Predicted outputs
@@ -346,10 +355,24 @@ class HEALPixUNet(Module):
                     input_tensor = self._reshape_inputs(
                         [outputs[-1]] + list(inputs[1:]), step
                     )
-            encodings = self.encoder(input_tensor)
-            decodings = self.decoder(encodings)
 
-            reshaped = self._reshape_outputs(decodings)  # Absolute prediction
+            kwargs = {}
+            if conditions_cln is not None:
+                kwargs = {"conditions_cln": conditions_cln[step]}
+            else:
+                kwargs = {}
+
+            encodings = self.encoder(input_tensor, **kwargs)
+            decodings = self.decoder(encodings, **kwargs)
+
+            if self.residual_prediction:
+                prediction = input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
+            else:
+                prediction = decodings
+            
+            reshaped = self._reshape_outputs(
+                prediction
+            )
             outputs.append(reshaped)
 
         if output_only_last:


### PR DESCRIPTION
Adds changes needed to support coupled CRPS training, and adds variants of the CRPS loss used in experiments (spectral, spatially pooled, mean penalty, etc). The latter could use some cleanup but I want to push what I have now for clarity/consistency and so others have visibility into how these models are trained (and so Raul is not blocked).

Also adds support for:

- Configuring residual connection in either U-Net model
- Supporting the `ttr-3h-48H` coupler input for the ocean

Parallel PR: [NV-dlesm#100](https://github.com/AtmosSci-DLESM/NV-dlesm/pull/100)