### PR TITLE
Training and running models with diagnostic variables

### DIFF
--- a/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
@@ -208,9 +208,9 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
             )
 
         # for models with extra outputs
-        if "tp6" in self.ds["targets"].channel_out:
-            input_array = (input_array - self.input_scaling["mean"][:,:-1]) \
-                    / self.input_scaling["std"][:,:-1]
+        if len(self.ds["targets"].channel_out) != (len(self.ds["inputs"].channel_in)-len(self.couplings)):
+            input_array = (input_array - self.input_scaling["mean"][:,:-len(self.couplings)]) \
+                    / self.input_scaling["std"][:,:-len(self.couplings)]
         else:
             input_array = (input_array - self.input_scaling["mean"]) \
                     / self.input_scaling["std"]

--- a/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
@@ -208,9 +208,9 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
             )
 
         # for models with extra outputs
-        if len(self.ds["targets"].channel_out) != (len(self.ds["inputs"].channel_in)-len(self.couplings)):
-            input_array = (input_array - self.input_scaling["mean"][:,:-len(self.couplings)]) \
-                    / self.input_scaling["std"][:,:-len(self.couplings)]
+        if len(self.ds["targets"].channel_out) != (len(self.ds["inputs"].channel_in)-len(self.couplings[0].variables)):
+            input_array = (input_array - self.input_scaling["mean"][:,:-len(self.couplings[0].variables)]) \
+                    / self.input_scaling["std"][:,:-len(self.couplings[0].variables)]
         else:
             input_array = (input_array - self.input_scaling["mean"]) \
                     / self.input_scaling["std"]

--- a/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
@@ -207,9 +207,14 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
                 axis=2,
             )
 
-        input_array = (input_array - self.input_scaling["mean"]) / self.input_scaling[
-            "std"
-        ]
+        # for models with extra outputs
+        if "tp6" in self.ds["targets"].channel_out:
+            input_array = (input_array - self.input_scaling["mean"][:,:-1]) \
+                    / self.input_scaling["std"][:,:-1]
+        else:
+            input_array = (input_array - self.input_scaling["mean"]) \
+                    / self.input_scaling["std"]
+
         if not self.forecast_mode:
             # BAD NEWS: Indexing the array as commented out below causes unexpected behavior in target creation.
             #     leaving this in here as a warning

--- a/physicsnemo/datapipes/healpix/timeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/timeseries_dataset.py
@@ -244,7 +244,7 @@ class TimeSeriesDataset(Dataset, Datapipe):
             # 'if' statement used for cases where atmos model
             # includes diagnostic variables like tp6 and msl.
             # using 'channel_out' is still necessary for ocean models.
-            if len(self.ds.channel_out) != (len(self.ds.channel_in)-len(self.couplings)):
+            if len(self.ds.channel_out) != (len(self.ds.channel_in)-len(self.couplings[0].variables)):
                 self.input_scaling = scaling_da.sel(
                     index=self.ds.channel_in.values
                 ).rename({"index": "channel_in"})

--- a/physicsnemo/datapipes/healpix/timeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/timeseries_dataset.py
@@ -241,10 +241,10 @@ class TimeSeriesDataset(Dataset, Datapipe):
 
         # REMARK: we remove the xarray overhead from these
         try:
-            # we use channel_out instead of channel_in because
-            # the list of input channels may contain data fetched outside
-            # the datasets such as coupled fields
-            if "tp6" in self.ds["targets"].channel_out:
+            # 'if' statement used for cases where atmos model
+            # includes diagnostic variables like tp6 and msl.
+            # using 'channel_out' is still necessary for ocean models.
+            if len(self.ds.channel_out) != (len(self.ds.channel_in)-len(self.couplings)):
                 self.input_scaling = scaling_da.sel(
                     index=self.ds.channel_in.values
                 ).rename({"index": "channel_in"})

--- a/physicsnemo/datapipes/healpix/timeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/timeseries_dataset.py
@@ -244,9 +244,14 @@ class TimeSeriesDataset(Dataset, Datapipe):
             # we use channel_out instead of channel_in because
             # the list of input channels may contain data fetched outside
             # the datasets such as coupled fields
-            self.input_scaling = scaling_da.sel(
-                index=self.ds.channel_out.values
-            ).rename({"index": "channel_in"})
+            if "tp6" in self.ds["targets"].channel_out:
+                self.input_scaling = scaling_da.sel(
+                    index=self.ds.channel_in.values
+                ).rename({"index": "channel_in"})
+            else:
+                self.input_scaling = scaling_da.sel(
+                    index=self.ds.channel_out.values
+                ).rename({"index": "channel_in"})
             self.input_scaling = {
                 "mean": np.expand_dims(
                     self.input_scaling["mean"].to_numpy(), (0, 2, 3, 4)

--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -398,14 +398,14 @@ class HEALPixRecUNet(Module):
                 s = step - self.presteps + prestep
                 if len(self.couplings) > 0:
                     input_tensor = self._reshape_inputs(
-                        inputs=[outputs[s - 1]]
+                        inputs=[outputs[s - 1][:, :, :, :self.input_channels]]
                         + list(inputs[1:3])
                         + [inputs[3][step - (prestep - self.presteps)]],
                         step=s + 1,
                     )
                 else:
                     input_tensor = self._reshape_inputs(
-                        inputs=[outputs[s - 1]] + list(inputs[1:]), step=s + 1
+                        inputs=[outputs[s - 1][:, :, :, :self.input_channels]] + list(inputs[1:]), step=s + 1
                     )
             # Forward the data through the model to initialize hidden states
             self.decoder(self.encoder(input_tensor, conditions_cln=conditions_cln), conditions_cln=conditions_cln)
@@ -479,14 +479,14 @@ class HEALPixRecUNet(Module):
             else:
                 if len(self.couplings) > 0:
                     input_tensor = self._reshape_inputs(
-                        inputs=[outputs[-1]]
+                        inputs=[outputs[-1][:, :, :, :self.input_channels]]
                         + list(inputs[1:3])
                         + [inputs[3][self.presteps + step]],
                         step=step + self.presteps,
                     )
                 else:
                     input_tensor = self._reshape_inputs(
-                        inputs=[outputs[-1]] + list(inputs[1:]),
+                        inputs=[outputs[-1][:, :, :, :self.input_channels]] + list(inputs[1:]),
                         step=step + self.presteps,
                     )
             th.cuda.nvtx.range_pop()
@@ -505,22 +505,21 @@ class HEALPixRecUNet(Module):
             th.cuda.nvtx.range_pop()
 
             # Residual prediction
+            combined = self._reshape_outputs(decodings)
+            prognostics = combined[:, :, :, :self.input_channels]
             if self.residual_prediction:
-                prediction = input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
-            else:
-                prediction = decodings
-            th.cuda.nvtx.range_push("Reshape outputs")
-            reshaped = self._reshape_outputs(
-                prediction
-            )
-            th.cuda.nvtx.range_pop()
+                prognostics += self._reshape_outputs(
+                    input_tensor[:, :self.input_channels * self.input_time_dim]
+                )
+            diagnostics = combined[:, :, :, self.input_channels:]
+            out = th.cat([prognostics, diagnostics], dim=3)
 
             # Apply constraints
             if self.constraints is not None:
                 for constraint in self.constraints:
-                    reshaped = constraint(reshaped)
+                    out = constraint(out)
 
-            outputs.append(reshaped)
+            outputs.append(out)
             th.cuda.nvtx.range_pop()
 
         if output_only_last:

--- a/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_layers.py
@@ -596,6 +596,7 @@ class HEALPixLayer(th.nn.Module):
                 enable_healpixpad
                 and have_healpixpad
                 and th.cuda.is_available()
+                and not enable_nhwc
             ):  # pragma: no cover
                 layers.append(HEALPixPaddingv2(padding=padding))
             else:


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
## Description
This PR adds the functionality to train, fine tune, and run models with diagnostic outputs. Specifically, the changes proposed:
- correctly build scaling arrays for inputs when a diagnostic variable (tp6) is in the outputs
- enforce that only inputs are passed to model in autoregressive rollout (cuts diagnostic outputs from inputs for next step)
- differentiate between prognostic and diagnostic variables so that residual predictions are correctly added to input variables only
- are good for training, coupled fine tuning, and coupled inference