### PR TITLE
Smoothed interpolation conv upsampling

### DIFF
--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -24,6 +24,8 @@ from .normalization import ConditionalLayerNorm
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 
+from hydra.utils import get_class
+
 #
 # RECURRENT BLOCKS
 #
@@ -115,7 +117,6 @@ class ConvGRUBlock(th.nn.Module):
         """Reset the update gates"""
         self.h = th.zeros_like(self.h)
 
-
 #
 # CONV BLOCKS
 #
@@ -162,6 +163,7 @@ class BasicConvBlock(th.nn.Module):
             If HEALPixPadding should be enabled, passed to wrapper
         """
         super().__init__()
+
         if latent_channels is None:
             latent_channels = max(in_channels, out_channels)
         convblock = []
@@ -195,7 +197,6 @@ class BasicConvBlock(th.nn.Module):
             result of the forward pass
         """
         return self.convblock(x)
-
 
 class ConvNeXtBlock(th.nn.Module):
     """Class implementing a modified ConvNeXt network as described in https://arxiv.org/pdf/2201.03545.pdf
@@ -626,13 +627,13 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         self.activation = activation
         self.dropout = dropout > 0.0
         self.cln_enabled = conditional_layer_norm is not None
-
+        
         if use_block_skip_connection:
             if in_channels == int(out_channels):
                 self.skip_module = lambda x: x
             else:
                 self.skip_module = geometry_layer(
-                    layer=th.nn.Conv2d,
+                    layer=torch.nn.Conv2d,
                     in_channels=in_channels,
                     out_channels=out_channels,
                     kernel_size=1,
@@ -646,7 +647,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         # 3x3: in → latent
         convblock.append(
             geometry_layer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=in_channels,
                 out_channels=int(latent_channels),
                 kernel_size=kernel_size,
@@ -670,7 +671,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         # 1x1: latent → latent * upscale
         convblock.append(
             geometry_layer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=int(latent_channels * upscale_factor),
                 kernel_size=1,
@@ -693,7 +694,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         # 1x1: upscale → latent
         convblock.append(
             geometry_layer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels * upscale_factor),
                 out_channels=int(latent_channels),
                 kernel_size=1,
@@ -715,7 +716,7 @@ class SymmetricConvNeXtBlock(th.nn.Module):
         # 3x3: latent → out (no norm on this one, following convnext)
         convblock.append(
             geometry_layer(
-                layer=th.nn.Conv2d,
+                layer=torch.nn.Conv2d,
                 in_channels=int(latent_channels),
                 out_channels=out_channels,
                 kernel_size=kernel_size,
@@ -837,6 +838,7 @@ class AvgPool(th.nn.Module):
             If HEALPixPadding should be enabled, passed to wrapper
         """
         super().__init__()
+
         self.avgpool = geometry_layer(
             layer=torch.nn.AvgPool2d,
             kernel_size=pooling,
@@ -858,7 +860,6 @@ class AvgPool(th.nn.Module):
             The averaged values
         """
         return self.avgpool(x)
-
 
 #
 # UPSAMPLING BLOCKS
@@ -899,6 +900,7 @@ class TransposedConvUpsample(th.nn.Module):
             If HEALPixPadding should be enabled, passed to wrapper
         """
         super().__init__()
+                     
         upsampler = []
         # Upsample transpose conv
         upsampler.append(
@@ -932,11 +934,111 @@ class TransposedConvUpsample(th.nn.Module):
         """
         return self.upsampler(x)
 
+class SmoothedInterpolateConv(th.nn.Module):
+    """
+    Class for sequentially interpolating, applying a smoothing filter which
+    preserves zonally uniform signals, then applying a simple Conv2d on
+    HEALPix tensor data
+    """
+
+    def __init__(
+        self,
+        geometry_layer: th.nn.Module = HEALPixLayer,
+        in_channels = 3,
+        out_channels = 3,
+        kernel_size = 3,
+        dilation = 1,
+        scale_factor = 2,
+        mode = 'nearest',
+        activation: th.nn.Module = None,
+        enable_nhwc = False,
+        enable_healpixpad = True,
+    ):
+        """
+        Parameters
+        ----------
+        geometry_layer: torch.nn.Module, optional
+            The wrapper for the geometry of the tensor being bassed to this module
+        in_channels: int, optional
+            The number of input channels
+        out_channels: int, optional
+            The number of output channels
+        kernel_size: int, optional
+            Size of the convolutional kernel
+        dilation: int, optional
+            Spacing between kernel points, passed to torch.nn.Conv2d
+        scale_factor: int, optional
+            Multiplier for spatial size, passed to torch.nn.functional.interpolate
+        mode: str, optional
+            Algorithm used for upsampling, passed to torch.nn.functional.interpolate
+        activation: torch.nn.Module, optional
+            Activation function used in upsampling
+        enable_nhwc: bool, optional
+            Enable nhwc format, passed to wrapper
+        enable_healpixpad: bool, optional
+            If HEALPixPadding should be enabled, passed to wrapper
+        """
+        super().__init__()
+
+        if dilation > 1:
+            raise Exception(
+                f"dilation > 1 is not currently supported for hpx resize \
+                convolutions, received dilation = {dilation}"
+            )
+
+        # We pad first before upsampling to prevent edge artifacts at seams
+        # between HPX faces. This means that our final upsampled signal will
+        # have extra padding which we need to trim before passing to conv. We
+        # only require padding=1 before upsampling, so only need to trim 1 row/
+        # column from each side of result.
+        trim_size = 1 
+
+        block = []
+        block += [
+            geometry_layer(
+                layer=SmoothedInterpolate,
+                in_channels=in_channels,
+                scale_factor=scale_factor,
+                mode=mode,
+                trim_size=trim_size,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            ),
+            geometry_layer(
+                layer=torch.nn.Conv2d,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=kernel_size,
+                dilation=dilation,
+                enable_nhwc=enable_nhwc,
+                enable_healpixpad=enable_healpixpad,
+            )
+        ]
+
+        if activation is not None:
+            block.append(activation)
+        self.block = th.nn.Sequential(*block)
+
+    def forward(self, x: th.Tensor) -> th.Tensor:
+        """
+        Forward pass of the ResizeConv layer
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            inputs to the forward pass
+
+        Returns
+        -------
+        torch.Tensor
+            result of the forward pass
+        """
+        x = self.block(x)
+        return x
 
 #
 # Helper classes
 #
-
 
 class Interpolate(th.nn.Module):
     """Helper class that handles interpolation
@@ -971,3 +1073,67 @@ class Interpolate(th.nn.Module):
             the interpolated values
         """
         return self.interp(inputs, scale_factor=self.scale_factor, mode=self.mode)
+
+class SmoothedInterpolate(th.nn.Module):
+    """
+    Helper class for interpolating a HEALPix signal then applying a four point
+    smoother which preserves zonal uniformity if the upsampling mode is nearest
+    neighbor or bilinear.
+    """
+    
+    def __init__(
+        self,
+        in_channels: int = 3,
+        scale_factor: int = 2,
+        mode: str = 'nearest',
+        trim_size: int = 0,
+    ):
+        """
+        Parameters
+        ----------
+        in_channels: int, optional
+            The number of input channels
+        scale_factor: int, optional
+            Multiplier for spatial size, passed to torch.nn.functional.interpolate
+        mode: str, optional
+            Algorithm used for upsampling, passed to torch.nn.functional.interpolate
+        trim_size: int, optional
+            Amount of padding to trim from final tensor, which is assumed to be
+            square
+        """
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.scale_factor = scale_factor
+        self.mode = mode
+        self.trim_size = trim_size
+        self.interp = th.nn.functional.interpolate
+
+        # Four point smoother specific to HPX grid. This smooths out the specific
+        # type of aliasing that nearest neighbor and bilinear upsampling introduce
+        # into zonally uniform signals
+        self.smoother_kernel = torch.tensor(
+            [[0.,1.,0.],
+             [1.,0.,1.],
+             [0.,1.,0.]]
+        )
+        self.smoother_kernel = self.smoother_kernel.unsqueeze(0).unsqueeze(0)  # shape (1,1,3,3)
+        self.smoother_kernel = self.smoother_kernel.repeat((in_channels,1,1,1))
+
+    def forward(self, x: th.Tensor) -> th.Tensor:
+        self.smoother_kernel = self.smoother_kernel.to(device=x.device, dtype=x.dtype)
+
+        # Interpolate, smooth, trim in order
+        x = self.interp(x, scale_factor=self.scale_factor, mode=self.mode)
+
+        x = torch.nn.functional.conv2d(
+            x,
+            self.smoother_kernel,
+            padding=0,
+            groups=self.in_channels
+        ) / 4 # divide by 4 to take average of 4 neighbors
+
+        if self.trim_size > 0:
+            x = x[..., self.trim_size:-self.trim_size, self.trim_size:-self.trim_size]
+
+        return x

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_blocks.py
@@ -24,8 +24,6 @@ from .normalization import ConditionalLayerNorm
 from hydra.utils import instantiate
 from omegaconf import DictConfig
 
-from hydra.utils import get_class
-
 #
 # RECURRENT BLOCKS
 #

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
@@ -585,12 +585,21 @@ class HEALPixLayer(th.nn.Module):
         else:
             enable_healpixpad = False
 
-        # Define a HEALPixPadding layer if the given layer is a convolution layer
+        # Define a HEALPixPadding layer if the given layer is a convolution or
+        # interpolation layer
+        if layer.__bases__[0] is th.nn.modules.conv._ConvNd:
+            layer_type = "conv"
+        elif "Interpolate" in layer.__name__:
+            layer_type = "interp"
+        else:
+            layer_type = "other"
+
         if (
-            layer.__bases__[0] is th.nn.modules.conv._ConvNd
-            and kwargs["kernel_size"] > 1
+            (layer_type == "conv" and kwargs["kernel_size"] > 1)
+            or (layer_type == "interp")
         ):
-            kwargs["padding"] = 0  # Disable native padding
+            if layer_type == "conv":
+                kwargs["padding"] = 0  # Disable native padding
             kernel_size = 3 if "kernel_size" not in kwargs else kwargs["kernel_size"]
             dilation = 1 if "dilation" not in kwargs else kwargs["dilation"]
             padding = ((kernel_size - 1) // 2) * dilation


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR adds a new upsampling scheme. Simple nearest neighbor and bilinear upsampling methods applied individually to HEALPix faces introduce artifacts at seams and along lines of constant latitude when the incoming signal is zonally uniform (no east-west variance). This new upsampling scheme mitigates this by applying padding before the interpolation and also applying a HEALPix specific four-point smoother after the interpolation which preserves zonal uniformity when the interpolation mode is nearest neighbor or bilinear.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->