### PR TITLE
Optimized CLN implementation

### DIFF
--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -26,6 +26,15 @@ except ImportError:
     _APEX_AVAILABLE = False
 
 
+@th.compile
+def _cln_affine(x_norm, gamma_raw, beta, scale_center, n_faces):
+    """Fused affine transform: expand gamma/beta across faces and apply to normalized input."""
+    C = gamma_raw.shape[-1]
+    gamma = (scale_center + gamma_raw).unsqueeze(1).expand(-1, n_faces, -1).reshape(-1, 1, 1, C)
+    beta = beta.unsqueeze(1).expand(-1, n_faces, -1).reshape(-1, 1, 1, C)
+    return gamma * x_norm + beta
+
+
 class ConditionalLayerNorm(th.nn.Module):
     def __init__(
         self,
@@ -71,16 +80,18 @@ class ConditionalLayerNorm(th.nn.Module):
         self.channel_depth = channel_depth
         self.hidden_dims = mlp_hidden_dims
         self.activation = activation if activation is not None else th.nn.Identity()
-        self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
-        self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
+        self.gamma_beta_mlp = self._make_mlp(
+            self.condition_shape,
+            [2 * h for h in self.hidden_dims],
+            2 * self.channel_depth,
+            self.activation,
+        )
         self.n_faces = n_faces
         self.scale_center = scale_center
 
         if init_cln_to_zero:
-            self.gamma_mlp[-1].weight.data.zero_()
-            self.beta_mlp[-1].weight.data.zero_()
-            self.gamma_mlp[-1].bias.data.zero_()
-            self.beta_mlp[-1].bias.data.zero_()
+            self.gamma_beta_mlp[-1].weight.data.zero_()
+            self.gamma_beta_mlp[-1].bias.data.zero_()
 
         if norm_op == "torch":
             self.norm = th.nn.LayerNorm(channel_depth, elementwise_affine=False)
@@ -100,6 +111,87 @@ class ConditionalLayerNorm(th.nn.Module):
         layers.append(th.nn.Linear(in_dim, out_dim))
         return th.nn.Sequential(*layers)
 
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+        """Backward compatibility: merge old separate gamma_mlp/beta_mlp into fused gamma_beta_mlp.
+
+        Old MLPs had hidden_dims [h1, h2, ...] and output dim C.
+        New fused MLP has hidden_dims [2*h1, 2*h2, ...] and output dim 2*C.
+
+        For the first Linear (condition_shape → 2*h1), we vertically concatenate:
+            new_weight = cat([gamma_weight, beta_weight], dim=0)
+
+        For subsequent Linear layers (2*h_i → 2*h_{i+1} or 2*h_last → 2*C),
+        we build a block-diagonal weight matrix:
+            new_weight = [[gamma_weight, 0          ],
+                          [0,            beta_weight]]
+
+        Biases are always concatenated: cat([gamma_bias, beta_bias]).
+        """
+        gamma_prefix = prefix + "gamma_mlp."
+        beta_prefix = prefix + "beta_mlp."
+        fused_prefix = prefix + "gamma_beta_mlp."
+
+        has_old_keys = any(k.startswith(gamma_prefix) for k in state_dict)
+
+        if has_old_keys:
+            # Collect all Linear layer indices from the old gamma MLP
+            gamma_layer_indices = set()
+            for k in state_dict:
+                if k.startswith(gamma_prefix):
+                    layer_key = k[len(gamma_prefix):]
+                    parts = layer_key.split(".")
+                    if len(parts) == 2 and parts[1] in ("weight", "bias"):
+                        gamma_layer_indices.add(int(parts[0]))
+            first_layer_idx = min(gamma_layer_indices)
+
+            keys_to_remove = []
+            keys_to_add = {}
+
+            for k in list(state_dict.keys()):
+                if k.startswith(gamma_prefix):
+                    layer_key = k[len(gamma_prefix):]  # e.g. "0.weight"
+                    parts = layer_key.split(".")
+                    if len(parts) != 2 or parts[1] not in ("weight", "bias"):
+                        continue
+                    idx = int(parts[0])
+                    param_type = parts[1]
+                    fused_key = fused_prefix + layer_key
+                    beta_key = beta_prefix + layer_key
+
+                    if beta_key not in state_dict:
+                        continue
+
+                    gamma_val = state_dict[k]
+                    beta_val = state_dict[beta_key]
+
+                    if param_type == "bias":
+                        # Biases are always concatenated
+                        keys_to_add[fused_key] = th.cat([gamma_val, beta_val], dim=0)
+                    elif idx == first_layer_idx:
+                        # First layer: input dim is shared (condition_shape),
+                        # just concatenate along output dim
+                        keys_to_add[fused_key] = th.cat([gamma_val, beta_val], dim=0)
+                    else:
+                        # Hidden→hidden or hidden→output: block-diagonal
+                        # gamma_val: (out_old, in_old), beta_val: (out_old, in_old)
+                        # result: (2*out_old, 2*in_old)
+                        out_old, in_old = gamma_val.shape
+                        zeros = th.zeros(out_old, in_old, dtype=gamma_val.dtype, device=gamma_val.device)
+                        keys_to_add[fused_key] = th.cat([
+                            th.cat([gamma_val, zeros], dim=1),
+                            th.cat([zeros, beta_val], dim=1),
+                        ], dim=0)
+
+                    keys_to_remove.append(k)
+                    if beta_key not in keys_to_remove:
+                        keys_to_remove.append(beta_key)
+
+            for k in keys_to_remove:
+                if k in state_dict:
+                    del state_dict[k]
+            state_dict.update(keys_to_add)
+
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
 
     def forward(self, x: th.Tensor, conditions: th.Tensor) -> th.Tensor:
         """
@@ -116,18 +208,23 @@ class ConditionalLayerNorm(th.nn.Module):
             Normalized and conditioned tensor of shape: (B, C, H, W)
         """
 
-        # normal layer norm without default scale, bias applied (permute to channels_last)
-        x = x.permute(0, 2, 3, 1)
-        x_norm = self.norm(x)
-    
-        # Compute gamma and beta from conditions
-        gamma = self.scale_center + self.gamma_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
-        beta = self.beta_mlp(conditions)[:, None, None, :] # (B*n_cond, 1, 1, C)
+        is_channels_last = x.is_contiguous(memory_format=th.channels_last)
 
-        # Repeat for the number of faces(which has been folded into the batch dimension)
-        gamma = gamma.repeat_interleave(self.n_faces, dim=0)
-        beta = beta.repeat_interleave(self.n_faces, dim=0)
+        # LayerNorm on last dim: permute to (B, H, W, C)
+        x_nhwc = x.permute(0, 2, 3, 1)
+        if not is_channels_last:
+            x_nhwc = x_nhwc.contiguous()
+        x_norm = self.norm(x_nhwc)
 
-        # Apply and reshape to channels first
-        x = gamma * x_norm + beta
-        return x.permute(0, 3, 1, 2)
+        # Fused gamma/beta MLP: single forward pass, then split
+        gamma_beta = self.gamma_beta_mlp(conditions)  # (B*n_cond, 2*C)
+        gamma_raw, beta = gamma_beta.chunk(2, dim=-1)  # each (B*n_cond, C)
+
+        # Fused affine: expand across faces + scale_center + multiply + add
+        result = _cln_affine(x_norm, gamma_raw, beta, self.scale_center, self.n_faces)
+
+        # Return to NCHW logical layout, preserving channels_last memory format if input was
+        if is_channels_last:
+            return result.permute(0, 3, 1, 2).contiguous(memory_format=th.channels_last)
+        else:
+            return result.permute(0, 3, 1, 2)

--- a/test/models/dlwp_healpix/_cln_reference.py
+++ b/test/models/dlwp_healpix/_cln_reference.py
@@ -1,0 +1,73 @@
+# Reference (old) implementation of ConditionalLayerNorm for testing.
+# This is a copy of the original code before optimization.
+
+from typing import List
+
+import torch as th
+
+try:
+    from apex.normalization import FusedLayerNorm
+    _APEX_AVAILABLE = True
+except ImportError:
+    _APEX_AVAILABLE = False
+
+
+class ConditionalLayerNormReference(th.nn.Module):
+    def __init__(
+        self,
+        condition_shape: int,
+        channel_depth: int,
+        mlp_hidden_dims: List[int] = [128, 128],
+        activation: th.nn.Module = None,
+        eps: float = 1e-5,
+        n_faces: int = 12,
+        norm_op: str = "torch",
+        init_cln_to_zero: bool = False,
+        scale_center: float = 0.0,
+    ):
+        super().__init__()
+        self.eps = eps
+        self.condition_shape = condition_shape
+        self.channel_depth = channel_depth
+        self.hidden_dims = mlp_hidden_dims
+        self.activation = activation if activation is not None else th.nn.Identity()
+        self.gamma_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
+        self.beta_mlp = self._make_mlp(self.condition_shape, self.hidden_dims, self.channel_depth, self.activation)
+        self.n_faces = n_faces
+        self.scale_center = scale_center
+
+        if init_cln_to_zero:
+            self.gamma_mlp[-1].weight.data.zero_()
+            self.beta_mlp[-1].weight.data.zero_()
+            self.gamma_mlp[-1].bias.data.zero_()
+            self.beta_mlp[-1].bias.data.zero_()
+
+        if norm_op == "torch":
+            self.norm = th.nn.LayerNorm(channel_depth, elementwise_affine=False)
+        elif norm_op == "apex":
+            if not _APEX_AVAILABLE:
+                raise ImportError("Apex FusedLayerNorm requested but apex is not available")
+            self.norm = FusedLayerNorm(channel_depth, elementwise_affine=False)
+
+    def _make_mlp(self, in_dim: int, hidden_dims: List[int], out_dim: int, activation: th.nn.Module) -> th.nn.Sequential:
+        layers = []
+        for hdim in hidden_dims:
+            layers.append(th.nn.Linear(in_dim, hdim))
+            if activation:
+                layers.append(activation)
+            in_dim = hdim
+        layers.append(th.nn.Linear(in_dim, out_dim))
+        return th.nn.Sequential(*layers)
+
+    def forward(self, x: th.Tensor, conditions: th.Tensor) -> th.Tensor:
+        x = x.permute(0, 2, 3, 1)
+        x_norm = self.norm(x)
+
+        gamma = self.scale_center + self.gamma_mlp(conditions)[:, None, None, :]
+        beta = self.beta_mlp(conditions)[:, None, None, :]
+
+        gamma = gamma.repeat_interleave(self.n_faces, dim=0)
+        beta = beta.repeat_interleave(self.n_faces, dim=0)
+
+        x = gamma * x_norm + beta
+        return x.permute(0, 3, 1, 2)

--- a/test/models/dlwp_healpix/test_conditional_layer_norm.py
+++ b/test/models/dlwp_healpix/test_conditional_layer_norm.py
@@ -1,0 +1,265 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pytest
+import torch
+from _cln_reference import ConditionalLayerNormReference
+from physicsnemo.models.dlwp_healpix_layers.normalization import ConditionalLayerNorm
+
+
+def _make_old_cln(condition_shape, channel_depth, **kwargs):
+    """Instantiate the reference (old) implementation."""
+    return ConditionalLayerNormReference(
+        condition_shape=condition_shape, channel_depth=channel_depth, **kwargs
+    ).cuda()
+
+
+def _make_new_cln(condition_shape, channel_depth, **kwargs):
+    """Instantiate the optimized (new) implementation."""
+    return ConditionalLayerNorm(
+        condition_shape=condition_shape, channel_depth=channel_depth, **kwargs
+    ).cuda()
+
+
+def _copy_old_to_new(old_cln, new_cln):
+    """Copy old separate gamma/beta MLP weights into new fused MLP using block-diagonal structure.
+
+    Old: gamma_mlp and beta_mlp each have hidden_dims [h1, h2] and output C.
+    New: gamma_beta_mlp has hidden_dims [2*h1, 2*h2] and output 2*C.
+
+    Layer 0 (condition_shape → 2*h1): vertical cat of gamma/beta weights.
+    Layer i>0 (2*h_{i-1} → 2*h_i or 2*C): block-diagonal [[gamma, 0], [0, beta]].
+    Biases: always concatenated.
+    """
+    old_sd = old_cln.state_dict()
+
+    # Collect Linear layer indices from the old gamma MLP
+    gamma_linear_indices = sorted({
+        int(k.split(".")[1])
+        for k in old_sd if k.startswith("gamma_mlp.") and k.endswith(".weight")
+    })
+    first_layer_idx = gamma_linear_indices[0]
+
+    new_sd = {}
+    for key in old_sd:
+        if key.startswith("norm."):
+            new_sd[key] = old_sd[key]
+
+    for idx in gamma_linear_indices:
+        for param in ("weight", "bias"):
+            gamma_val = old_sd[f"gamma_mlp.{idx}.{param}"]
+            beta_val = old_sd[f"beta_mlp.{idx}.{param}"]
+            fused_key = f"gamma_beta_mlp.{idx}.{param}"
+
+            if param == "bias":
+                new_sd[fused_key] = torch.cat([gamma_val, beta_val], dim=0)
+            elif idx == first_layer_idx:
+                # First layer: shared input dim, just cat along output dim
+                new_sd[fused_key] = torch.cat([gamma_val, beta_val], dim=0)
+            else:
+                # Block-diagonal: [[gamma, 0], [0, beta]]
+                out_old, in_old = gamma_val.shape
+                zeros = torch.zeros_like(gamma_val)
+                new_sd[fused_key] = torch.cat([
+                    torch.cat([gamma_val, zeros], dim=1),
+                    torch.cat([zeros, beta_val], dim=1),
+                ], dim=0)
+
+    new_cln.load_state_dict(new_sd)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("n_cond", [1, 2, 4])
+@pytest.mark.parametrize("channels_last", [False, True])
+@pytest.mark.parametrize("scale_center", [0.0, 1.0])
+def test_old_vs_new_forward(n_cond, channels_last, scale_center):
+    """Verify optimized CLN matches reference implementation with block-diagonal weight mapping."""
+    C, H, W = 128, 16, 16
+    cond_shape = 32
+    B_nf = n_cond * 12
+
+    torch.manual_seed(42)
+    old_cln = _make_old_cln(cond_shape, C, scale_center=scale_center)
+
+    new_cln = _make_new_cln(cond_shape, C, scale_center=scale_center)
+    _copy_old_to_new(old_cln, new_cln)
+
+    x = torch.randn(B_nf, C, H, W, device="cuda")
+    cond = torch.randn(n_cond, cond_shape, device="cuda")
+
+    if channels_last:
+        x = x.to(memory_format=torch.channels_last)
+
+    with torch.no_grad():
+        out_old = old_cln(x, cond)
+        out_new = new_cln(x, cond)
+
+    assert out_old.shape == out_new.shape
+    assert torch.allclose(out_old, out_new, atol=1e-5, rtol=1e-4), \
+        f"Max diff: {(out_old - out_new).abs().max().item()}"
+
+    if channels_last:
+        assert out_new.is_contiguous(memory_format=torch.channels_last), \
+            "Output should preserve channels_last format"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channels_last", [False, True])
+def test_old_vs_new_backward(channels_last):
+    """Verify gradients match between old and new implementations."""
+    C, H, W = 64, 8, 8
+    cond_shape = 16
+    n_cond = 2
+    B_nf = n_cond * 12
+
+    torch.manual_seed(42)
+    old_cln = _make_old_cln(cond_shape, C)
+    new_cln = _make_new_cln(cond_shape, C)
+    _copy_old_to_new(old_cln, new_cln)
+
+    x_base = torch.randn(B_nf, C, H, W, device="cuda")
+    cond_base = torch.randn(n_cond, cond_shape, device="cuda")
+
+    if channels_last:
+        x_base = x_base.to(memory_format=torch.channels_last)
+
+    x_old = x_base.clone().detach().requires_grad_(True)
+    cond_old = cond_base.clone().detach().requires_grad_(True)
+    x_new = x_base.clone().detach().requires_grad_(True)
+    cond_new = cond_base.clone().detach().requires_grad_(True)
+
+    out_old = old_cln(x_old, cond_old)
+    out_old.sum().backward()
+
+    out_new = new_cln(x_new, cond_new)
+    out_new.sum().backward()
+
+    assert torch.allclose(x_old.grad, x_new.grad, atol=1e-4, rtol=1e-3), \
+        f"Input grad max diff: {(x_old.grad - x_new.grad).abs().max().item()}"
+
+    assert torch.allclose(cond_old.grad, cond_new.grad, atol=1e-4, rtol=1e-3), \
+        f"Cond grad max diff: {(cond_old.grad - cond_new.grad).abs().max().item()}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channels_last", [False, True])
+def test_init_cln_to_zero_matches_layer_norm(channels_last):
+    """With scale_center=1.0 and init_cln_to_zero=True, CLN should behave like plain LayerNorm."""
+    C, H, W = 64, 8, 8
+    n_cond = 2
+    B_nf = n_cond * 12
+
+    torch.manual_seed(42)
+    cln = _make_new_cln(32, C, scale_center=1.0, init_cln_to_zero=True)
+    plain_ln = torch.nn.LayerNorm(C, elementwise_affine=False).cuda()
+
+    x = torch.randn(B_nf, C, H, W, device="cuda")
+    cond = torch.randn(n_cond, 32, device="cuda")
+
+    if channels_last:
+        x = x.to(memory_format=torch.channels_last)
+
+    with torch.no_grad():
+        out_cln = cln(x, cond)
+        x_nhwc = x.permute(0, 2, 3, 1)
+        out_ln = plain_ln(x_nhwc).permute(0, 3, 1, 2)
+
+    assert torch.allclose(out_cln, out_ln, atol=1e-5, rtol=1e-4), \
+        f"Max diff: {(out_cln - out_ln).abs().max().item()}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("channels_last", [False, True])
+def test_backward_gradients(channels_last):
+    """Verify gradients flow through CLN and are finite."""
+    C, H, W = 64, 8, 8
+    cond_shape = 16
+    n_cond = 2
+    B_nf = n_cond * 12
+
+    torch.manual_seed(42)
+    cln = _make_new_cln(cond_shape, C)
+
+    x = torch.randn(B_nf, C, H, W, device="cuda")
+    cond = torch.randn(n_cond, cond_shape, device="cuda")
+
+    if channels_last:
+        x = x.to(memory_format=torch.channels_last)
+
+    x = x.requires_grad_(True)
+    cond = cond.requires_grad_(True)
+
+    out = cln(x, cond)
+    out.sum().backward()
+
+    assert x.grad is not None, "No gradient for input x"
+    assert cond.grad is not None, "No gradient for conditions"
+    assert torch.isfinite(x.grad).all(), "Non-finite input gradients"
+    assert torch.isfinite(cond.grad).all(), "Non-finite condition gradients"
+
+    for name, p in cln.named_parameters():
+        assert p.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(p.grad).all(), f"Non-finite gradient for {name}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_backward_channels_last_matches_contiguous():
+    """Verify channels_last and contiguous inputs produce the same gradients."""
+    C, H, W = 64, 8, 8
+    cond_shape = 16
+    n_cond = 2
+    B_nf = n_cond * 12
+
+    torch.manual_seed(42)
+    cln = _make_new_cln(cond_shape, C)
+
+    x_base = torch.randn(B_nf, C, H, W, device="cuda")
+    cond_base = torch.randn(n_cond, cond_shape, device="cuda")
+
+    # Contiguous path
+    x_cont = x_base.clone().detach().requires_grad_(True)
+    cond_cont = cond_base.clone().detach().requires_grad_(True)
+    out_cont = cln(x_cont, cond_cont)
+    out_cont.sum().backward()
+
+    cln.zero_grad()
+
+    # Channels-last path
+    x_cl = x_base.clone().detach().to(memory_format=torch.channels_last).requires_grad_(True)
+    cond_cl = cond_base.clone().detach().requires_grad_(True)
+    out_cl = cln(x_cl, cond_cl)
+    out_cl.sum().backward()
+
+    assert torch.allclose(out_cont, out_cl, atol=1e-5, rtol=1e-4), \
+        f"Output max diff: {(out_cont - out_cl).abs().max().item()}"
+    assert torch.allclose(x_cont.grad, x_cl.grad, atol=1e-5, rtol=1e-4), \
+        f"Input grad max diff: {(x_cont.grad - x_cl.grad).abs().max().item()}"
+    assert torch.allclose(cond_cont.grad, cond_cl.grad, atol=1e-5, rtol=1e-4), \
+        f"Cond grad max diff: {(cond_cont.grad - cond_cl.grad).abs().max().item()}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_load_old_checkpoint():
+    """Verify new CLN can load old-format state dict via _load_from_state_dict."""
+    C, cond_shape = 64, 16
+    torch.manual_seed(42)
+    old_cln = _make_old_cln(cond_shape, C)
+    old_sd = old_cln.state_dict()
+
+    new_cln = _make_new_cln(cond_shape, C)
+    new_cln.load_state_dict(old_sd, strict=False)
+
+    # Verify outputs match after loading old checkpoint
+    x = torch.randn(12, C, 8, 8, device="cuda")
+    cond = torch.randn(1, cond_shape, device="cuda")
+
+    with torch.no_grad():
+        out_old = old_cln(x, cond)
+        out_new = new_cln(x, cond)
+
+    assert out_new.shape == (12, C, 8, 8)
+    assert torch.isfinite(out_new).all()
+    assert torch.allclose(out_old, out_new, atol=1e-5, rtol=1e-4), \
+        f"Max diff after loading old checkpoint: {(out_old - out_new).abs().max().item()}"


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

### Summary

- **Fused gamma/beta MLP**: Replace two separate MLPs (`gamma_mlp`, `beta_mlp`) with a single `gamma_beta_mlp` that outputs `2*C` and splits via `chunk(2)`. Hidden dims are doubled (`[2*h for h in hidden_dims]`) to preserve independent gamma/beta capacity — with block-diagonal weight structure, the top half computes gamma features and the bottom half computes beta features with zero cross-talk. This halves the number of linear-layer kernel launches from 6 to 3.
- **Channels-last awareness**: Detect `channels_last` memory format and skip the expensive `.contiguous()` call after `permute()`. When input is already NHWC in memory, the permute is a free stride rearrangement. Output preserves `channels_last` format so downstream convolutions stay on the fast NHWC cuDNN path.
- **Zero-copy face expansion**: Replace `repeat_interleave(n_faces)` (allocates a new tensor) with `unsqueeze + expand + reshape` (zero-copy stride trick).
- **`torch.compile` fused affine**: The `_cln_affine` function wraps `scale_center + gamma_raw`, expand across faces, and `gamma * x_norm + beta` under `@torch.compile`, letting Inductor fuse them into minimal CUDA kernels.
- **Backward-compatible checkpoint loading**: `_load_from_state_dict` override detects old `gamma_mlp`/`beta_mlp` keys and converts them to the fused `gamma_beta_mlp` format using block-diagonal weight matrices for hidden layers and concatenation for the first layer and biases.

### Backward Compatibility

No changes to the `__init__` signature — all existing configs work unchanged. Old checkpoints with separate `gamma_mlp`/`beta_mlp` keys are automatically converted on load via block-diagonal weight merging, producing numerically identical outputs to the old implementation. Both `norm_op="torch"` and `norm_op="apex"` (FusedLayerNorm) are supported.

### Testing

- `pytest test/models/dlwp_healpix/test_conditional_layer_norm.py -v`
  - `test_old_vs_new_forward` — verifies numerical equivalence (atol=1e-5) across n_cond∈{1,2,4}, channels_last∈{False,True}, and scale_center∈{0.0,1.0} using block-diagonal weight mapping from old→new
  - `test_old_vs_new_backward` — verifies input and condition gradient equivalence between old and new
  - `test_init_cln_to_zero_matches_layer_norm` — verifies CLN with `scale_center=1.0, init_cln_to_zero=True` matches plain LayerNorm
  - `test_backward_gradients` — verifies all parameter/input/condition gradients are finite
  - `test_backward_channels_last_matches_contiguous` — verifies channels_last and contiguous paths produce identical outputs and gradients
  - `test_load_old_checkpoint` — verifies old-format state dict loads via `_load_from_state_dict` and produces matching outputs

### Benchmark results

```
================================================================================
  Memory format: contiguous, norm_op: torch
  Warmup: 20, Iters: 100
================================================================================

  small  (C=64,  H=W=16, cond=32, hidden=[64,64])
    Forward:          old=0.150ms  new=0.104ms  speedup=1.44x
    Forward memory:   old=18.0MB  new=18.0MB  saved=0.0MB
    Forward+Backward: old=0.718ms  new=0.574ms  speedup=1.25x
    Fwd+Bwd memory:   old=18.3MB  new=18.3MB  saved=-0.1MB

  medium (C=128, H=W=32, cond=32, hidden=[64,64])
    Forward:          old=0.379ms  new=0.298ms  speedup=1.27x
    Forward memory:   old=144.1MB  new=144.0MB  saved=0.1MB
    Forward+Backward: old=0.935ms  new=0.692ms  speedup=1.35x
    Fwd+Bwd memory:   old=240.9MB  new=145.0MB  saved=95.9MB

  large  (C=256, H=W=64, cond=32, hidden=[128,128])
    Forward:          old=2.187ms  new=1.751ms  speedup=1.25x
    Forward memory:   old=1152.2MB  new=1152.0MB  saved=0.2MB
    Forward+Backward: old=5.279ms  new=4.024ms  speedup=1.31x
    Fwd+Bwd memory:   old=1287.3MB  new=1155.8MB  saved=131.5MB

================================================================================
  Memory format: channels_last, norm_op: torch
  Warmup: 20, Iters: 100
================================================================================

  small  (C=64,  H=W=16, cond=32, hidden=[64,64])
    Forward:          old=0.142ms  new=0.134ms  speedup=1.06x
    Forward memory:   old=18.0MB  new=12.0MB  saved=6.0MB
    Forward+Backward: old=0.703ms  new=0.619ms  speedup=1.14x
    Fwd+Bwd memory:   old=18.3MB  new=12.3MB  saved=5.9MB

  medium (C=128, H=W=32, cond=32, hidden=[64,64])
    Forward:          old=0.284ms  new=0.203ms  speedup=1.40x
    Forward memory:   old=144.1MB  new=96.0MB  saved=48.1MB
    Forward+Backward: old=0.692ms  new=0.621ms  speedup=1.11x
    Fwd+Bwd memory:   old=240.9MB  new=97.0MB  saved=143.9MB

  large  (C=256, H=W=64, cond=32, hidden=[128,128])
    Forward:          old=1.395ms  new=0.958ms  speedup=1.46x
    Forward memory:   old=1152.2MB  new=768.0MB  saved=384.2MB
    Forward+Backward: old=3.235ms  new=2.775ms  speedup=1.17x
    Fwd+Bwd memory:   old=1287.3MB  new=771.8MB  saved=515.5MB

================================================================================
  Memory format: contiguous, norm_op: apex
  Warmup: 20, Iters: 100
================================================================================

  small  (C=64,  H=W=16, cond=32, hidden=[64,64])
    Forward:          old=0.168ms  new=0.168ms  speedup=1.00x
    Forward memory:   old=18.0MB  new=18.0MB  saved=0.0MB
    Forward+Backward: old=0.888ms  new=0.815ms  speedup=1.09x
    Fwd+Bwd memory:   old=24.3MB  new=18.5MB  saved=5.7MB

  medium (C=128, H=W=32, cond=32, hidden=[64,64])
    Forward:          old=0.368ms  new=0.287ms  speedup=1.28x
    Forward memory:   old=144.1MB  new=144.0MB  saved=0.1MB
    Forward+Backward: old=1.004ms  new=0.817ms  speedup=1.23x
    Fwd+Bwd memory:   old=288.9MB  new=145.7MB  saved=143.2MB

  large  (C=256, H=W=64, cond=32, hidden=[128,128])
    Forward:          old=2.092ms  new=1.655ms  speedup=1.26x
    Forward memory:   old=1152.2MB  new=1152.0MB  saved=0.2MB
    Forward+Backward: old=5.405ms  new=4.153ms  speedup=1.30x
    Fwd+Bwd memory:   old=1671.3MB  new=1158.8MB  saved=512.5MB

================================================================================
  Memory format: channels_last, norm_op: apex
  Warmup: 20, Iters: 100
================================================================================

  small  (C=64,  H=W=16, cond=32, hidden=[64,64])
    Forward:          old=0.162ms  new=0.158ms  speedup=1.03x
    Forward memory:   old=18.0MB  new=12.0MB  saved=6.0MB
    Forward+Backward: old=0.875ms  new=0.800ms  speedup=1.09x
    Fwd+Bwd memory:   old=18.3MB  new=12.5MB  saved=5.7MB

  medium (C=128, H=W=32, cond=32, hidden=[64,64])
    Forward:          old=0.272ms  new=0.192ms  speedup=1.42x
    Forward memory:   old=144.1MB  new=96.0MB  saved=48.1MB
    Forward+Backward: old=0.879ms  new=0.800ms  speedup=1.10x
    Fwd+Bwd memory:   old=240.9MB  new=97.7MB  saved=143.2MB

  large  (C=256, H=W=64, cond=32, hidden=[128,128])
    Forward:          old=1.301ms  new=0.865ms  speedup=1.50x
    Forward memory:   old=1152.2MB  new=768.0MB  saved=384.2MB
    Forward+Backward: old=3.366ms  new=2.905ms  speedup=1.16x
    Fwd+Bwd memory:   old=1287.3MB  new=774.8MB  saved=512.5MB
```

#### Kernel Fusion

```
================================================================================
  Kernel fusion analysis: _cln_affine
  (n_cond=8, n_faces=12, C=128, H=32, W=32)
================================================================================

  Eager (uncompiled):
    Total CUDA kernels: 4
      void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctorOnSelf_add<float>, std::array<char*, 2ul> >(int, at::native::CUDAFunctorOnSelf_add<float>, std::array<char*, 2ul>)  count=1  gpu_time=1.7us
      void at::native::elementwise_kernel<128, 2, at::native::gpu_kernel_impl_nocast<at::native::direct_copy_kernel_cuda(at::TensorIteratorBase&)::{lambda()#3}::operator()() const::{lambda()#7}::operator()() const::{lambda(float)#1}>(at::TensorIteratorBase&, at::native::direct_copy_kernel_cuda(at::TensorIteratorBase&)::{lambda()#3}::operator()() const::{lambda()#7}::operator()() const::{lambda(float)#1} const&)::{lambda(int)#1}>(int, at::native::gpu_kernel_impl_nocast<at::native::direct_copy_kernel_cuda(at::TensorIteratorBase&)::{lambda()#3}::operator()() const::{lambda()#7}::operator()() const::{lambda(float)#1}>(at::TensorIteratorBase&, at::native::direct_copy_kernel_cuda(at::TensorIteratorBase&)::{lambda()#3}::operator()() const::{lambda()#7}::operator()() const::{lambda(float)#1} const&)::{lambda(int)#1})  count=2  gpu_time=2.4us
      void at::native::elementwise_kernel<128, 2, at::native::gpu_kernel_impl_nocast<at::native::BinaryFunctor<float, float, float, at::native::binary_internal::MulFunctor<float> > >(at::TensorIteratorBase&, at::native::BinaryFunctor<float, float, float, at::native::binary_internal::MulFunctor<float> > const&)::{lambda(int)#1}>(int, at::native::gpu_kernel_impl_nocast<at::native::BinaryFunctor<float, float, float, at::native::binary_internal::MulFunctor<float> > >(at::TensorIteratorBase&, at::native::BinaryFunctor<float, float, float, at::native::binary_internal::MulFunctor<float> > const&)::{lambda(int)#1})  count=1  gpu_time=46.1us
      void at::native::elementwise_kernel<128, 2, at::native::gpu_kernel_impl_nocast<at::native::CUDAFunctor_add<float> >(at::TensorIteratorBase&, at::native::CUDAFunctor_add<float> const&)::{lambda(int)#1}>(int, at::native::gpu_kernel_impl_nocast<at::native::CUDAFunctor_add<float> >(at::TensorIteratorBase&, at::native::CUDAFunctor_add<float> const&)::{lambda(int)#1})  count=1  gpu_time=46.5us

  Compiled (torch.compile):
    Total CUDA kernels: 1
      triton_poi_fused_add_mul_0                                    count=1  gpu_time=36.2us

  Kernel reduction: 4 -> 1
```



## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->
No new deps