### PR TITLE
Loss function wrapper to add hydrostatic constraints

### DIFF
--- a/physicsnemo/metrics/climate/hydrostasy.py
+++ b/physicsnemo/metrics/climate/hydrostasy.py
@@ -673,6 +673,9 @@ class LossWithHydrostasy(torch.nn.MSELoss):
         pushes weights to cuda device
         """
 
+        # Call setup for data loss first
+        self.data_loss.setup(trainer)
+
         if len(self.z_pressure_levels) - 1 != len(
             self.loss_weights
         ):

--- a/physicsnemo/metrics/climate/hydrostasy.py
+++ b/physicsnemo/metrics/climate/hydrostasy.py
@@ -478,7 +478,6 @@ class WeightedMSEWithHydrostasy(torch.nn.MSELoss):
     def forward(self, prediction, target, average_channels=True):
         """
         Forward pass of the WeightedMSE pass
-        #Tensors are expected to be in the shape [N, B, F, C, H, W]
         Tensors are expected to be in the shape [N, F, B, C, H, W]
 
         Parameters
@@ -497,7 +496,6 @@ class WeightedMSEWithHydrostasy(torch.nn.MSELoss):
             prediction = prediction.float()
             target = target.float()
 
-            # N, B, F, C, H, W = tuple(prediction.shape)
             N, F, B, C, H, W = tuple(prediction.shape)
 
             if not (prediction.ndim == 6 and target.ndim == 6):
@@ -657,7 +655,7 @@ class LossWithHydrostasy(torch.nn.MSELoss):
         # Get topography information
         ds = xr.open_zarr(f"{src_directory}{dataset_name}.zarr")
         self.topography = (
-            surface_geopotential_std * ds.constants[1, :, :, :].values
+            surface_geopotential_std * ds.constants.sel(channel_c='z').values
             + surface_geopotential_mean
         ) / self.g0
 
@@ -789,8 +787,7 @@ class LossWithHydrostasy(torch.nn.MSELoss):
 
     def forward(self, prediction, target, average_channels=True):
         """
-        Forward pass of the WeightedMSE pass
-        #Tensors are expected to be in the shape [N, B, F, C, H, W]
+        Forward pass of LossWithHydrostasy
         Tensors are expected to be in the shape [N, F, B, C, H, W]
 
         Parameters
@@ -808,9 +805,6 @@ class LossWithHydrostasy(torch.nn.MSELoss):
         with torch.cuda.amp.autocast(enabled=False):
             prediction = prediction.float()
             target = target.float()
-
-            # N, B, F, C, H, W = tuple(prediction.shape)
-            N, F, B, C, H, W = tuple(prediction.shape)
 
             if not (prediction.ndim == 6 and target.ndim == 6):
                 raise AssertionError("Expected predictions to have 6 dimensions")

--- a/physicsnemo/metrics/climate/hydrostasy.py
+++ b/physicsnemo/metrics/climate/hydrostasy.py
@@ -522,3 +522,312 @@ class WeightedMSEWithHydrostasy(torch.nn.MSELoss):
                 return torch.mean(d)
             else:
                 return d
+
+
+class LossWithHydrostasy(torch.nn.MSELoss):
+
+    """
+    Loss object that adds a differential Hydrostatic balance constraint in addition to
+    user defined data loss 
+    """
+
+    def __init__(
+        self,
+        data_loss: torch.nn.MSELoss,
+        hPa_levels: Sequence[int],
+        channels: Sequence[str],
+        weights: Sequence,
+        alpha: Sequence[float],  # K
+        scaling: Dict[str, Dict[str, float]],
+        src_directory: str,
+        dst_directory: str,
+        dataset_name: str,
+        data_format: str,
+        surface_geopotential_mean: float = -597.7115478515625,
+        surface_geopotential_std: float = 55658.21484375,
+        R: float = 287,  # J K^{-1} kg^{-1}
+        g0: float = 9.81,  # m s^{-2}
+        topography_masking: bool = True,
+    ):
+        """
+        Parameters
+        ----------
+        weights: Sequence
+            list of floats that determine weighting of hydrostatic loss terms, assumed to be
+            in order of increasing pressure levels
+        """
+        super().__init__()
+        self.data_loss = data_loss
+        self.loss_weights = torch.tensor(weights)
+        self.device = None
+        self.g0 = g0
+        self.topography_masking = topography_masking
+
+        # Get channel index to pressure level mapping
+        self.pressure_levels = sorted(hPa_levels)
+        self.z_pressure_levels = {
+            channels.index(f"z{int(pl)}"): pl
+            for i, pl in enumerate(self.pressure_levels)
+        }
+        self.T_pressure_levels = {
+            channels.index(f"t{int(pl)}"): pl
+            for i, pl in enumerate(self.pressure_levels)
+        }
+        self.q_pressure_levels = {
+            channels.index(f"q{int(pl)}"): pl
+            for i, pl in enumerate(self.pressure_levels)
+            if f"q{int(pl)}" in channels
+        }
+        # Get offset to map from q channels here to Tv channels
+        # Relies on all pressure levels below a threshold to have q channels
+        for i, pl in enumerate(self.pressure_levels):
+            if f"q{int(pl)}" in channels:
+                self.q_index_offset = i
+                break
+
+        # Create mapping for new tensor that holds only the constraint variables
+        self.z_constraint_pressure_levels = {
+            i: pl for i, pl in enumerate(self.pressure_levels)
+        }
+        self.Tv_constraint_pressure_levels = {
+            len(self.z_constraint_pressure_levels) + i: pl
+            for i, pl in enumerate(self.pressure_levels)
+        }
+
+        # Get scaling weights
+        self.z_mean = torch.Tensor(
+            [
+                scaling[f"z{int(pl)}"]["mean"]
+                for i, pl in enumerate(self.pressure_levels)
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.z_std = torch.Tensor(
+            [scaling[f"z{int(pl)}"]["std"] for i, pl in enumerate(self.pressure_levels)]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.T_mean = torch.Tensor(
+            [
+                scaling[f"t{int(pl)}"]["mean"]
+                for i, pl in enumerate(self.pressure_levels)
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.T_std = torch.Tensor(
+            [scaling[f"t{int(pl)}"]["std"] for i, pl in enumerate(self.pressure_levels)]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.q_mean = torch.Tensor(
+            [
+                scaling[f"q{int(pl)}"]["mean"]
+                for i, pl in enumerate(self.q_pressure_levels.values())
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.q_std = torch.Tensor(
+            [
+                scaling[f"q{int(pl)}"]["std"]
+                for i, pl in enumerate(self.q_pressure_levels.values())
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+
+        # Set per level alphas
+        if len(alpha) != len(hPa_levels) - 1:
+            raise AssertionError(
+                f"Incorrect number of alpha values. Expected len(hPa_levels)-1 [{len(hPa_levels)-1}], got {len(alpha)}"
+            )
+        self.alpha = torch.Tensor(alpha).reshape((1, 1, -1, 1, 1))
+
+        # Molecular weight ratio factor of water vapor to air
+        self.Mw_ratio = 28.97 / 18.016 - 1.0  # 0.6078
+
+        # Create the constraint
+        # TODO: remove anchor levels since it's not needed for the
+        # differential constraint
+        self.constraint = DifferentialHydrostaticBalanceConstraint(
+            self.z_constraint_pressure_levels,
+            self.Tv_constraint_pressure_levels,
+            0,
+            len(self.z_pressure_levels),
+            R,
+            self.g0,
+        )
+
+        self.num_z_levels = len(self.z_constraint_pressure_levels)
+        self.num_Tv_levels = len(self.Tv_constraint_pressure_levels)
+        self.z_level_mapping = torch.tensor(list(self.z_pressure_levels.keys()))
+        self.T_level_mapping = torch.tensor(list(self.T_pressure_levels.keys()))
+        self.q_level_mapping = torch.tensor(list(self.q_pressure_levels.keys()))
+
+        # Get topography information
+        ds = xr.open_zarr(f"{src_directory}{dataset_name}.zarr")
+        self.topography = (
+            surface_geopotential_std * ds.constants[1, :, :, :].values
+            + surface_geopotential_mean
+        ) / self.g0
+
+        self.topography = torch.tensor(
+            self.topography[np.newaxis, :, np.newaxis, :, :], dtype=torch.float
+        )
+        logger.info(
+            f"Min/Max topography (m): {self.topography.min()}/{self.topography.max()}"
+        )
+
+    def setup(self, trainer):
+        """
+        pushes weights to cuda device
+        """
+
+        if len(self.z_pressure_levels) - 1 != len(
+            self.loss_weights
+        ):
+            raise ValueError("Length of loss_weights is not one less than number of pressure levels!")
+
+        self.loss_weights = self.loss_weights.to(device=trainer.device)
+
+        # Move means and stds
+        self.z_mean = self.z_mean.to(device=trainer.device)
+        self.z_std = self.z_std.to(device=trainer.device)
+        self.T_mean = self.T_mean.to(device=trainer.device)
+        self.T_std = self.T_std.to(device=trainer.device)
+        self.q_mean = self.q_mean.to(device=trainer.device)
+        self.q_std = self.q_std.to(device=trainer.device)
+
+        # Move alphas
+        self.alpha = self.alpha.to(device=trainer.device)
+
+        # Move indexing arrays for CUDA graphs
+        self.z_level_mapping = self.z_level_mapping.to(device=trainer.device)
+        self.T_level_mapping = self.T_level_mapping.to(device=trainer.device)
+        self.q_level_mapping = self.q_level_mapping.to(device=trainer.device)
+
+        # Move topography
+        self.topography = self.topography.to(device=trainer.device)
+
+    def scale(self, x):
+        """
+        Scale inputs to physical values and compute virtual temperature
+        Tensors are expected to be in the shape [N, B, F, C, H, W]
+        """
+        # N, B, F, C, H, W = x.shape
+        N, F, B, C, H, W = x.shape
+        C_scaled = self.num_z_levels + self.num_Tv_levels
+        x_scaled = torch.zeros(
+            # (N, B, F, C_scaled, H, W), device=x.device, dtype=torch.float
+            (N, F, B, C_scaled, H, W),
+            device=x.device,
+            dtype=torch.float,
+        )
+        # Get scaled geopotential heights
+        x_scaled[:, :, :, : self.num_z_levels, :, :] = (
+            x[:, :, :, self.z_level_mapping, :, :] * self.z_std + self.z_mean
+        ) / self.g0  # divide by g0 for heights
+        # Get scaled temperatures
+        x_scaled[:, :, :, self.num_z_levels :, :, :] = (
+            x[:, :, :, self.T_level_mapping, :, :] * self.T_std + self.T_mean
+        )
+        # Add q correction to get virtual temperature for levels with non-zero q
+        x_scaled[
+            :,
+            :,
+            :,
+            (self.num_z_levels + self.q_index_offset) :,
+            :,
+            :,
+        ] *= 1.0 + self.Mw_ratio * (
+            x[:, :, :, self.q_level_mapping, :, :] * self.q_std + self.q_mean
+        )
+
+        # transpose B dim to before F
+        x_scaled = x_scaled.transpose(1, 2)
+
+        # Combine N and B dimensions and return
+        return x_scaled.reshape((-1, F, C_scaled, H, W))
+
+    def error_histogram(self, prediction, bins, accumulator=None):
+        N, F, B, C, H, W = tuple(prediction.shape)
+
+        if not (prediction.ndim == 6):
+            raise AssertionError("Expected predictions to have 6 dimensions")
+
+        # Scale to physical units and compute virtual temperature
+        x = self.scale(prediction)
+        Tv_avg, Tv_model_avg = self.constraint(x)
+        Tv_error = Tv_avg - Tv_model_avg
+        # Mask out error in regions below the surface
+        if self.topography_masking:
+            Tv_error[x[:, :, 1 : self.num_z_levels, :, :] < self.topography] = 0.0
+
+        vlevels = Tv_error.shape[2]
+        if accumulator is None:
+            if isinstance(bins, int):
+                accumulator = torch.zeros(
+                    (vlevels, bins), dtype=torch.float32, device=prediction.device
+                )
+            else:
+                accumulator = torch.zeros(
+                    (vlevels, bins.shape[1] - 1),
+                    dtype=torch.float32,
+                    device=prediction.device,
+                )
+        if isinstance(bins, int):
+            bin_edges = torch.zeros(
+                (vlevels, bins + 1),
+                dtype=prediction.dtype,
+                device=prediction.device,
+            )
+        else:
+            bin_edges = bins
+
+        for l in range(vlevels):
+            hist, be = torch.histogram(
+                torch.absolute(Tv_error[:, :, l, :, :]),
+                bins=bins if isinstance(bins, int) else bin_edges[l, :],
+            )
+            accumulator[l, :] += hist
+            bin_edges[l, :] = be
+
+        return accumulator, bin_edges
+
+    def forward(self, prediction, target, average_channels=True):
+        """
+        Forward pass of the WeightedMSE pass
+        #Tensors are expected to be in the shape [N, B, F, C, H, W]
+        Tensors are expected to be in the shape [N, F, B, C, H, W]
+
+        Parameters
+        ----------
+        prediction: torch.Tensor
+            The prediction tensor
+        target: torch.Tensor
+            The target tensor
+        average_channels: bool, optional
+            whether the mean of the channels should be taken
+        """
+
+        # Need to scale back to physical units here so disable autocast
+        # and explicitly cast to float32
+        with torch.cuda.amp.autocast(enabled=False):
+            prediction = prediction.float()
+            target = target.float()
+
+            # N, B, F, C, H, W = tuple(prediction.shape)
+            N, F, B, C, H, W = tuple(prediction.shape)
+
+            if not (prediction.ndim == 6 and target.ndim == 6):
+                raise AssertionError("Expected predictions to have 6 dimensions")
+
+            # Scale to physical units and compute virtual temperature
+            x = self.scale(prediction)
+            Tv_avg, Tv_model_avg = self.constraint(x)
+            Tv_error = ((Tv_avg - Tv_model_avg) / self.alpha) ** 2
+
+            # Mask out error in regions below the surface
+            if self.topography_masking:
+                Tv_error[x[:, :, 1 : self.num_z_levels, :, :] < self.topography] = 0.0
+
+            # Compute the error tolerant loss
+            Tv_loss = self.loss_weights * (Tv_error / (1 + torch.exp(1 - Tv_error))).mean(dim=(0, 1, 3, 4))
+
+            # Compute data loss
+            data_loss = self.data_loss(prediction, target, average_channels=average_channels)
+
+            if average_channels:
+                return data_loss + torch.mean(Tv_loss)
+            else:
+                return torch.concatenate((data_loss, Tv_loss))


### PR DESCRIPTION
New loss class that wraps any data loss class (sub-classed from `torch.nn.MSELoss`) and adds hydrostatic constraints

<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->