### PR TITLE
Model output constraints

### DIFF
--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -67,8 +67,6 @@ class HEALPixRecUNet(Module):
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
         couplings: list = [],
-        hpx_padding_mode: str = 'karlbauer',
-        enforce_reflectional_equivariance: bool = False,
         constraints = None,
     ):
         """
@@ -332,17 +330,6 @@ class HEALPixRecUNet(Module):
         )
 
         return res
-
-    def hpx_reflect(self, x):
-        '''
-        Helper function to reflect a HPX tensor across its horizontal axis.
-        Assumes x has shape [B*F,C,H,W]
-        '''
-        x = th.rot90(th.flip(x, dims=[3]), dims=(-1,-2))
-        x = x.reshape(-1, 12, *x.shape[1:])
-        x = th.index_select(x, dim=1, index=self.refl_face_order.to(x.device))
-        x = x.reshape(x.shape[0]*x.shape[1], *x.shape[2:])
-        return x
 
     def set_constraints(self, constraints):
         if constraints is not None:

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -67,7 +67,7 @@ class HEALPixRecUNet(Module):
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
         couplings: list = [],
-        constraints = None,
+        constraints: list[DictConfig] = None,
     ):
         """
         Parameters
@@ -331,7 +331,15 @@ class HEALPixRecUNet(Module):
 
         return res
 
-    def set_constraints(self, constraints):
+    def set_constraints(self, constraints: list[DictConfig] = None):
+        """
+        Sets constraints (e.g., non-negative) to be applied to the model outputs
+
+        Parameters
+        ----------
+        constraints: list[DictConfig]
+            List of hydra instantiable DictConfigs specifying constraints
+        """
         if constraints is not None:
             self.constraints = [instantiate(constraints[constraint]) for constraint in constraints]
 

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -67,6 +67,9 @@ class HEALPixRecUNet(Module):
         enable_nhwc: bool = False,
         enable_healpixpad: bool = False,
         couplings: list = [],
+        hpx_padding_mode: str = 'karlbauer',
+        enforce_reflectional_equivariance: bool = False,
+        constraints = None,
     ):
         """
         Parameters
@@ -162,6 +165,9 @@ class HEALPixRecUNet(Module):
             enable_nhwc=self.enable_nhwc,
             enable_healpixpad=self.enable_healpixpad,
         )
+
+        self.constraints = None
+        self.set_constraints(constraints)
 
     @property
     def integration_steps(self):
@@ -327,6 +333,21 @@ class HEALPixRecUNet(Module):
 
         return res
 
+    def hpx_reflect(self, x):
+        '''
+        Helper function to reflect a HPX tensor across its horizontal axis.
+        Assumes x has shape [B*F,C,H,W]
+        '''
+        x = th.rot90(th.flip(x, dims=[3]), dims=(-1,-2))
+        x = x.reshape(-1, 12, *x.shape[1:])
+        x = th.index_select(x, dim=1, index=self.refl_face_order.to(x.device))
+        x = x.reshape(x.shape[0]*x.shape[1], *x.shape[2:])
+        return x
+
+    def set_constraints(self, constraints):
+        if constraints is not None:
+            self.constraints = [instantiate(constraints[constraint]) for constraint in constraints]
+
     def _initialize_hidden(
         self, inputs: Sequence, outputs: Sequence, step: int, conditions_cln: Sequence = None
     ) -> None:
@@ -473,6 +494,12 @@ class HEALPixRecUNet(Module):
             reshaped = self._reshape_outputs(
                 input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
             )
+
+            # Apply constraints
+            if self.constraints is not None:
+                for constraint in self.constraints:
+                    reshaped = constraint(reshaped)
+
             outputs.append(reshaped)
 
         if output_only_last:

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -65,6 +65,7 @@ class HEALPixUNet(Module):
         enable_healpixpad: bool = False,
         couplings: list = [],
         residual_prediction: bool = False,
+        constraints: list[DictConfig] = None,
     ):
         """
         Parameters
@@ -150,6 +151,9 @@ class HEALPixUNet(Module):
             enable_nhwc=self.enable_nhwc,
             enable_healpixpad=self.enable_healpixpad,
         )
+
+    self.constraints = None
+    self.set_constraints(constraints)
 
     @property
     def integration_steps(self):
@@ -315,6 +319,17 @@ class HEALPixUNet(Module):
 
         return res
 
+    def set_constraints(self, constraints: list[DictConfig] = None):
+        """
+        Sets constraints (e.g., non-negative) to be applied to the model outputs
+        Parameters
+        ----------
+        constraints: list[DictConfig]
+            List of hydra instantiable DictConfigs specifying constraints
+        """
+        if constraints is not None:
+            self.constraints = [instantiate(constraints[constraint]) for constraint in constraints]
+
     def forward(self, inputs: Sequence, output_only_last=False, conditions_cln: Sequence=None) -> th.Tensor:
         """
         Forward pass of the HEALPixUnet
@@ -373,6 +388,12 @@ class HEALPixUNet(Module):
             reshaped = self._reshape_outputs(
                 prediction
             )
+
+            # Apply constraints
+            if self.constraints is not None:
+                for constraint in self.constraints:
+                    reshaped = constraint(reshaped)
+
             outputs.append(reshaped)
 
         if output_only_last:

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
@@ -1,0 +1,39 @@
+import numpy as np
+import torch
+import xarray as xr
+
+class NonnegativeConstraint(torch.nn.Module):
+    def __init__(
+        self,
+        variables,
+        channels,
+        scaling,
+    ):
+        super().__init__()
+        self.variables = variables
+        self.channels = channels
+        self.scaling = scaling
+
+        var_indices = torch.tensor(
+            [channels.index(var) for var in self.variables],
+            dtype=torch.long
+        )
+        self.register_buffer('var_indices', var_indices, persistent=False)
+
+        self.var_means = torch.tensor([scaling[var]['mean'] for var in self.variables])
+        self.var_stds = torch.tensor([scaling[var]['std'] for var in self.variables])
+
+        thresholds = (0. - self.var_means) / self.var_stds
+        thresholds = thresholds.view(1, 1, 1, -1, 1, 1)
+        self.register_buffer('thresholds', thresholds, persistent=False)
+
+    def forward(self, x):
+        '''
+        Tensors are expected to be in the shape [B, F, T, C, H, W]
+        '''
+        
+        selected_vars = torch.index_select(x, dim=3, index=self.var_indices)
+        clamped = torch.maximum(selected_vars, self.thresholds)
+        x.index_copy_(3, self.var_indices, clamped)
+
+        return x

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
@@ -14,6 +14,9 @@ class NonnegativeConstraint(torch.nn.Module):
         self.channels = channels
         self.scaling = scaling
 
+        # Only apply constraint to variables that are used by model
+        self.variables = [var for var in self.variables if var in channels]
+
         var_indices = torch.tensor(
             [channels.index(var) for var in self.variables],
             dtype=torch.long

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_constraints.py
@@ -5,10 +5,20 @@ import xarray as xr
 class NonnegativeConstraint(torch.nn.Module):
     def __init__(
         self,
-        variables,
-        channels,
-        scaling,
+        variables: list[str],
+        channels: list[str],
+        scaling: dict[str, dict[str, float]],
     ):
+        """
+        Parameters
+        ----------
+        variables: list[str]
+            List of variable names to apply the constraint to.
+        channels: list[str]
+            List of all input channel names in the model.
+        scaling: dict[str, dict[str, float]]
+            Dictionary containing the mean and std for each variable.
+        """
         super().__init__()
         self.variables = variables
         self.channels = channels
@@ -34,7 +44,6 @@ class NonnegativeConstraint(torch.nn.Module):
         '''
         Tensors are expected to be in the shape [B, F, T, C, H, W]
         '''
-        
         selected_vars = torch.index_select(x, dim=3, index=self.var_indices)
         clamped = torch.maximum(selected_vars, self.thresholds)
         x.index_copy_(3, self.var_indices, clamped)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR adds the ability to specify constraints to model outputs (e.g., enforcing non-negativity in water vapor). These constraints are given as hydra instantiable DictConfigs and applied directly to model output before that output is autoregressively fed back into the model. Included is one such constraint to enforce non-negativity in specified variables. There is a [corresponding PR in NV-dlesm](https://github.com/AtmosSci-DLESM/NV-dlesm/pull/102) for small changes to support these constraints.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->