### PR TITLE
Distributed probabilistic loss

### DIFF
--- a/physicsnemo/distributed/autograd.py
+++ b/physicsnemo/distributed/autograd.py
@@ -333,6 +333,75 @@ def gather_v(
     return GatherVAutograd.apply(tensor, sizes, dim, dst, group)
 
 
+class RingExchangeAutograd(torch.autograd.Function):
+    """
+    Ring exchange autograd primitive.
+
+    Forward maps output_r <- input_{r-1}. Backward performs reverse exchange.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        tensor: torch.Tensor,
+        group: Optional[dist.ProcessGroup] = None,
+    ) -> torch.Tensor:  # pragma: no cover
+        if group is None or not dist.is_initialized():
+            return tensor
+        ws = dist.get_world_size(group=group)
+        if ws == 1:
+            return tensor
+        rank = dist.get_rank(group=group)
+        send_peer = (rank + 1) % ws
+        recv_peer = (rank - 1 + ws) % ws
+        send_to = dist.get_global_rank(group, send_peer)
+        recv_from = dist.get_global_rank(group, recv_peer)
+        tensor = tensor.contiguous()
+        recv = torch.empty_like(tensor)
+        ops = [
+            dist.P2POp(dist.isend, tensor, send_to, group),
+            dist.P2POp(dist.irecv, recv, recv_from, group),
+        ]
+        reqs = dist.batch_isend_irecv(ops)
+        for req in reqs:
+            req.wait()
+        ctx.group = group
+        return recv
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # pragma: no cover
+        group = ctx.group
+        if group is None or not dist.is_initialized():
+            return grad_output, None
+        ws = dist.get_world_size(group=group)
+        if ws == 1:
+            return grad_output, None
+        rank = dist.get_rank(group=group)
+        # Reverse communication for gradient of ring shift.
+        send_peer = (rank - 1 + ws) % ws
+        recv_peer = (rank + 1) % ws
+        send_to = dist.get_global_rank(group, send_peer)
+        recv_from = dist.get_global_rank(group, recv_peer)
+        grad_output = grad_output.contiguous()
+        grad_input = torch.empty_like(grad_output)
+        ops = [
+            dist.P2POp(dist.isend, grad_output, send_to, group),
+            dist.P2POp(dist.irecv, grad_input, recv_from, group),
+        ]
+        reqs = dist.batch_isend_irecv(ops)
+        for req in reqs:
+            req.wait()
+        return grad_input, None
+
+
+def ring_exchange(
+    tensor: torch.Tensor,
+    group: Optional[dist.ProcessGroup] = None,
+) -> torch.Tensor:  # pragma: no cover
+    """Autograd-safe one-step ring exchange."""
+    return RingExchangeAutograd.apply(tensor, group)
+
+
 def scatter_v(
     tensor: torch.Tensor,
     sizes: List[int],

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -538,7 +538,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
         diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
         crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
-        crps *= lsm_tensor
+        crps = crps * lsm_tensor
         return crps
 
     def _pool(self, tensor, scale):
@@ -621,8 +621,10 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         target = target.to(th.float32)
         
         # Apply channel weights across channel dims
-        prediction *= self.loss_weights[None, None, None, None, :, None, None]
-        target *= self.loss_weights[None, None, None, :, None, None]
+        lw_p = self.loss_weights[None, None, None, None, :, None, None]
+        lw_t = self.loss_weights[None, None, None, :, None, None]
+        prediction = prediction * lw_p
+        target = target * lw_t
 
         if distributed_loss:
             if self.masked_processing and self.lsm_tensor.numel() > 1:
@@ -1007,8 +1009,10 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         target = target.to(th.float32)
 
         # Apply channel weights across channel dims
-        prediction *= self.loss_weights[None, None, None, None, :, None, None]
-        target *= self.loss_weights[None, None, None, :, None, None]
+        lw_p = self.loss_weights[None, None, None, None, :, None, None]
+        lw_t = self.loss_weights[None, None, None, :, None, None]
+        prediction = prediction * lw_p
+        target = target * lw_t
 
         if distributed_loss:
             if self.multiscale > 0:
@@ -1044,7 +1048,15 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
                         spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
                         spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                        spec_loss = self.averaging_coeff * (skill_mul * skill_spec - self.coeff_eps * spread_spec) / (b * t * self.lmax * self.mmax)
+                        # Required to match non-distributed n==2 special case
+                        spec_denom = (
+                            b * t * c
+                            if self.n_members == 2
+                            else b * t * self.lmax * self.mmax
+                        )
+                        spec_loss = self.averaging_coeff * (
+                            skill_mul * skill_spec - self.coeff_eps * spread_spec
+                        ) / spec_denom
                     loss = loss + self.lambda_spec * spec_loss
                 return loss
 
@@ -1079,9 +1091,15 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                     skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
                     spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
                     spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
+                    # Required to match non-distributed n==2 special case
+                    spec_denom = (
+                        b * t
+                        if self.n_members == 2
+                        else b * t * self.lmax * self.mmax
+                    )
                     loss = loss + self.lambda_spec * self.averaging_coeff * (
                         skill_mul * skill_spec - self.coeff_eps * spread_spec
-                    ) / (b * t * self.lmax * self.mmax)
+                    ) / spec_denom
             return loss
 
         if n == 2:
@@ -1097,7 +1115,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
             if self.lambda_spec > 0:
 
-                with th.cuda.amp.autocast(enabled=False):
+                with th.amp.autocast("cuda", enabled=False):
                     # # Reorder predictions: [N, B, F, T, C, H, W] -> [N, B, T, C, F*H*W]
                     # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 3, 4, 2, 5, 6).reshape(n, b, t, c, f*h*w))
 
@@ -1128,7 +1146,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             if self.multiscale > 0:
                 for scale in self.scales:
                     l_filter = self._l_filter(scale, device=prediction.device)
-                    with th.cuda.amp.autocast(enabled=False):
+                    with th.amp.autocast("cuda", enabled=False):
                         sht_pred= self._apply_sht(prediction, face_dim=2, return_abs=False)
                         sht_tar = self._apply_sht(target, face_dim=1, return_abs=False)
 
@@ -1142,7 +1160,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
                         crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
-                        crps *= self.lsm_tensor
+                        crps = crps * self.lsm_tensor
 
                         if average_channels:
                             loss += self.multiscale * crps.mean()
@@ -1172,7 +1190,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
 
                 if self.lambda_spec > 0:
-                    with th.cuda.amp.autocast(enabled=False):
+                    with th.amp.autocast("cuda", enabled=False):
                         # # Reorder predictions: [C, Cond, B, F, T, H, W] -> [C, Cond, B, T, F*H*W]
                         # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 2, 4, 3, 5, 6).reshape(c, n, b, t, f*h*w))
 
@@ -1204,7 +1222,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
 
                 if self.lambda_spec > 0:
-                    with th.cuda.amp.autocast(enabled=False):
+                    with th.amp.autocast("cuda", enabled=False):
                         # # Reorder predictions: [Cond, B, F, T, C, H, W] -> [Cond, B, T, C, F*H*W]
                         # pred_ring = self.reorder_to_ring(prediction.permute(0, 1, 3, 4, 2, 5, 6).reshape(n, b, t, c, f*h*w))
 
@@ -1295,8 +1313,10 @@ class SpreadSkillRatioLoss(th.nn.MSELoss):
         target = target.to(th.float32)
 
         # Apply channel weights before computing spread and skill.
-        prediction *= self.loss_weights[None, None, None, None, :, None, None]
-        target *= self.loss_weights[None, None, None, :, None, None]
+        lw_p = self.loss_weights[None, None, None, None, :, None, None]
+        lw_t = self.loss_weights[None, None, None, :, None, None]
+        prediction = prediction * lw_p
+        target = target * lw_t
 
         spread_field = prediction.std(dim=0)
         spread = spread_field.mean(dim=(0, 1, 2, 4, 5))
@@ -1622,10 +1642,10 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 dim=(0, 1)
             )  # [B,F,T,C,H,W]
 
-        es *= self.lsm_tensor
+        es = es * self.lsm_tensor
 
         # Apply channel weights (per-variable scaling)
-        es *= self.loss_weights[None, None, None, :, None, None]
+        es = es * self.loss_weights[None, None, None, :, None, None]
 
         if average_channels:
             loss = es.mean()

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -18,6 +18,7 @@ from typing import Sequence
 
 import numpy as np
 import torch as th
+import torch.distributed as dist
 import xarray as xr
 
 import earth2grid
@@ -38,6 +39,44 @@ average output channels. This is used in the varible wise logging of validation 
 """
 
 
+def _distributed_reduce_loss(loss, ensemble_group=None, enabled=False):
+    if not enabled or ensemble_group is None or not dist.is_initialized():
+        return loss
+    dist.all_reduce(loss, group=ensemble_group)
+    loss = loss / dist.get_world_size(group=ensemble_group)
+    return loss
+
+
+def _dist_allreduce_sum(x, group):
+    if group is None or not dist.is_initialized():
+        return x
+    dist.all_reduce(x, group=group)
+    return x
+
+
+def _dist_ring_rotate(block: th.Tensor, group):
+    if group is None or not dist.is_initialized():
+        return block
+    ws = dist.get_world_size(group=group)
+    if ws == 1:
+        return block
+    rank = dist.get_rank(group=group)
+    # P2P peer ranks are global process ranks, not group-local indices.
+    send_peer = (rank + 1) % ws
+    recv_peer = (rank - 1 + ws) % ws
+    send_to = dist.get_global_rank(group, send_peer)
+    recv_from = dist.get_global_rank(group, recv_peer)
+    recv = th.empty_like(block)
+    ops = [
+        dist.P2POp(dist.isend, block.contiguous(), send_to, group),
+        dist.P2POp(dist.irecv, recv, recv_from, group),
+    ]
+    reqs = dist.batch_isend_irecv(ops)
+    for req in reqs:
+        req.wait()
+    return recv
+
+
 class BaseMSE(th.nn.MSELoss):
     """
     Base MSE class offers impementaion for basic MSE loss compatable with dlwp custom loss training
@@ -56,7 +95,7 @@ class BaseMSE(th.nn.MSELoss):
         """
         pass
 
-    def forward(self, prediction, target, average_channels=True):
+    def forward(self, prediction, target, average_channels=True, **kwargs):
         """
         Forward pass of the base MSE class
         Tensors are expected to be in the shape [N, B, F, C, H, W]
@@ -111,7 +150,7 @@ class WeightedMSE(th.nn.MSELoss):
 
         self.loss_weights = self.loss_weights.to(device=trainer.device)
 
-    def forward(self, prediction, target, average_channels=True):
+    def forward(self, prediction, target, average_channels=True, **kwargs):
         """
         Forward pass of the WeightedMSE pass
         Tensors are expected to be in the shape [N, B, F, C, H, W]
@@ -230,7 +269,7 @@ class OceanMSE(th.nn.MSELoss):
             np.expand_dims(self.lsm_ds.values, (0, 2, 3))
         ).to(trainer.device)
 
-    def forward(self, prediction, target, average_channels=True):
+    def forward(self, prediction, target, average_channels=True, **kwargs):
 
         if not self.lsm_sum_calculated:
             self.lsm_sum = th.broadcast_to(self.lsm_tensor, target.shape).sum()
@@ -366,6 +405,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.multiscale = multiscale
         self.scales = [4, 16, 32]
         self.masked_processing = masked_processing
+        self.alpha = alpha
 
         if lsm_file is not None:
             self.lsm_ds = xr.open_dataset(lsm_file, **open_dict).constants.sel(selection_dict)
@@ -442,7 +482,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         pooled_tensor = pooled_values / (pooled_mask + 1e-8) # Avoid division by zero
         return pooled_tensor, pooled_mask
 
-    def forward(self, prediction, target, average_channels=True):
+    def forward(self, prediction, target, average_channels=True, **kwargs):
         """
         Forward pass of the WeightedCRPSLoss 
         Computes the CRPS loss for the model prediction and target.
@@ -459,17 +499,40 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
-        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
+        n = prediction.shape[0] // b
+        prediction = prediction.view(n, b, f, t, c, h, w)
+        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        ensemble_group = kwargs.get("ensemble_group", None)
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
             raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
     
-        if not prediction.shape[0] == self.n_members:
+        if (not distributed_loss) and (not prediction.shape[0] == self.n_members):
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
+        if distributed_loss and n < 1:
+            raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
+        # Avoid th.tensor/th.ones allocations here when using distributed exact loss:
+        # CUDA graph capture forbids creating new tensors during the captured region.
+        if not distributed_loss:
+            local_diag_mask = (
+                self.diag_mask if n == self.n_members else
+                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
+            )
+            local_coeff_eps = (
+                self.coeff_eps if n == self.n_members else
+                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
+            )
+            local_averaging_coeff = (
+                self.averaging_coeff
+                if n == self.n_members
+                else (
+                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
+                    if n > 1
+                    else th.tensor(0.0, device=prediction.device)
+                )
+            )
 
-        n = self.n_members
-        
         # Manual Cast
         prediction = prediction.to(th.float32)
         target = target.to(th.float32)
@@ -477,6 +540,77 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         # Apply channel weights across channel dims
         prediction *= self.loss_weights[None, None, None, None, :, None, None]
         target *= self.loss_weights[None, None, None, :, None, None]
+
+        if distributed_loss:
+            if self.masked_processing and self.lsm_tensor.numel() > 1:
+                prediction = prediction * self.lsm_tensor
+                target = target * self.lsm_tensor
+                valid_pixels = b * t * self.lsm_tensor.sum()
+            else:
+                valid_pixels = b * f * t * h * w
+
+            if average_channels:
+                pred_flat = prediction.reshape(n, -1)
+                tar_flat = target.reshape(1, -1)
+                s1_local = th.abs(pred_flat - tar_flat).sum()
+
+                # exact ordered pairwise sum over all members via ring
+                s2_local = pred_flat.new_tensor(0.0)
+                # local-local ordered pairs
+                s2_local = s2_local + th.cdist(pred_flat, pred_flat, p=1).sum()
+                remote = pred_flat
+                ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+                for _ in range(ws - 1):
+                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    s2_local = s2_local + th.cdist(pred_flat, remote, p=1).sum()
+
+                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                # remove diagonal contribution from local-local block
+                # diagonal elements are zero in L1, so no-op retained for clarity
+                crps = self.averaging_coeff * (
+                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                ) / valid_pixels
+
+                bias_penalty = pred_flat.new_tensor(0.0)
+                if self.mean_penalty > 0:
+                    ens_global_sum = _dist_allreduce_sum((prediction * self.lsm_tensor).sum(dim=(0, 1, 2, 3, 5, 6)), ensemble_group)
+                    target_global_sum = _dist_allreduce_sum((target * self.lsm_tensor).sum(dim=(0, 1, 2, 4, 5)), ensemble_group)
+                    prediction_count = self.n_members * b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
+                    target_count = b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
+                    ens_global_means = ens_global_sum / prediction_count
+                    target_global_means = target_global_sum / target_count
+                    bias_penalty = self.mean_penalty * th.abs(ens_global_means - target_global_means).mean()
+                return crps + bias_penalty
+            else:
+                pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
+                tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
+                s1_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
+
+                s2_local = pred_c.new_zeros(c)
+                for ci in range(c):
+                    local = pred_c[ci]
+                    s2_local[ci] += th.cdist(local, local, p=1).sum()
+                    remote = local
+                    ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+                    for _ in range(ws - 1):
+                        remote = _dist_ring_rotate(remote, ensemble_group)
+                        s2_local[ci] += th.cdist(local, remote, p=1).sum()
+
+                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                crps = self.averaging_coeff * (
+                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                ) / valid_pixels
+                if self.mean_penalty > 0:
+                    ens_global_sum = _dist_allreduce_sum((prediction * self.lsm_tensor).sum(dim=(0, 1, 2, 3, 5, 6)), ensemble_group)
+                    target_global_sum = _dist_allreduce_sum((target * self.lsm_tensor).sum(dim=(0, 1, 2, 4, 5)), ensemble_group)
+                    prediction_count = self.n_members * b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
+                    target_count = b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
+                    ens_global_means = ens_global_sum / prediction_count
+                    target_global_means = target_global_sum / target_count
+                    crps = crps + self.mean_penalty * th.abs(ens_global_means - target_global_means)
+                return crps
 
         if n == 2:
             # Use faster explicit implementation
@@ -526,7 +660,11 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 crps_scales = crps_scales / len(self.scales)
                 loss += self.multiscale * crps_scales
                 
-            return loss
+            return _distributed_reduce_loss(
+                loss,
+                ensemble_group=ensemble_group,
+                enabled=distributed_loss,
+            )
         else:
             # Do mean penalty
             bias_penalty = 0
@@ -566,18 +704,22 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 diff = self.pdist(prediction, target) # [C, Cond]
                 dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(2))  # [C, Cond, Cond]
                 
-                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/valid_pixels
+                diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                crps = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/valid_pixels
             else:
                 prediction = prediction.reshape(n, -1)
                 target = target.unsqueeze(0).reshape(1, -1) # [1, ...] (first dim will broadcast across ensemble)
                 diff = self.pdist(prediction, target) # [Cond]
                 dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(0))  # [Cond, Cond] 
 
-                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/valid_pixels
+                diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                crps = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/valid_pixels
 
-            return crps + bias_penalty
+            return _distributed_reduce_loss(
+                crps + bias_penalty,
+                ensemble_group=ensemble_group,
+                enabled=distributed_loss,
+            )
 
 
 class WeightedCRPSLossSpectral(th.nn.MSELoss):
@@ -633,6 +775,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         self.device = None
         self.lambda_spec = lambda_spec
         self.multiscale = multiscale
+        self.alpha = alpha
 
         # Parameters for "almost fair CRPS" loss. See https://arxiv.org/html/2412.15832v1
         self.coeff_eps = 1 - ((1-alpha) / (n_members))
@@ -729,7 +872,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         ell = th.arange(self.lmax, device=device, dtype=th.float32)
         return th.exp(-0.5* ell * (ell + 1) * (scale_radians ** 2))
 
-    def forward(self, prediction, target, average_channels=True):
+    def forward(self, prediction, target, average_channels=True, **kwargs):
         """
         Forward pass of the WeightedCRPSLoss 
         Computes the CRPS loss for the model prediction and target.
@@ -746,16 +889,37 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
-        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
+        n = prediction.shape[0] // b
+        prediction = prediction.view(n, b, f, t, c, h, w)
+        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        ensemble_group = kwargs.get("ensemble_group", None)
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
             raise ValueError(f"Shape of prediction should match shape of target along non-ensemble dimensions, got {prediction.shape} and {target.shape}")
     
-        if not prediction.shape[0] == self.n_members:
+        if (not distributed_loss) and (not prediction.shape[0] == self.n_members):
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
-
-        n = self.n_members
+        if distributed_loss and n < 1:
+            raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
+        if not distributed_loss:
+            local_diag_mask = (
+                self.diag_mask if n == self.n_members else
+                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
+            )
+            local_coeff_eps = (
+                self.coeff_eps if n == self.n_members else
+                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
+            )
+            local_averaging_coeff = (
+                self.averaging_coeff
+                if n == self.n_members
+                else (
+                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
+                    if n > 1
+                    else th.tensor(0.0, device=prediction.device)
+                )
+            )
 
         # Manual cast
         prediction = prediction.to(th.float32)
@@ -765,11 +929,80 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         prediction *= self.loss_weights[None, None, None, None, :, None, None]
         target *= self.loss_weights[None, None, None, :, None, None]
 
+        if distributed_loss:
+            if self.multiscale > 0:
+                raise NotImplementedError(
+                    "Exact distributed spectral mode does not support multiscale > 0 yet."
+                )
+            ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+            if average_channels:
+                pred_flat = prediction.reshape(n, -1)
+                tar_flat = target.reshape(1, -1)
+                s1_local = th.abs(pred_flat - tar_flat).sum()
+                s2_local = th.cdist(pred_flat, pred_flat, p=1).sum()
+                remote = pred_flat
+                for _ in range(ws - 1):
+                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    s2_local = s2_local + th.cdist(pred_flat, remote, p=1).sum()
+                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1 - self.coeff_eps * s2) / (b * f * c * t * h * w)
+
+                if self.lambda_spec > 0:
+                    with th.amp.autocast("cuda", enabled=False):
+                        sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).reshape(n, -1)
+                        sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).reshape(1, -1)
+                        s1s_local = th.abs(sht_pred - sht_tar).sum()
+                        s2s_local = th.cdist(sht_pred, sht_pred, p=1).sum()
+                        remote_s = sht_pred
+                        for _ in range(ws - 1):
+                            remote_s = _dist_ring_rotate(remote_s, ensemble_group)
+                            s2s_local = s2s_local + th.cdist(sht_pred, remote_s, p=1).sum()
+                        s1s = _dist_allreduce_sum(s1s_local, ensemble_group)
+                        s2s = _dist_allreduce_sum(s2s_local, ensemble_group)
+                        spec_loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1s - self.coeff_eps * s2s) / (b * t * self.lmax * self.mmax)
+                    loss = loss + self.lambda_spec * spec_loss
+                return loss
+
+            pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
+            tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
+            s1_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
+            s2_local = pred_c.new_zeros(c)
+            for ci in range(c):
+                local = pred_c[ci]
+                s2_local[ci] += th.cdist(local, local, p=1).sum()
+                remote = local
+                for _ in range(ws - 1):
+                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    s2_local[ci] += th.cdist(local, remote, p=1).sum()
+            s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+            s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+            loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1 - self.coeff_eps * s2) / (b * f * t * h * w)
+            if self.lambda_spec > 0:
+                with th.amp.autocast("cuda", enabled=False):
+                    sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).permute(3, 0, 1, 2, 4, 5).reshape(c, n, -1)
+                    sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).permute(2, 0, 1, 3, 4).reshape(c, 1, -1)
+                    s1s_local = th.abs(sht_pred - sht_tar).sum(dim=(1, 2))
+                    s2s_local = sht_pred.new_zeros(c)
+                    for ci in range(c):
+                        local = sht_pred[ci]
+                        s2s_local[ci] += th.cdist(local, local, p=1).sum()
+                        remote = local
+                        for _ in range(ws - 1):
+                            remote = _dist_ring_rotate(remote, ensemble_group)
+                            s2s_local[ci] += th.cdist(local, remote, p=1).sum()
+                    s1s = _dist_allreduce_sum(s1s_local, ensemble_group)
+                    s2s = _dist_allreduce_sum(s2s_local, ensemble_group)
+                    loss = loss + self.lambda_spec * self.averaging_coeff * (
+                        2 * (self.n_members - 1) * s1s - self.coeff_eps * s2s
+                    ) / (b * t * self.lmax * self.mmax)
+            return loss
+
         if n == 2:
             # Use faster explicit implementation
             diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
             diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+            crps = local_averaging_coeff*(diff_target - local_coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
             if average_channels:
                 loss = crps.mean()
@@ -796,7 +1029,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                     diff_sht_target = th.abs(sht_pred - sht_tar.unsqueeze(0)).sum(dim=(0, 4, 5)) # [B, T, C]
                     diff_sht_ensemble = th.abs(sht_pred[0] - sht_pred[1]).sum(dim=(-1,-2)) # [B, T, C] 
-                    crps_sht = self.averaging_coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble) # [B, T, C]
+                    crps_sht = local_averaging_coeff * (diff_sht_target - local_coeff_eps * diff_sht_ensemble) # [B, T, C]
 
                     # Compute spectral afCRPS
                     if average_channels:
@@ -821,7 +1054,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                         diff_target = th.abs(pred_smooth - tar_smooth.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
                         diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
-                        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+                        crps = local_averaging_coeff*(diff_target - local_coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
                         crps *= self.lsm_tensor
 
@@ -830,7 +1063,11 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         else:
                             loss += self.multiscale * crps.mean(dim=(0, 1, 2, 4, 5))
                         
-            return loss
+            return _distributed_reduce_loss(
+                loss,
+                ensemble_group=ensemble_group,
+                enabled=distributed_loss,
+            )
         
         else:
             # Use pairwise distance method
@@ -845,8 +1082,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 diff = self.pdist(pred, tar) # [C, Cond]
                 dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(2))  # [C, Cond, Cond]
                 
-                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
+                diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                loss = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
 
                 if self.lambda_spec > 0:
                     with th.cuda.amp.autocast(enabled=False):
@@ -868,8 +1105,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff = self.pdist(sht_pred, sht_tar) # [C, Cond]
                         dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(2))  # [C, Cond, Cond]
                         
-                        diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*t*self.lmax*self.mmax)
+                        diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/(b*t*self.lmax*self.mmax)
 
             else:
                 pred = prediction.reshape(n, -1)
@@ -877,8 +1114,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 diff = self.pdist(pred, tar) # [Cond]
                 dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(0))  # [Cond, Cond] 
 
-                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
+                diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                loss = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
 
                 if self.lambda_spec > 0:
                     with th.cuda.amp.autocast(enabled=False):
@@ -899,10 +1136,14 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff = self.pdist(sht_pred, sht_tar) # [Cond]
                         dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(0))  # [Cond, Cond] 
                         
-                        diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
+                        diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
 
-            return loss
+            return _distributed_reduce_loss(
+                loss,
+                ensemble_group=ensemble_group,
+                enabled=distributed_loss,
+            )
         
 
 class SpreadSkillRatioLoss(th.nn.MSELoss):
@@ -1049,6 +1290,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         self.n_members = n_members
         self.loss_weights = th.tensor(weights)
         self.device = None
+        self.alpha = alpha
 
         if patch_size < 1 or patch_size % 2 != 1:
             raise ValueError("patch_size must be a positive odd integer")
@@ -1170,7 +1412,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         patches = patches.permute(0, 2, 1, 3, 5, 6, 4)  # [B, F, T, C, H, W, D]
         return patches
 
-    def forward(self, prediction, target, average_channels: bool = True):
+    def forward(self, prediction, target, average_channels: bool = True, **kwargs):
         """
         Forward pass of the patched energy score loss.
 
@@ -1178,7 +1420,10 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         target: [B, F, T, C, H, W]
         """
         b, f, t, c, h, w = target.shape
-        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
+        n = prediction.shape[0] // b
+        prediction = prediction.view(n, b, f, t, c, h, w)
+        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        ensemble_group = kwargs.get("ensemble_group", None)
 
         if prediction.shape[1:] != target.shape:
             raise ValueError(
@@ -1186,13 +1431,31 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 f"got {prediction.shape} and {target.shape}"
             )
 
-        if prediction.shape[0] != self.n_members:
+        if (not distributed_loss) and (prediction.shape[0] != self.n_members):
             raise ValueError(
                 f"Shape of prediction should have ensemble dimension of size {self.n_members}, "
                 f"got {prediction.shape[0]}"
             )
-
-        n = self.n_members
+        if distributed_loss and n < 1:
+            raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
+        if not distributed_loss:
+            local_diag_mask = (
+                self.diag_mask if n == self.n_members else
+                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
+            )
+            local_coeff_eps = (
+                self.coeff_eps if n == self.n_members else
+                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
+            )
+            local_averaging_coeff = (
+                self.averaging_coeff
+                if n == self.n_members
+                else (
+                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
+                    if n > 1
+                    else th.tensor(0.0, device=prediction.device)
+                )
+            )
 
         prediction = prediction.to(th.float32)
         target = target.to(th.float32)
@@ -1206,12 +1469,65 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             pred_patches - tar_patches.unsqueeze(0)
         )  # [Cond,B,F,T,C,H,W]
 
+        if distributed_loss:
+            ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+            if average_channels:
+                s1_local = diff_to_target.sum()
+
+                # exact ordered member-member term via ring exchange
+                s2_local = pred_patches.new_tensor(0.0)
+                # local-local block
+                for i in range(n):
+                    for j in range(n):
+                        s2_local = s2_local + self._weighted_patch_norm(
+                            pred_patches[i] - pred_patches[j]
+                        ).sum()
+                remote = pred_patches
+                for _ in range(ws - 1):
+                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    for i in range(n):
+                        for j in range(n):
+                            s2_local = s2_local + self._weighted_patch_norm(
+                                pred_patches[i] - remote[j]
+                            ).sum()
+
+                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                es = self.averaging_coeff * (
+                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                )
+                es = es / (b * f * t * c * h * w)
+                return es
+            else:
+                s1_local = diff_to_target.sum(dim=(0, 1, 2, 4, 5))  # [C]
+                s2_local = pred_patches.new_zeros(c)
+                for i in range(n):
+                    for j in range(n):
+                        s2_local = s2_local + self._weighted_patch_norm(
+                            pred_patches[i] - pred_patches[j]
+                        ).sum(dim=(0, 1, 3, 4))
+                remote = pred_patches
+                for _ in range(ws - 1):
+                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    for i in range(n):
+                        for j in range(n):
+                            s2_local = s2_local + self._weighted_patch_norm(
+                                pred_patches[i] - remote[j]
+                            ).sum(dim=(0, 1, 3, 4))
+
+                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
+                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                es = self.averaging_coeff * (
+                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                ) / (b * f * t * h * w)
+                return es
+
         if n == 2:
             diff_target = diff_to_target.sum(dim=0)  # [B,F,T,C,H,W]
             diff_ensemble = self._weighted_patch_norm(
                 pred_patches[0] - pred_patches[1]
             )  # [B,F,T,C,H,W]
-            es = self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
+            es = local_averaging_coeff * (diff_target - local_coeff_eps * diff_ensemble)
         else:
             diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
             diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
@@ -1221,11 +1537,11 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             pred_j = pred_patches.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W,D]
             dist_ensemble = self._weighted_patch_norm(pred_i - pred_j)  # [Cond,Cond,B,F,T,C,H,W]
 
-            mask = self.diag_mask[:, :, None, None, None, None, None, None]
+            mask = local_diag_mask[:, :, None, None, None, None, None, None]
             diff_terms = mask * (diff_i_i + diff_j_i)
             dist_terms = mask * dist_ensemble
 
-            es = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_terms).sum(
+            es = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_terms).sum(
                 dim=(0, 1)
             )  # [B,F,T,C,H,W]
 
@@ -1239,4 +1555,8 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         else:
             loss = es.mean(dim=(0, 1, 2, 4, 5))
 
-        return loss
+        return _distributed_reduce_loss(
+            loss,
+            ensemble_group=ensemble_group,
+            enabled=distributed_loss,
+        )

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -38,8 +38,27 @@ average output channels. This is used in the varible wise logging of validation 
 
 """
 
-
+# Distributed primitives for probabilistic losses
 def _distributed_reduce_loss(loss, ensemble_group=None, enabled=False):
+    """
+    Reduces the loss tensor by averaging across all processes in the specified distributed group.
+
+    This function performs an all-reduce (sum) operation on the input `loss` tensor across all processes
+    in the `ensemble_group` communicator, and then divides the summed loss by the world size to obtain the
+    mean loss over all processes. This is useful when you want to compute the globally averaged loss value
+    in distributed training, for correct logging or optimization step equivalence.
+
+    If distributed mode is not enabled, or if the group is None or collective communication is not
+    initialized, the loss is returned unchanged.
+
+    Args:
+        loss (torch.Tensor): The loss tensor to reduce (e.g., a scalar or per-variable loss).
+        ensemble_group (optional): The distributed process group to perform reduction over. Default: None.
+        enabled (bool): If True, perform reduction, otherwise return input as-is.
+
+    Returns:
+        torch.Tensor: The reduced (averaged across group) loss tensor.
+    """
     if not enabled or ensemble_group is None or not dist.is_initialized():
         return loss
     dist.all_reduce(loss, group=ensemble_group)
@@ -48,6 +67,21 @@ def _distributed_reduce_loss(loss, ensemble_group=None, enabled=False):
 
 
 def _dist_allreduce_sum(x, group):
+    """
+    Sums the input tensor `x` across all processes in the specified distributed process group.
+
+    Performs an in-place all-reduce (sum) on `x` over the given group, which is useful for synchronizing
+    results or statistics in distributed settings.
+
+    If the group is None or distributed mode is not initialized, returns the original input tensor.
+
+    Args:
+        x (torch.Tensor): The tensor to sum/reduce across all participating processes.
+        group (optional): The process group for all-reduce. Default: None.
+
+    Returns:
+        torch.Tensor: The summed tensor across the group.
+    """
     if group is None or not dist.is_initialized():
         return x
     dist.all_reduce(x, group=group)
@@ -55,6 +89,38 @@ def _dist_allreduce_sum(x, group):
 
 
 def _dist_ring_rotate(block: th.Tensor, group):
+    """
+    Perform a ring exchange (rotate) of a tensor block across distributed processes.
+
+    In a distributed environment with multiple processes (e.g., in distributed ensemble loss calculations),
+    this function performs a ring-wise rotation of the input tensor `block` among all processes in the
+    specified `group`. Each process sends its tensor to the next process in the ring and receives a tensor
+    from the previous process.
+
+    The operation can be visualized as:
+        rank i sends its tensor to rank (i+1) % world_size,
+        and receives a tensor from rank (i-1+world_size) % world_size.
+
+    If distributed mode is not enabled, no collective is initialized, or the group size is 1, 
+    then the input block is returned unchanged.
+
+    Parameters
+    ----------
+    block : torch.Tensor
+        The tensor to be exchanged.
+    group : Any
+        The process group for communication (typically torch.distributed process group).
+
+    Returns
+    -------
+    torch.Tensor
+        The received tensor from the previous process in the ring.
+
+    Notes
+    -----
+    This is used for exactly ordered member-member terms via ring exchange in distributed ensemble loss 
+    computation.
+    """
     if group is None or not dist.is_initialized():
         return block
     ws = dist.get_world_size(group=group)

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -132,7 +132,7 @@ def _dist_ring_rotate(block: th.Tensor, group):
     recv_peer = (rank - 1 + ws) % ws
     send_to = dist.get_global_rank(group, send_peer)
     recv_from = dist.get_global_rank(group, recv_peer)
-    recv = th.empty_like(block)
+    recv = th.empty(block.shape, dtype=block.dtype, device=block.device)
     ops = [
         dist.P2POp(dist.isend, block.contiguous(), send_to, group),
         dist.P2POp(dist.irecv, recv, recv_from, group),
@@ -141,6 +141,37 @@ def _dist_ring_rotate(block: th.Tensor, group):
     for req in reqs:
         req.wait()
     return recv
+
+
+def _dist_pairwise_duplicate_factor(ensemble_group, n_members: int) -> float:
+    """When ``n_members == 2`` and the ensemble group has two ranks, each rank's ring
+    step computes the same member–member distance; ``all_reduce`` sums two identical
+    contributions. Halve the all-reduced spread sum after reduction in that case only.
+    """
+    if n_members != 2 or ensemble_group is None or not dist.is_initialized():
+        return 1.0
+    if dist.get_world_size(group=ensemble_group) != 2:
+        return 1.0
+    return 0.5
+
+
+def _dist_ensemble_skill_prefactor(n_members: int) -> int:
+    """Scale the all-reduced **skill** sum (total ``Σ_i ‖x_i - y‖``) in distributed
+    almost-fair CRPS / energy score.
+
+    Here ``skill`` is the global sum of ‖pred−target‖ contributions from every
+    rank's local members, i.e. it already aggregates the full ensemble once. For
+    ``n_members > 2`` the ordered-pair expansion uses a ``2*(n_members-1)`` factor
+    (see the non-distributed pairwise reduction). For ``n_members == 2`` the
+    closed-form path (``_2member_crps``) uses that total once; applying ``2*(n-1)=2``
+    would double the skill term. The spread term (member–member distances) may 
+    still be doubled across two ranks; see ``_dist_pairwise_duplicate_factor``.
+    """
+    if n_members < 2:
+        raise ValueError("n_members must be at least 2")
+    if n_members == 2:
+        return 1
+    return 2 * (n_members - 1)
 
 
 class BaseMSE(th.nn.MSELoss):
@@ -601,28 +632,37 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             else:
                 valid_pixels = b * f * t * h * w
 
+            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
+
             if average_channels:
+                if self.n_members == 2 and not (
+                    self.masked_processing and self.lsm_tensor.numel() > 1
+                ):
+                    valid_px_avg = b * f * t * c * h * w
+                else:
+                    valid_px_avg = valid_pixels
                 pred_flat = prediction.reshape(n, -1)
                 tar_flat = target.reshape(1, -1)
-                s1_local = th.abs(pred_flat - tar_flat).sum()
+                skill_local = th.abs(pred_flat - tar_flat).sum()
 
-                # exact ordered pairwise sum over all members via ring
-                s2_local = pred_flat.new_tensor(0.0)
+                # spread: ordered member–member L1 sum via ring (see non-distributed pairwise CRPS)
+                spread_local = pred_flat.new_tensor(0.0)
                 # local-local ordered pairs
-                s2_local = s2_local + th.cdist(pred_flat, pred_flat, p=1).sum()
+                spread_local = spread_local + th.cdist(pred_flat, pred_flat, p=1).sum()
                 remote = pred_flat
                 ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
                 for _ in range(ws - 1):
                     remote = _dist_ring_rotate(remote, ensemble_group)
-                    s2_local = s2_local + th.cdist(pred_flat, remote, p=1).sum()
+                    spread_local = spread_local + th.cdist(pred_flat, remote, p=1).sum()
 
-                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                skill = _dist_allreduce_sum(skill_local, ensemble_group)
+                spread = _dist_allreduce_sum(spread_local, ensemble_group)
+                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
                 # remove diagonal contribution from local-local block
                 # diagonal elements are zero in L1, so no-op retained for clarity
                 crps = self.averaging_coeff * (
-                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
-                ) / valid_pixels
+                    skill_mul * skill - self.coeff_eps * spread
+                ) / valid_px_avg
 
                 bias_penalty = pred_flat.new_tensor(0.0)
                 if self.mean_penalty > 0:
@@ -637,22 +677,23 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             else:
                 pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
                 tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
-                s1_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
+                skill_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
 
-                s2_local = pred_c.new_zeros(c)
+                spread_local = pred_c.new_zeros(c)
                 for ci in range(c):
                     local = pred_c[ci]
-                    s2_local[ci] += th.cdist(local, local, p=1).sum()
+                    spread_local[ci] += th.cdist(local, local, p=1).sum()
                     remote = local
                     ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
                     for _ in range(ws - 1):
                         remote = _dist_ring_rotate(remote, ensemble_group)
-                        s2_local[ci] += th.cdist(local, remote, p=1).sum()
+                        spread_local[ci] += th.cdist(local, remote, p=1).sum()
 
-                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                skill = _dist_allreduce_sum(skill_local, ensemble_group)
+                spread = _dist_allreduce_sum(spread_local, ensemble_group)
+                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
                 crps = self.averaging_coeff * (
-                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                    skill_mul * skill - self.coeff_eps * spread
                 ) / valid_pixels
                 if self.mean_penalty > 0:
                     ens_global_sum = _dist_allreduce_sum((prediction * self.lsm_tensor).sum(dim=(0, 1, 2, 3, 5, 6)), ensemble_group)
@@ -975,66 +1016,71 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                     "Exact distributed spectral mode does not support multiscale > 0 yet."
                 )
             ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
             if average_channels:
                 pred_flat = prediction.reshape(n, -1)
                 tar_flat = target.reshape(1, -1)
-                s1_local = th.abs(pred_flat - tar_flat).sum()
-                s2_local = th.cdist(pred_flat, pred_flat, p=1).sum()
+                skill_local = th.abs(pred_flat - tar_flat).sum()
+                spread_local = th.cdist(pred_flat, pred_flat, p=1).sum()
                 remote = pred_flat
                 for _ in range(ws - 1):
                     remote = _dist_ring_rotate(remote, ensemble_group)
-                    s2_local = s2_local + th.cdist(pred_flat, remote, p=1).sum()
-                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
-                loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1 - self.coeff_eps * s2) / (b * f * c * t * h * w)
+                    spread_local = spread_local + th.cdist(pred_flat, remote, p=1).sum()
+                skill = _dist_allreduce_sum(skill_local, ensemble_group)
+                spread = _dist_allreduce_sum(spread_local, ensemble_group)
+                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
+                loss = self.averaging_coeff * (skill_mul * skill - self.coeff_eps * spread) / (b * f * c * t * h * w)
 
                 if self.lambda_spec > 0:
                     with th.amp.autocast("cuda", enabled=False):
                         sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).reshape(n, -1)
                         sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).reshape(1, -1)
-                        s1s_local = th.abs(sht_pred - sht_tar).sum()
-                        s2s_local = th.cdist(sht_pred, sht_pred, p=1).sum()
+                        skill_spec_local = th.abs(sht_pred - sht_tar).sum()
+                        spread_spec_local = th.cdist(sht_pred, sht_pred, p=1).sum()
                         remote_s = sht_pred
                         for _ in range(ws - 1):
                             remote_s = _dist_ring_rotate(remote_s, ensemble_group)
-                            s2s_local = s2s_local + th.cdist(sht_pred, remote_s, p=1).sum()
-                        s1s = _dist_allreduce_sum(s1s_local, ensemble_group)
-                        s2s = _dist_allreduce_sum(s2s_local, ensemble_group)
-                        spec_loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1s - self.coeff_eps * s2s) / (b * t * self.lmax * self.mmax)
+                            spread_spec_local = spread_spec_local + th.cdist(sht_pred, remote_s, p=1).sum()
+                        skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
+                        spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
+                        spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
+                        spec_loss = self.averaging_coeff * (skill_mul * skill_spec - self.coeff_eps * spread_spec) / (b * t * self.lmax * self.mmax)
                     loss = loss + self.lambda_spec * spec_loss
                 return loss
 
             pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
             tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
-            s1_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
-            s2_local = pred_c.new_zeros(c)
+            skill_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
+            spread_local = pred_c.new_zeros(c)
             for ci in range(c):
                 local = pred_c[ci]
-                s2_local[ci] += th.cdist(local, local, p=1).sum()
+                spread_local[ci] += th.cdist(local, local, p=1).sum()
                 remote = local
                 for _ in range(ws - 1):
                     remote = _dist_ring_rotate(remote, ensemble_group)
-                    s2_local[ci] += th.cdist(local, remote, p=1).sum()
-            s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-            s2 = _dist_allreduce_sum(s2_local, ensemble_group)
-            loss = self.averaging_coeff * (2 * (self.n_members - 1) * s1 - self.coeff_eps * s2) / (b * f * t * h * w)
+                    spread_local[ci] += th.cdist(local, remote, p=1).sum()
+            skill = _dist_allreduce_sum(skill_local, ensemble_group)
+            spread = _dist_allreduce_sum(spread_local, ensemble_group)
+            spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
+            loss = self.averaging_coeff * (skill_mul * skill - self.coeff_eps * spread) / (b * f * t * h * w)
             if self.lambda_spec > 0:
                 with th.amp.autocast("cuda", enabled=False):
                     sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).permute(3, 0, 1, 2, 4, 5).reshape(c, n, -1)
                     sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).permute(2, 0, 1, 3, 4).reshape(c, 1, -1)
-                    s1s_local = th.abs(sht_pred - sht_tar).sum(dim=(1, 2))
-                    s2s_local = sht_pred.new_zeros(c)
+                    skill_spec_local = th.abs(sht_pred - sht_tar).sum(dim=(1, 2))
+                    spread_spec_local = sht_pred.new_zeros(c)
                     for ci in range(c):
                         local = sht_pred[ci]
-                        s2s_local[ci] += th.cdist(local, local, p=1).sum()
+                        spread_spec_local[ci] += th.cdist(local, local, p=1).sum()
                         remote = local
                         for _ in range(ws - 1):
                             remote = _dist_ring_rotate(remote, ensemble_group)
-                            s2s_local[ci] += th.cdist(local, remote, p=1).sum()
-                    s1s = _dist_allreduce_sum(s1s_local, ensemble_group)
-                    s2s = _dist_allreduce_sum(s2s_local, ensemble_group)
+                            spread_spec_local[ci] += th.cdist(local, remote, p=1).sum()
+                    skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
+                    spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
+                    spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
                     loss = loss + self.lambda_spec * self.averaging_coeff * (
-                        2 * (self.n_members - 1) * s1s - self.coeff_eps * s2s
+                        skill_mul * skill_spec - self.coeff_eps * spread_spec
                     ) / (b * t * self.lmax * self.mmax)
             return loss
 
@@ -1498,15 +1544,16 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
 
         if distributed_loss:
             ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
+            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
             if average_channels:
-                s1_local = diff_to_target.sum()
+                skill_local = diff_to_target.sum()
 
-                # exact ordered member-member term via ring exchange
-                s2_local = pred_patches.new_tensor(0.0)
+                # spread: ordered member–member patch distances via ring exchange
+                spread_local = pred_patches.new_tensor(0.0)
                 # local-local block
                 for i in range(n):
                     for j in range(n):
-                        s2_local = s2_local + self._weighted_patch_norm(
+                        spread_local = spread_local + self._weighted_patch_norm(
                             pred_patches[i] - pred_patches[j]
                         ).sum()
                 remote = pred_patches
@@ -1514,38 +1561,41 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                     remote = _dist_ring_rotate(remote, ensemble_group)
                     for i in range(n):
                         for j in range(n):
-                            s2_local = s2_local + self._weighted_patch_norm(
+                            spread_local = spread_local + self._weighted_patch_norm(
                                 pred_patches[i] - remote[j]
                             ).sum()
 
-                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                skill = _dist_allreduce_sum(skill_local, ensemble_group)
+                spread = _dist_allreduce_sum(spread_local, ensemble_group)
+                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
                 es = self.averaging_coeff * (
-                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                    skill_mul * skill - self.coeff_eps * spread
                 )
                 es = es / (b * f * t * c * h * w)
                 return es
             else:
-                s1_local = diff_to_target.sum(dim=(0, 1, 2, 4, 5))  # [C]
-                s2_local = pred_patches.new_zeros(c)
+                # diff_to_target: [Cond, B, F, T, C, H, W] — reduce to one value per channel
+                skill_local = diff_to_target.sum(dim=(0, 1, 2, 3, 5, 6))
+                spread_local = pred_patches.new_zeros(c)
                 for i in range(n):
                     for j in range(n):
-                        s2_local = s2_local + self._weighted_patch_norm(
+                        spread_local = spread_local + self._weighted_patch_norm(
                             pred_patches[i] - pred_patches[j]
-                        ).sum(dim=(0, 1, 3, 4))
+                        ).sum(dim=(0, 1, 2, 4, 5))
                 remote = pred_patches
                 for _ in range(ws - 1):
                     remote = _dist_ring_rotate(remote, ensemble_group)
                     for i in range(n):
                         for j in range(n):
-                            s2_local = s2_local + self._weighted_patch_norm(
+                            spread_local = spread_local + self._weighted_patch_norm(
                                 pred_patches[i] - remote[j]
-                            ).sum(dim=(0, 1, 3, 4))
+                            ).sum(dim=(0, 1, 2, 4, 5))
 
-                s1 = _dist_allreduce_sum(s1_local, ensemble_group)
-                s2 = _dist_allreduce_sum(s2_local, ensemble_group)
+                skill = _dist_allreduce_sum(skill_local, ensemble_group)
+                spread = _dist_allreduce_sum(spread_local, ensemble_group)
+                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
                 es = self.averaging_coeff * (
-                    2 * (self.n_members - 1) * s1 - self.coeff_eps * s2
+                    skill_mul * skill - self.coeff_eps * spread
                 ) / (b * f * t * h * w)
                 return es
 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -24,6 +24,7 @@ import xarray as xr
 import earth2grid
 from cuhpx import SHTCUDA, iSHTCUDA
 from earth2grid.healpix import HEALPIX_PAD_XY, PixelOrder
+from physicsnemo.distributed.autograd import ring_exchange
 from physicsnemo.models.dlwp_healpix_layers.healpix_layers import HEALPixPadding, HEALPixPaddingv2
 
 """
@@ -38,140 +39,38 @@ average output channels. This is used in the varible wise logging of validation 
 
 """
 
-# Distributed primitives for probabilistic losses
-def _distributed_reduce_loss(loss, ensemble_group=None, enabled=False):
-    """
-    Reduces the loss tensor by averaging across all processes in the specified distributed group.
-
-    This function performs an all-reduce (sum) operation on the input `loss` tensor across all processes
-    in the `ensemble_group` communicator, and then divides the summed loss by the world size to obtain the
-    mean loss over all processes. This is useful when you want to compute the globally averaged loss value
-    in distributed training, for correct logging or optimization step equivalence.
-
-    If distributed mode is not enabled, or if the group is None or collective communication is not
-    initialized, the loss is returned unchanged.
-
-    Args:
-        loss (torch.Tensor): The loss tensor to reduce (e.g., a scalar or per-variable loss).
-        ensemble_group (optional): The distributed process group to perform reduction over. Default: None.
-        enabled (bool): If True, perform reduction, otherwise return input as-is.
-
-    Returns:
-        torch.Tensor: The reduced (averaged across group) loss tensor.
-    """
-    if not enabled or ensemble_group is None or not dist.is_initialized():
-        return loss
-    dist.all_reduce(loss, group=ensemble_group)
-    loss = loss / dist.get_world_size(group=ensemble_group)
-    return loss
+def _validate_distributed_members(
+    prediction: th.Tensor,
+    n_members: int,
+    ensemble_group=None,
+):
+    """Validate member sharding for distributed probabilistic losses."""
+    if ensemble_group is None or not dist.is_initialized():
+        raise ValueError("Distributed ensemble loss requires an initialized process group")
+    ws = dist.get_world_size(group=ensemble_group)
+    local_members = prediction.shape[0]
+    if n_members <= 2:
+        raise ValueError(
+            f"Distributed probabilistic losses require n_members > 2, got {n_members}"
+        )
+    if n_members % ws != 0:
+        raise ValueError(
+            f"n_members ({n_members}) must be divisible by world size ({ws}) for distributed loss"
+        )
+    expected_local = n_members // ws
+    if local_members != expected_local:
+        raise ValueError(
+            f"Expected local member count {expected_local}, got {local_members}"
+        )
 
 
-def _dist_allreduce_sum(x, group):
-    """
-    Sums the input tensor `x` across all processes in the specified distributed process group.
-
-    Performs an in-place all-reduce (sum) on `x` over the given group, which is useful for synchronizing
-    results or statistics in distributed settings.
-
-    If the group is None or distributed mode is not initialized, returns the original input tensor.
-
-    Args:
-        x (torch.Tensor): The tensor to sum/reduce across all participating processes.
-        group (optional): The process group for all-reduce. Default: None.
-
-    Returns:
-        torch.Tensor: The summed tensor across the group.
-    """
-    if group is None or not dist.is_initialized():
-        return x
-    dist.all_reduce(x, group=group)
-    return x
-
-
-def _dist_ring_rotate(block: th.Tensor, group):
-    """
-    Perform a ring exchange (rotate) of a tensor block across distributed processes.
-
-    In a distributed environment with multiple processes (e.g., in distributed ensemble loss calculations),
-    this function performs a ring-wise rotation of the input tensor `block` among all processes in the
-    specified `group`. Each process sends its tensor to the next process in the ring and receives a tensor
-    from the previous process.
-
-    The operation can be visualized as:
-        rank i sends its tensor to rank (i+1) % world_size,
-        and receives a tensor from rank (i-1+world_size) % world_size.
-
-    If distributed mode is not enabled, no collective is initialized, or the group size is 1, 
-    then the input block is returned unchanged.
-
-    Parameters
-    ----------
-    block : torch.Tensor
-        The tensor to be exchanged.
-    group : Any
-        The process group for communication (typically torch.distributed process group).
-
-    Returns
-    -------
-    torch.Tensor
-        The received tensor from the previous process in the ring.
-
-    Notes
-    -----
-    This is used for exactly ordered member-member terms via ring exchange in distributed ensemble loss 
-    computation.
-    """
-    if group is None or not dist.is_initialized():
-        return block
-    ws = dist.get_world_size(group=group)
-    if ws == 1:
-        return block
-    rank = dist.get_rank(group=group)
-    # P2P peer ranks are global process ranks, not group-local indices.
-    send_peer = (rank + 1) % ws
-    recv_peer = (rank - 1 + ws) % ws
-    send_to = dist.get_global_rank(group, send_peer)
-    recv_from = dist.get_global_rank(group, recv_peer)
-    recv = th.empty(block.shape, dtype=block.dtype, device=block.device)
-    ops = [
-        dist.P2POp(dist.isend, block.contiguous(), send_to, group),
-        dist.P2POp(dist.irecv, recv, recv_from, group),
-    ]
-    reqs = dist.batch_isend_irecv(ops)
-    for req in reqs:
-        req.wait()
-    return recv
-
-
-def _dist_pairwise_duplicate_factor(ensemble_group, n_members: int) -> float:
-    """When ``n_members == 2`` and the ensemble group has two ranks, each rank's ring
-    step computes the same member–member distance; ``all_reduce`` sums two identical
-    contributions. Halve the all-reduced spread sum after reduction in that case only.
-    """
-    if n_members != 2 or ensemble_group is None or not dist.is_initialized():
-        return 1.0
-    if dist.get_world_size(group=ensemble_group) != 2:
-        return 1.0
-    return 0.5
-
-
-def _dist_ensemble_skill_prefactor(n_members: int) -> int:
-    """Scale the all-reduced **skill** sum (total ``Σ_i ‖x_i - y‖``) in distributed
-    almost-fair CRPS / energy score.
-
-    Here ``skill`` is the global sum of ‖pred−target‖ contributions from every
-    rank's local members, i.e. it already aggregates the full ensemble once. For
-    ``n_members > 2`` the ordered-pair expansion uses a ``2*(n_members-1)`` factor
-    (see the non-distributed pairwise reduction). For ``n_members == 2`` the
-    closed-form path (``_2member_crps``) uses that total once; applying ``2*(n-1)=2``
-    would double the skill term. The spread term (member–member distances) may 
-    still be doubled across two ranks; see ``_dist_pairwise_duplicate_factor``.
-    """
-    if n_members < 2:
-        raise ValueError("n_members must be at least 2")
-    if n_members == 2:
-        return 1
-    return 2 * (n_members - 1)
+def _distributed_value_from_local(local_value: th.Tensor, ensemble_group=None):
+    """Return global summed value while keeping local gradient flow."""
+    if ensemble_group is None or not dist.is_initialized():
+        return local_value
+    value = local_value.detach().clone()
+    dist.all_reduce(value, group=ensemble_group)
+    return local_value + (value - local_value.detach())
 
 
 class BaseMSE(th.nn.MSELoss):
@@ -627,6 +526,14 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         target = target * lw_t
 
         if distributed_loss:
+            _validate_distributed_members(
+                prediction=prediction,
+                n_members=self.n_members,
+                ensemble_group=ensemble_group,
+            )
+            ws = dist.get_world_size(group=ensemble_group)
+            skill_mul = 2 * (self.n_members - 1)
+
             if self.masked_processing and self.lsm_tensor.numel() > 1:
                 prediction = prediction * self.lsm_tensor
                 target = target * self.lsm_tensor
@@ -634,78 +541,70 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             else:
                 valid_pixels = b * f * t * h * w
 
-            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
-
             if average_channels:
-                if self.n_members == 2 and not (
-                    self.masked_processing and self.lsm_tensor.numel() > 1
-                ):
-                    valid_px_avg = b * f * t * c * h * w
-                else:
-                    valid_px_avg = valid_pixels
                 pred_flat = prediction.reshape(n, -1)
                 tar_flat = target.reshape(1, -1)
                 skill_local = th.abs(pred_flat - tar_flat).sum()
 
-                # spread: ordered member–member L1 sum via ring (see non-distributed pairwise CRPS)
-                spread_local = pred_flat.new_tensor(0.0)
-                # local-local ordered pairs
-                spread_local = spread_local + th.cdist(pred_flat, pred_flat, p=1).sum()
+                spread_local = th.cdist(pred_flat, pred_flat, p=1).sum()
                 remote = pred_flat
-                ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
                 for _ in range(ws - 1):
-                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    remote = ring_exchange(remote, ensemble_group)
                     spread_local = spread_local + th.cdist(pred_flat, remote, p=1).sum()
 
-                skill = _dist_allreduce_sum(skill_local, ensemble_group)
-                spread = _dist_allreduce_sum(spread_local, ensemble_group)
-                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                # remove diagonal contribution from local-local block
-                # diagonal elements are zero in L1, so no-op retained for clarity
-                crps = self.averaging_coeff * (
-                    skill_mul * skill - self.coeff_eps * spread
-                ) / valid_px_avg
-
-                bias_penalty = pred_flat.new_tensor(0.0)
+                local_loss = self.averaging_coeff * (
+                    skill_mul * skill_local - self.coeff_eps * spread_local
+                ) / valid_pixels
                 if self.mean_penalty > 0:
-                    ens_global_sum = _dist_allreduce_sum((prediction * self.lsm_tensor).sum(dim=(0, 1, 2, 3, 5, 6)), ensemble_group)
-                    target_global_sum = _dist_allreduce_sum((target * self.lsm_tensor).sum(dim=(0, 1, 2, 4, 5)), ensemble_group)
-                    prediction_count = self.n_members * b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
-                    target_count = b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
-                    ens_global_means = ens_global_sum / prediction_count
-                    target_global_means = target_global_sum / target_count
-                    bias_penalty = self.mean_penalty * th.abs(ens_global_means - target_global_means).mean()
-                return crps + bias_penalty
+                    prediction_count = self.n_members * b * t * (
+                        self.lsm_tensor.sum()
+                        if (self.masked_processing and self.lsm_tensor.numel() > 1)
+                        else f * h * w
+                    )
+                    target_count = b * t * (
+                        self.lsm_tensor.sum()
+                        if (self.masked_processing and self.lsm_tensor.numel() > 1)
+                        else f * h * w
+                    )
+                    mean_local = (
+                        self.mean_penalty
+                        * th.abs(
+                            (prediction.sum(dim=(0, 1, 2, 3, 5, 6)) / prediction_count)
+                            - (target.sum(dim=(0, 1, 2, 4, 5)) / target_count)
+                        ).mean()
+                    )
+                    local_loss = local_loss + mean_local
             else:
                 pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
                 tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
                 skill_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
-
                 spread_local = pred_c.new_zeros(c)
                 for ci in range(c):
                     local = pred_c[ci]
                     spread_local[ci] += th.cdist(local, local, p=1).sum()
                     remote = local
-                    ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
                     for _ in range(ws - 1):
-                        remote = _dist_ring_rotate(remote, ensemble_group)
+                        remote = ring_exchange(remote, ensemble_group)
                         spread_local[ci] += th.cdist(local, remote, p=1).sum()
-
-                skill = _dist_allreduce_sum(skill_local, ensemble_group)
-                spread = _dist_allreduce_sum(spread_local, ensemble_group)
-                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                crps = self.averaging_coeff * (
-                    skill_mul * skill - self.coeff_eps * spread
+                local_loss = self.averaging_coeff * (
+                    skill_mul * skill_local - self.coeff_eps * spread_local
                 ) / valid_pixels
                 if self.mean_penalty > 0:
-                    ens_global_sum = _dist_allreduce_sum((prediction * self.lsm_tensor).sum(dim=(0, 1, 2, 3, 5, 6)), ensemble_group)
-                    target_global_sum = _dist_allreduce_sum((target * self.lsm_tensor).sum(dim=(0, 1, 2, 4, 5)), ensemble_group)
-                    prediction_count = self.n_members * b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
-                    target_count = b * t * (self.lsm_tensor.sum() if (self.masked_processing and self.lsm_tensor.numel() > 1) else f * h * w)
-                    ens_global_means = ens_global_sum / prediction_count
-                    target_global_means = target_global_sum / target_count
-                    crps = crps + self.mean_penalty * th.abs(ens_global_means - target_global_means)
-                return crps
+                    prediction_count = self.n_members * b * t * (
+                        self.lsm_tensor.sum()
+                        if (self.masked_processing and self.lsm_tensor.numel() > 1)
+                        else f * h * w
+                    )
+                    target_count = b * t * (
+                        self.lsm_tensor.sum()
+                        if (self.masked_processing and self.lsm_tensor.numel() > 1)
+                        else f * h * w
+                    )
+                    local_loss = local_loss + self.mean_penalty * th.abs(
+                        (prediction.sum(dim=(0, 1, 2, 3, 5, 6)) / prediction_count)
+                        - (target.sum(dim=(0, 1, 2, 4, 5)) / target_count)
+                    )
+            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             # Use faster explicit implementation
@@ -755,11 +654,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 crps_scales = crps_scales / len(self.scales)
                 loss += self.multiscale * crps_scales
                 
-            return _distributed_reduce_loss(
-                loss,
-                ensemble_group=ensemble_group,
-                enabled=distributed_loss,
-            )
+            return loss
         else:
             # Do mean penalty
             bias_penalty = 0
@@ -810,11 +705,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
                 crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/valid_pixels
 
-            return _distributed_reduce_loss(
-                crps + bias_penalty,
-                ensemble_group=ensemble_group,
-                enabled=distributed_loss,
-            )
+            return crps + bias_penalty
 
 
 class WeightedCRPSLossSpectral(th.nn.MSELoss):
@@ -1019,8 +910,14 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 raise NotImplementedError(
                     "Exact distributed spectral mode does not support multiscale > 0 yet."
                 )
-            ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
-            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
+            _validate_distributed_members(
+                prediction=prediction,
+                n_members=self.n_members,
+                ensemble_group=ensemble_group,
+            )
+            ws = dist.get_world_size(group=ensemble_group)
+            skill_mul = 2 * (self.n_members - 1)
+
             if average_channels:
                 pred_flat = prediction.reshape(n, -1)
                 tar_flat = target.reshape(1, -1)
@@ -1028,79 +925,71 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 spread_local = th.cdist(pred_flat, pred_flat, p=1).sum()
                 remote = pred_flat
                 for _ in range(ws - 1):
-                    remote = _dist_ring_rotate(remote, ensemble_group)
+                    remote = ring_exchange(remote, ensemble_group)
                     spread_local = spread_local + th.cdist(pred_flat, remote, p=1).sum()
-                skill = _dist_allreduce_sum(skill_local, ensemble_group)
-                spread = _dist_allreduce_sum(spread_local, ensemble_group)
-                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                loss = self.averaging_coeff * (skill_mul * skill - self.coeff_eps * spread) / (b * f * c * t * h * w)
+                local_loss = self.averaging_coeff * (
+                    skill_mul * skill_local - self.coeff_eps * spread_local
+                ) / (b * f * c * t * h * w)
 
                 if self.lambda_spec > 0:
                     with th.amp.autocast("cuda", enabled=False):
-                        sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).reshape(n, -1)
-                        sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).reshape(1, -1)
+                        sht_pred = self._apply_sht(
+                            prediction, face_dim=2, return_abs=True
+                        ).reshape(n, -1)
+                        sht_tar = self._apply_sht(
+                            target, face_dim=1, return_abs=True
+                        ).reshape(1, -1)
                         skill_spec_local = th.abs(sht_pred - sht_tar).sum()
                         spread_spec_local = th.cdist(sht_pred, sht_pred, p=1).sum()
                         remote_s = sht_pred
                         for _ in range(ws - 1):
-                            remote_s = _dist_ring_rotate(remote_s, ensemble_group)
-                            spread_spec_local = spread_spec_local + th.cdist(sht_pred, remote_s, p=1).sum()
-                        skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
-                        spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
-                        spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                        # Required to match non-distributed n==2 special case
-                        spec_denom = (
-                            b * t * c
-                            if self.n_members == 2
-                            else b * t * self.lmax * self.mmax
-                        )
-                        spec_loss = self.averaging_coeff * (
-                            skill_mul * skill_spec - self.coeff_eps * spread_spec
-                        ) / spec_denom
-                    loss = loss + self.lambda_spec * spec_loss
-                return loss
+                            remote_s = ring_exchange(remote_s, ensemble_group)
+                            spread_spec_local = spread_spec_local + th.cdist(
+                                sht_pred, remote_s, p=1
+                            ).sum()
+                        spec_loss_local = self.averaging_coeff * (
+                            skill_mul * skill_spec_local
+                            - self.coeff_eps * spread_spec_local
+                        ) / (b * t * self.lmax * self.mmax)
+                    local_loss = local_loss + self.lambda_spec * spec_loss_local
+            else:
+                pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
+                tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
+                skill_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
+                spread_local = pred_c.new_zeros(c)
+                for ci in range(c):
+                    local = pred_c[ci]
+                    spread_local[ci] += th.cdist(local, local, p=1).sum()
+                    remote = local
+                    for _ in range(ws - 1):
+                        remote = ring_exchange(remote, ensemble_group)
+                        spread_local[ci] += th.cdist(local, remote, p=1).sum()
+                local_loss = self.averaging_coeff * (
+                    skill_mul * skill_local - self.coeff_eps * spread_local
+                ) / (b * f * t * h * w)
 
-            pred_c = prediction.permute(4, 0, 1, 2, 3, 5, 6).reshape(c, n, -1)
-            tar_c = target.permute(3, 0, 1, 2, 4, 5).reshape(c, 1, -1)
-            skill_local = th.abs(pred_c - tar_c).sum(dim=(1, 2))
-            spread_local = pred_c.new_zeros(c)
-            for ci in range(c):
-                local = pred_c[ci]
-                spread_local[ci] += th.cdist(local, local, p=1).sum()
-                remote = local
-                for _ in range(ws - 1):
-                    remote = _dist_ring_rotate(remote, ensemble_group)
-                    spread_local[ci] += th.cdist(local, remote, p=1).sum()
-            skill = _dist_allreduce_sum(skill_local, ensemble_group)
-            spread = _dist_allreduce_sum(spread_local, ensemble_group)
-            spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-            loss = self.averaging_coeff * (skill_mul * skill - self.coeff_eps * spread) / (b * f * t * h * w)
-            if self.lambda_spec > 0:
-                with th.amp.autocast("cuda", enabled=False):
-                    sht_pred = self._apply_sht(prediction, face_dim=2, return_abs=True).permute(3, 0, 1, 2, 4, 5).reshape(c, n, -1)
-                    sht_tar = self._apply_sht(target, face_dim=1, return_abs=True).permute(2, 0, 1, 3, 4).reshape(c, 1, -1)
-                    skill_spec_local = th.abs(sht_pred - sht_tar).sum(dim=(1, 2))
-                    spread_spec_local = sht_pred.new_zeros(c)
-                    for ci in range(c):
-                        local = sht_pred[ci]
-                        spread_spec_local[ci] += th.cdist(local, local, p=1).sum()
-                        remote = local
-                        for _ in range(ws - 1):
-                            remote = _dist_ring_rotate(remote, ensemble_group)
-                            spread_spec_local[ci] += th.cdist(local, remote, p=1).sum()
-                    skill_spec = _dist_allreduce_sum(skill_spec_local, ensemble_group)
-                    spread_spec = _dist_allreduce_sum(spread_spec_local, ensemble_group)
-                    spread_spec = spread_spec * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                    # Required to match non-distributed n==2 special case
-                    spec_denom = (
-                        b * t
-                        if self.n_members == 2
-                        else b * t * self.lmax * self.mmax
-                    )
-                    loss = loss + self.lambda_spec * self.averaging_coeff * (
-                        skill_mul * skill_spec - self.coeff_eps * spread_spec
-                    ) / spec_denom
-            return loss
+                if self.lambda_spec > 0:
+                    with th.amp.autocast("cuda", enabled=False):
+                        sht_pred = self._apply_sht(
+                            prediction, face_dim=2, return_abs=True
+                        ).permute(3, 0, 1, 2, 4, 5).reshape(c, n, -1)
+                        sht_tar = self._apply_sht(
+                            target, face_dim=1, return_abs=True
+                        ).permute(2, 0, 1, 3, 4).reshape(c, 1, -1)
+                        skill_spec_local = th.abs(sht_pred - sht_tar).sum(dim=(1, 2))
+                        spread_spec_local = sht_pred.new_zeros(c)
+                        for ci in range(c):
+                            local = sht_pred[ci]
+                            spread_spec_local[ci] += th.cdist(local, local, p=1).sum()
+                            remote = local
+                            for _ in range(ws - 1):
+                                remote = ring_exchange(remote, ensemble_group)
+                                spread_spec_local[ci] += th.cdist(local, remote, p=1).sum()
+                        local_loss = local_loss + self.lambda_spec * self.averaging_coeff * (
+                            skill_mul * skill_spec_local
+                            - self.coeff_eps * spread_spec_local
+                        ) / (b * t * self.lmax * self.mmax)
+            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             # Use faster explicit implementation
@@ -1167,11 +1056,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         else:
                             loss += self.multiscale * crps.mean(dim=(0, 1, 2, 4, 5))
                         
-            return _distributed_reduce_loss(
-                loss,
-                ensemble_group=ensemble_group,
-                enabled=distributed_loss,
-            )
+            return loss
         
         else:
             # Use pairwise distance method
@@ -1243,11 +1128,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
                         loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
 
-            return _distributed_reduce_loss(
-                loss,
-                ensemble_group=ensemble_group,
-                enabled=distributed_loss,
-            )
+            return loss
         
 
 class SpreadSkillRatioLoss(th.nn.MSELoss):
@@ -1563,61 +1444,35 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         )  # [Cond,B,F,T,C,H,W]
 
         if distributed_loss:
-            ws = dist.get_world_size(group=ensemble_group) if (ensemble_group is not None and dist.is_initialized()) else 1
-            skill_mul = _dist_ensemble_skill_prefactor(self.n_members)
-            if average_channels:
-                skill_local = diff_to_target.sum()
-
-                # spread: ordered member–member patch distances via ring exchange
-                spread_local = pred_patches.new_tensor(0.0)
-                # local-local block
+            _validate_distributed_members(
+                prediction=prediction,
+                n_members=self.n_members,
+                ensemble_group=ensemble_group,
+            )
+            ws = dist.get_world_size(group=ensemble_group)
+            skill_mul = 2 * (self.n_members - 1)
+            lsm = self.lsm_tensor
+            skill_local = (diff_to_target * lsm).sum(dim=(0, 1, 2, 3, 5, 6))
+            spread_local = pred_patches.new_zeros(c)
+            for i in range(n):
+                for j in range(n):
+                    spread_local = spread_local + (
+                        self._weighted_patch_norm(pred_patches[i] - pred_patches[j]) * lsm
+                    ).sum(dim=(0, 1, 2, 4, 5))
+            remote = pred_patches
+            for _ in range(ws - 1):
+                remote = ring_exchange(remote, ensemble_group)
                 for i in range(n):
                     for j in range(n):
-                        spread_local = spread_local + self._weighted_patch_norm(
-                            pred_patches[i] - pred_patches[j]
-                        ).sum()
-                remote = pred_patches
-                for _ in range(ws - 1):
-                    remote = _dist_ring_rotate(remote, ensemble_group)
-                    for i in range(n):
-                        for j in range(n):
-                            spread_local = spread_local + self._weighted_patch_norm(
-                                pred_patches[i] - remote[j]
-                            ).sum()
-
-                skill = _dist_allreduce_sum(skill_local, ensemble_group)
-                spread = _dist_allreduce_sum(spread_local, ensemble_group)
-                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                es = self.averaging_coeff * (
-                    skill_mul * skill - self.coeff_eps * spread
-                )
-                es = es / (b * f * t * c * h * w)
-                return es
-            else:
-                # diff_to_target: [Cond, B, F, T, C, H, W] — reduce to one value per channel
-                skill_local = diff_to_target.sum(dim=(0, 1, 2, 3, 5, 6))
-                spread_local = pred_patches.new_zeros(c)
-                for i in range(n):
-                    for j in range(n):
-                        spread_local = spread_local + self._weighted_patch_norm(
-                            pred_patches[i] - pred_patches[j]
+                        spread_local = spread_local + (
+                            self._weighted_patch_norm(pred_patches[i] - remote[j]) * lsm
                         ).sum(dim=(0, 1, 2, 4, 5))
-                remote = pred_patches
-                for _ in range(ws - 1):
-                    remote = _dist_ring_rotate(remote, ensemble_group)
-                    for i in range(n):
-                        for j in range(n):
-                            spread_local = spread_local + self._weighted_patch_norm(
-                                pred_patches[i] - remote[j]
-                            ).sum(dim=(0, 1, 2, 4, 5))
-
-                skill = _dist_allreduce_sum(skill_local, ensemble_group)
-                spread = _dist_allreduce_sum(spread_local, ensemble_group)
-                spread = spread * _dist_pairwise_duplicate_factor(ensemble_group, self.n_members)
-                es = self.averaging_coeff * (
-                    skill_mul * skill - self.coeff_eps * spread
-                ) / (b * f * t * h * w)
-                return es
+            channel_loss = self.averaging_coeff * (
+                skill_mul * skill_local - self.coeff_eps * spread_local
+            ) / (b * f * t * h * w)
+            channel_loss = channel_loss * self.loss_weights
+            local_loss = channel_loss.mean() if average_channels else channel_loss
+            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             diff_target = diff_to_target.sum(dim=0)  # [B,F,T,C,H,W]
@@ -1652,8 +1507,4 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         else:
             loss = es.mean(dim=(0, 1, 2, 4, 5))
 
-        return _distributed_reduce_loss(
-            loss,
-            ensemble_group=ensemble_group,
-            enabled=distributed_loss,
-        )
+        return loss

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -365,6 +365,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         selection_dict: dict = {"channel_c": "land_sea_mask"},
         multiscale: float = 0.0,
         masked_processing: bool = False,
+        distributed_ensemble_loss: bool = False,
+        ensemble_group=None,
     ):
         """
         Parameters
@@ -389,6 +391,10 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             weight for the multiscale CRPS loss. Default is 0, no multiscale loss is applied.
         masked_processing: bool, optional
             whether masked pixels should be excluded from the processing. Default is False, no masked processing is applied.
+        distributed_ensemble_loss: bool, optional
+            Enable member-sharded distributed loss mode. Default False.
+        ensemble_group: torch.distributed.ProcessGroup, optional
+            Process group used for ensemble-member collectives in distributed loss mode.
         """
         super().__init__()
         self.loss_weights = th.tensor(weights)
@@ -417,6 +423,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         # Diagonal elements of (prediciton - target) matrix are zeroed out to avoid double counting
         self.pdist = th.nn.PairwiseDistance(p=1)
         self.diag_mask = th.ones(self.n_members, self.n_members) - th.eye(self.n_members) # Mask to zero out diagonal elements
+        self.distributed_ensemble_loss = bool(distributed_ensemble_loss)
+        self.ensemble_group = ensemble_group
 
     def setup(self, trainer):
         """
@@ -432,6 +440,11 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         self.pdist = self.pdist.to(device=trainer.device)
         self.diag_mask = self.diag_mask.to(device=trainer.device)   
         self.lsm_tensor = self.lsm_tensor.to(device=trainer.device)
+        self.distributed_ensemble_loss = bool(
+            getattr(trainer, "distributed_ensemble_loss", self.distributed_ensemble_loss)
+            and getattr(trainer, "ensemble_sharding_enabled", False)
+        )
+        self.ensemble_group = getattr(trainer, "ensemble_group", self.ensemble_group)
 
     def _2member_crps(self, prediction, target, lsm_tensor):
         diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
@@ -478,7 +491,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
         pooled_tensor = pooled_values / (pooled_mask + 1e-8) # Avoid division by zero
         return pooled_tensor, pooled_mask
 
-    def forward(self, prediction, target, average_channels=True, **kwargs):
+    def forward(self, prediction, target, average_channels=True):
         """
         Forward pass of the WeightedCRPSLoss 
         Computes the CRPS loss for the model prediction and target.
@@ -491,20 +504,14 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             The target tensor shape [B, F, T, C, H, W]
         average_channels: bool, optional
             whether the mean of the channels should be taken
-        **kwargs
-            Optional distributed context from the training loop (e.g. NV-dlesm
-            ``Trainer._criterion_kwargs``): ``distributed_ensemble_loss`` (bool)
-            enables member-sharded CRPS with collectives over ``ensemble_group``
-            (``torch.distributed.ProcessGroup``). ``ensemble_group_size`` may
-            also be passed for symmetry but is unused here.
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
-        ensemble_group = kwargs.get("ensemble_group", None)
+        distributed_loss = self.distributed_ensemble_loss
+        ensemble_group = self.ensemble_group
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
@@ -727,6 +734,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         lsm_file: str = None,
         open_dict: dict = {"engine": "zarr"},
         selection_dict: dict = {"channel_c": "land_sea_mask"},
+        distributed_ensemble_loss: bool = False,
+        ensemble_group=None,
     ):
         """
         Parameters
@@ -754,6 +763,10 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             dictionary of keyword arguments for xarray.open_dataset. Default is {"engine": "zarr"}.
         selection_dict: dict
             dictionary of keyword arguments for xarray.open_dataset. Default is {"channel_c": "land_sea_mask"}.
+        distributed_ensemble_loss: bool, optional
+            Enable member-sharded distributed loss mode. Default False.
+        ensemble_group: torch.distributed.ProcessGroup, optional
+            Process group used for ensemble-member collectives in distributed loss mode.
         """
         super().__init__()
         self.loss_weights = th.tensor(weights)
@@ -791,6 +804,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         # Diagonal elements of (prediciton - target) matrix are zeroed out to avoid double counting
         self.pdist = th.nn.PairwiseDistance(p=1)
         self.diag_mask = th.ones(self.n_members, self.n_members) - th.eye(self.n_members) # Mask to zero out diagonal elements
+        self.distributed_ensemble_loss = bool(distributed_ensemble_loss)
+        self.ensemble_group = ensemble_group
 
 
     def setup(self, trainer):
@@ -814,6 +829,11 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             self.reorder_from_ring = self.reorder_from_ring.to(device=trainer.device)
         if self.lsm_file is not None:
             self.lsm_tensor = self.lsm_tensor.to(device=trainer.device)
+        self.distributed_ensemble_loss = bool(
+            getattr(trainer, "distributed_ensemble_loss", self.distributed_ensemble_loss)
+            and getattr(trainer, "ensemble_sharding_enabled", False)
+        )
+        self.ensemble_group = getattr(trainer, "ensemble_group", self.ensemble_group)
 
     def _apply_sht(self, x, face_dim, return_abs=True):
         """Apply SHT to a tensor
@@ -858,7 +878,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
         ell = th.arange(self.lmax, device=device, dtype=th.float32)
         return th.exp(-0.5* ell * (ell + 1) * (scale_radians ** 2))
 
-    def forward(self, prediction, target, average_channels=True, **kwargs):
+    def forward(self, prediction, target, average_channels=True):
         """
         Forward pass of the WeightedCRPSLossSpectral 
         Computes the CRPS loss for the model prediction and target.
@@ -871,20 +891,14 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             The target tensor shape [B, F, T, C, H, W]
         average_channels: bool, optional
             whether the mean of the channels should be taken
-        **kwargs
-            Optional distributed context from the training loop (e.g. NV-dlesm
-            ``Trainer._criterion_kwargs``): ``distributed_ensemble_loss`` (bool)
-            enables member-sharded CRPS with collectives over ``ensemble_group``
-            (``torch.distributed.ProcessGroup``). ``ensemble_group_size`` may
-            also be passed for symmetry but is unused here.
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
-        ensemble_group = kwargs.get("ensemble_group", None)
+        distributed_loss = self.distributed_ensemble_loss
+        ensemble_group = self.ensemble_group
 
         # checks for dimensions 
         if not prediction.shape[1:] == target.shape:
@@ -1243,6 +1257,8 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         use_earth2grid_padding: bool = True,
         enable_nhwc: bool = True,
         patch_weight_sigma: float = None,
+        distributed_ensemble_loss: bool = False,
+        ensemble_group=None,
     ):
         """
         Parameters
@@ -1270,6 +1286,10 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             Patch_weight_sigma is the standard deviation of the Gaussian.
             Patch_weight_sigma = 1 for standard normal distribution.
             If None, no spatial weighting within the patch (default).
+        distributed_ensemble_loss: bool, optional
+            Enable member-sharded distributed loss mode. Default False.
+        ensemble_group: torch.distributed.ProcessGroup, optional
+            Process group used for ensemble-member collectives in distributed loss mode.
         """
         super().__init__()
         if n_members < 2:
@@ -1320,6 +1340,8 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 )
         else:
             self.hpx_pad = None
+        self.distributed_ensemble_loss = bool(distributed_ensemble_loss)
+        self.ensemble_group = ensemble_group
 
     def setup(self, trainer):
         if len(trainer.output_variables) != len(self.loss_weights):
@@ -1334,6 +1356,11 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             self.hpx_pad = self.hpx_pad.to(device=trainer.device)
         if self.patch_weights is not None:
             self.patch_weights = self.patch_weights.to(device=trainer.device)
+        self.distributed_ensemble_loss = bool(
+            getattr(trainer, "distributed_ensemble_loss", self.distributed_ensemble_loss)
+            and getattr(trainer, "ensemble_sharding_enabled", False)
+        )
+        self.ensemble_group = getattr(trainer, "ensemble_group", self.ensemble_group)
 
     def _weighted_patch_norm(self, diff_vec: th.Tensor) -> th.Tensor:
         """
@@ -1399,23 +1426,18 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         patches = patches.permute(0, 2, 1, 3, 5, 6, 4)  # [B, F, T, C, H, W, D]
         return patches
 
-    def forward(self, prediction, target, average_channels: bool = True, **kwargs):
+    def forward(self, prediction, target, average_channels: bool = True):
         """
         Forward pass of the patched energy score loss.
 
         prediction: [Cond*B, F, T, C, H, W]
         target: [B, F, T, C, H, W]
-        **kwargs
-            Optional distributed context (e.g. NV-dlesm ``Trainer._criterion_kwargs``):
-            ``distributed_ensemble_loss`` and ``ensemble_group`` for member-sharded
-            energy score with ensemble-group collectives. ``ensemble_group_size`` may
-            be passed for symmetry but is unused here.
         """
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
-        ensemble_group = kwargs.get("ensemble_group", None)
+        distributed_loss = self.distributed_ensemble_loss
+        ensemble_group = self.ensemble_group
 
         if prediction.shape[1:] != target.shape:
             raise ValueError(

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -495,13 +495,19 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             The target tensor shape [B, F, T, C, H, W]
         average_channels: bool, optional
             whether the mean of the channels should be taken
+        **kwargs
+            Optional distributed context from the training loop (e.g. NV-dlesm
+            ``Trainer._criterion_kwargs``): ``distributed_ensemble_loss`` (bool)
+            enables member-sharded CRPS with collectives over ``ensemble_group``
+            (``torch.distributed.ProcessGroup``). ``ensemble_group_size`` may
+            also be passed for symmetry but is unused here.
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
         ensemble_group = kwargs.get("ensemble_group", None)
 
         # checks for dimensions 
@@ -512,26 +518,6 @@ class WeightedCRPSLoss(th.nn.MSELoss):
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
         if distributed_loss and n < 1:
             raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
-        # Avoid th.tensor/th.ones allocations here when using distributed exact loss:
-        # CUDA graph capture forbids creating new tensors during the captured region.
-        if not distributed_loss:
-            local_diag_mask = (
-                self.diag_mask if n == self.n_members else
-                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
-            )
-            local_coeff_eps = (
-                self.coeff_eps if n == self.n_members else
-                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
-            )
-            local_averaging_coeff = (
-                self.averaging_coeff
-                if n == self.n_members
-                else (
-                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
-                    if n > 1
-                    else th.tensor(0.0, device=prediction.device)
-                )
-            )
 
         # Manual Cast
         prediction = prediction.to(th.float32)
@@ -704,16 +690,16 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                 diff = self.pdist(prediction, target) # [C, Cond]
                 dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(2))  # [C, Cond, Cond]
                 
-                diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                crps = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/valid_pixels
+                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/valid_pixels
             else:
                 prediction = prediction.reshape(n, -1)
                 target = target.unsqueeze(0).reshape(1, -1) # [1, ...] (first dim will broadcast across ensemble)
                 diff = self.pdist(prediction, target) # [Cond]
                 dist_matrix = self.pdist(prediction.unsqueeze(1), prediction.unsqueeze(0))  # [Cond, Cond] 
 
-                diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                crps = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/valid_pixels
+                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                crps = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/valid_pixels
 
             return _distributed_reduce_loss(
                 crps + bias_penalty,
@@ -874,7 +860,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
     def forward(self, prediction, target, average_channels=True, **kwargs):
         """
-        Forward pass of the WeightedCRPSLoss 
+        Forward pass of the WeightedCRPSLossSpectral 
         Computes the CRPS loss for the model prediction and target.
 
         Parameters
@@ -885,13 +871,19 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             The target tensor shape [B, F, T, C, H, W]
         average_channels: bool, optional
             whether the mean of the channels should be taken
+        **kwargs
+            Optional distributed context from the training loop (e.g. NV-dlesm
+            ``Trainer._criterion_kwargs``): ``distributed_ensemble_loss`` (bool)
+            enables member-sharded CRPS with collectives over ``ensemble_group``
+            (``torch.distributed.ProcessGroup``). ``ensemble_group_size`` may
+            also be passed for symmetry but is unused here.
         """
         
         # Unfold ensemble dimension from batch dimension to have shape [Cond, B, F, T, C, H, W]
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
         ensemble_group = kwargs.get("ensemble_group", None)
 
         # checks for dimensions 
@@ -902,24 +894,6 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             raise ValueError(f"Shape of prediction should have ensemble dimension of size {self.n_members}, got {prediction.shape[0]}")
         if distributed_loss and n < 1:
             raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
-        if not distributed_loss:
-            local_diag_mask = (
-                self.diag_mask if n == self.n_members else
-                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
-            )
-            local_coeff_eps = (
-                self.coeff_eps if n == self.n_members else
-                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
-            )
-            local_averaging_coeff = (
-                self.averaging_coeff
-                if n == self.n_members
-                else (
-                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
-                    if n > 1
-                    else th.tensor(0.0, device=prediction.device)
-                )
-            )
 
         # Manual cast
         prediction = prediction.to(th.float32)
@@ -1002,7 +976,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             # Use faster explicit implementation
             diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
             diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-            crps = local_averaging_coeff*(diff_target - local_coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
             if average_channels:
                 loss = crps.mean()
@@ -1029,7 +1003,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                     diff_sht_target = th.abs(sht_pred - sht_tar.unsqueeze(0)).sum(dim=(0, 4, 5)) # [B, T, C]
                     diff_sht_ensemble = th.abs(sht_pred[0] - sht_pred[1]).sum(dim=(-1,-2)) # [B, T, C] 
-                    crps_sht = local_averaging_coeff * (diff_sht_target - local_coeff_eps * diff_sht_ensemble) # [B, T, C]
+                    crps_sht = self.averaging_coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble) # [B, T, C]
 
                     # Compute spectral afCRPS
                     if average_channels:
@@ -1054,7 +1028,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                         diff_target = th.abs(pred_smooth - tar_smooth.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
                         diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
-                        crps = local_averaging_coeff*(diff_target - local_coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+                        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
 
                         crps *= self.lsm_tensor
 
@@ -1082,8 +1056,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 diff = self.pdist(pred, tar) # [C, Cond]
                 dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(2))  # [C, Cond, Cond]
                 
-                diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                loss = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
+                diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*f*t*h*w)
 
                 if self.lambda_spec > 0:
                     with th.cuda.amp.autocast(enabled=False):
@@ -1105,8 +1079,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff = self.pdist(sht_pred, sht_tar) # [C, Cond]
                         dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(2))  # [C, Cond, Cond]
                         
-                        diff_terms = local_diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
-                        loss += self.lambda_spec * local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum(dim=(1,2))/(b*t*self.lmax*self.mmax)
+                        diff_terms = self.diag_mask[None, ...] * (diff.unsqueeze(1) + diff.unsqueeze(2)) # [C, Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum(dim=(1,2))/(b*t*self.lmax*self.mmax)
 
             else:
                 pred = prediction.reshape(n, -1)
@@ -1114,8 +1088,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                 diff = self.pdist(pred, tar) # [Cond]
                 dist_matrix = self.pdist(pred.unsqueeze(1), pred.unsqueeze(0))  # [Cond, Cond] 
 
-                diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                loss = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
+                diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                loss = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*f*c*t*h*w)
 
                 if self.lambda_spec > 0:
                     with th.cuda.amp.autocast(enabled=False):
@@ -1136,8 +1110,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                         diff = self.pdist(sht_pred, sht_tar) # [Cond]
                         dist_matrix = self.pdist(sht_pred.unsqueeze(1), sht_pred.unsqueeze(0))  # [Cond, Cond] 
                         
-                        diff_terms = local_diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
-                        loss += self.lambda_spec * local_averaging_coeff * (diff_terms - local_coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
+                        diff_terms = self.diag_mask * (diff.unsqueeze(0) + diff.unsqueeze(1)) # [Cond, Cond], diagonal elements zeroed out
+                        loss += self.lambda_spec * self.averaging_coeff * (diff_terms - self.coeff_eps * dist_matrix).sum()/(b*t*self.lmax*self.mmax)
 
             return _distributed_reduce_loss(
                 loss,
@@ -1418,11 +1392,16 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
 
         prediction: [Cond*B, F, T, C, H, W]
         target: [B, F, T, C, H, W]
+        **kwargs
+            Optional distributed context (e.g. NV-dlesm ``Trainer._criterion_kwargs``):
+            ``distributed_ensemble_loss`` and ``ensemble_group`` for member-sharded
+            energy score with ensemble-group collectives. ``ensemble_group_size`` may
+            be passed for symmetry but is unused here.
         """
         b, f, t, c, h, w = target.shape
         n = prediction.shape[0] // b
         prediction = prediction.view(n, b, f, t, c, h, w)
-        distributed_loss = bool(kwargs.get("loss_distributed", False))
+        distributed_loss = bool(kwargs.get("distributed_ensemble_loss", False))
         ensemble_group = kwargs.get("ensemble_group", None)
 
         if prediction.shape[1:] != target.shape:
@@ -1438,24 +1417,6 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             )
         if distributed_loss and n < 1:
             raise ValueError(f"Distributed loss needs local members >= 1, got {n}")
-        if not distributed_loss:
-            local_diag_mask = (
-                self.diag_mask if n == self.n_members else
-                (th.ones(n, n, device=prediction.device) - th.eye(n, device=prediction.device))
-            )
-            local_coeff_eps = (
-                self.coeff_eps if n == self.n_members else
-                th.tensor(1 - ((1 - self.alpha) / n), device=prediction.device)
-            )
-            local_averaging_coeff = (
-                self.averaging_coeff
-                if n == self.n_members
-                else (
-                    th.tensor(1 / (2 * n * (n - 1)), device=prediction.device)
-                    if n > 1
-                    else th.tensor(0.0, device=prediction.device)
-                )
-            )
 
         prediction = prediction.to(th.float32)
         target = target.to(th.float32)
@@ -1527,7 +1488,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             diff_ensemble = self._weighted_patch_norm(
                 pred_patches[0] - pred_patches[1]
             )  # [B,F,T,C,H,W]
-            es = local_averaging_coeff * (diff_target - local_coeff_eps * diff_ensemble)
+            es = self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
         else:
             diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
             diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
@@ -1537,11 +1498,11 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             pred_j = pred_patches.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W,D]
             dist_ensemble = self._weighted_patch_norm(pred_i - pred_j)  # [Cond,Cond,B,F,T,C,H,W]
 
-            mask = local_diag_mask[:, :, None, None, None, None, None, None]
+            mask = self.diag_mask[:, :, None, None, None, None, None, None]
             diff_terms = mask * (diff_i_i + diff_j_i)
             dist_terms = mask * dist_ensemble
 
-            es = local_averaging_coeff * (diff_terms - local_coeff_eps * dist_terms).sum(
+            es = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_terms).sum(
                 dim=(0, 1)
             )  # [B,F,T,C,H,W]
 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -64,8 +64,15 @@ def _validate_distributed_members(
         )
 
 
-def _distributed_value_from_local(local_value: th.Tensor, ensemble_group=None):
-    """Return global summed value while keeping local gradient flow."""
+def _allreduce_sum_with_local_grad(local_value: th.Tensor, ensemble_group=None):
+    """
+    All-reduce local scalar/tensor by sum while preserving local backward path.
+
+    In distributed ensemble-loss mode, each rank computes a local contribution.
+    This helper returns the total loss value as the sum of the local contributions,
+    but keeps gradients flowing only through the local tensor by using a detached
+    all-reduced copy in the forward value.
+    """
     if ensemble_group is None or not dist.is_initialized():
         return local_value
     value = local_value.detach().clone()
@@ -611,7 +618,7 @@ class WeightedCRPSLoss(th.nn.MSELoss):
                         (prediction.sum(dim=(0, 1, 2, 3, 5, 6)) / prediction_count)
                         - (target.sum(dim=(0, 1, 2, 4, 5)) / target_count)
                     )
-            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
+            return _allreduce_sum_with_local_grad(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             # Use faster explicit implementation
@@ -1003,7 +1010,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
                             skill_mul * skill_spec_local
                             - self.coeff_eps * spread_spec_local
                         ) / (b * t * self.lmax * self.mmax)
-            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
+            return _allreduce_sum_with_local_grad(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             # Use faster explicit implementation
@@ -1494,7 +1501,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             ) / (b * f * t * h * w)
             channel_loss = channel_loss * self.loss_weights
             local_loss = channel_loss.mean() if average_channels else channel_loss
-            return _distributed_value_from_local(local_loss, ensemble_group=ensemble_group)
+            return _allreduce_sum_with_local_grad(local_loss, ensemble_group=ensemble_group)
 
         if n == 2:
             diff_target = diff_to_target.sum(dim=0)  # [B,F,T,C,H,W]

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -735,7 +735,10 @@ def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
 # Mode B — Sharded, gathered loss: ensemble members are split across processes; each rank
 #   holds a local shard. Predictions are all_gather'd along the member dimension, then
 #   the same non-distributed loss runs on the full tensor (simulates "gather then one-GPU
-#   loss" without changing the loss code path to distributed).
+#   loss" without changing the loss code path to distributed). To ensure that gradient
+#   updates are the same whether we use ensemble sharding or not, parameter gradients are
+#   all-reduced with ``ReduceOp.AVG`` over the world group (same as ``loss / world_size``
+#   then ``ReduceOp.SUM`` on gradients since loss is the same for all ranks).
 #
 # Mode C — Sharded, distributed loss: each rank keeps its shard; the loss uses
 #   ``distributed_ensemble_loss=True`` and ensemble-group collectives (including a ring
@@ -1118,11 +1121,19 @@ def _optimizer_step_all_modes(
         target,
         average_channels=True,
     )
-    gather_loss = gather_loss / world_size
+    assert torch.allclose(
+        ref_loss.detach(),
+        gather_loss.detach(),
+        rtol=1e-4,
+        atol=1e-4,
+    ), (
+        f"rank {dist.get_rank()}: Gathered loss does not match reference "
+        f"loss: {ref_loss.detach()} vs {gather_loss.detach()}"
+    )
     gather_loss.sum().backward()
     for param in model_gather.parameters():
         if param.grad is not None:
-            dist.all_reduce(param.grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+            dist.all_reduce(param.grad, op=dist.ReduceOp.AVG, group=dist.group.WORLD)
     opt_gather.step()
 
     opt_dist.zero_grad(set_to_none=True)
@@ -1134,6 +1145,15 @@ def _optimizer_step_all_modes(
         pred_loc_dist,
         target,
         average_channels=True,
+    )
+    assert torch.allclose(
+        ref_loss.detach(),
+        dist_loss.detach(),
+        rtol=1e-4,
+        atol=1e-4,
+    ), (
+        f"rank {dist.get_rank()}: Loss from distributed ensemble does not match reference "
+        f"loss: {ref_loss.detach()} vs {dist_loss.detach()}"
     )
     dist_loss.sum().backward()
     for param in model_dist.parameters():

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 import torch
 import torch.distributed as dist
+import torch.distributed.nn.functional as dist_nn_func
 import torch.multiprocessing as mp
 from pytest_utils import import_or_fail, nfsdata_or_fail
 
@@ -1175,14 +1176,17 @@ def _build_shared_model_inputs(rank: int, n_members: int, b: int, c: int, device
     return base, target, noise
 
 
-def _assert_model_grads_close(model_ref, model_dist, rank: int, rtol=1e-4, atol=1e-4):
+def _assert_model_grads_close(
+    model_ref, model_dist, rank: int, rtol=1e-4, atol=1e-4, reduce_dist_grads: bool = True
+):
     for (name_ref, p_ref), (name_dist, p_dist) in zip(
         model_ref.named_parameters(), model_dist.named_parameters()
     ):
         assert name_ref == name_dist
         assert p_ref.grad is not None and p_dist.grad is not None
         dist_grad = p_dist.grad.detach().clone()
-        dist.all_reduce(dist_grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+        if reduce_dist_grads:
+            dist.all_reduce(dist_grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
         assert torch.allclose(p_ref.grad, dist_grad, rtol=rtol, atol=atol), (
             f"rank {rank}: parameter grad mismatch for {name_ref}, "
             f"max_abs_diff={(p_ref.grad - dist_grad).abs().max().item()}"
@@ -1210,6 +1214,8 @@ def _crps_weight_grad_worker(
         torch.manual_seed(991)
         model_ref = _NoisyEnsembleModel(channels=c).to(device)
         torch.manual_seed(991)
+        model_gather = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(991)
         model_dist = _NoisyEnsembleModel(channels=c).to(device)
 
         loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
@@ -1225,15 +1231,33 @@ def _crps_weight_grad_worker(
         )
         ref_loss.sum().backward()
 
-        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
+        pred_gather = torch.cat(
+            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
+        )
+        gather_loss = loss_fn(
+            pred_gather,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        gather_loss = gather_loss / world_size
+        gather_loss.sum().backward()
+
+        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
         dist_loss = loss_fn(
-            pred_loc,
+            pred_loc_dist,
             target,
             average_channels=average_channels,
             distributed_ensemble_loss=True,
             ensemble_group=dist.group.WORLD,
         )
         dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
         _assert_model_grads_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
@@ -1261,6 +1285,8 @@ def _spectral_weight_grad_worker(
         torch.manual_seed(992)
         model_ref = _NoisyEnsembleModel(channels=c).to(device)
         torch.manual_seed(992)
+        model_gather = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(992)
         model_dist = _NoisyEnsembleModel(channels=c).to(device)
 
         loss_fn = WeightedCRPSLossSpectral(
@@ -1283,15 +1309,33 @@ def _spectral_weight_grad_worker(
         )
         ref_loss.sum().backward()
 
-        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
+        pred_gather = torch.cat(
+            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
+        )
+        gather_loss = loss_fn(
+            pred_gather,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        gather_loss = gather_loss / world_size
+        gather_loss.sum().backward()
+
+        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
         dist_loss = loss_fn(
-            pred_loc,
+            pred_loc_dist,
             target,
             average_channels=average_channels,
             distributed_ensemble_loss=True,
             ensemble_group=dist.group.WORLD,
         )
         dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
         _assert_model_grads_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
@@ -1318,6 +1362,8 @@ def _energy_weight_grad_worker(
         torch.manual_seed(993)
         model_ref = _NoisyEnsembleModel(channels=c).to(device)
         torch.manual_seed(993)
+        model_gather = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(993)
         model_dist = _NoisyEnsembleModel(channels=c).to(device)
 
         loss_fn = PatchedEnergyScoreLoss(
@@ -1335,15 +1381,33 @@ def _energy_weight_grad_worker(
         )
         ref_loss.sum().backward()
 
-        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
+        pred_gather = torch.cat(
+            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
+        )
+        gather_loss = loss_fn(
+            pred_gather,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        gather_loss = gather_loss / world_size
+        gather_loss.sum().backward()
+
+        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
+            local_members * b, 12, 2, c, 32, 32
+        )
         dist_loss = loss_fn(
-            pred_loc,
+            pred_loc_dist,
             target,
             average_channels=average_channels,
             distributed_ensemble_loss=True,
             ensemble_group=dist.group.WORLD,
         )
         dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
         _assert_model_grads_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
@@ -1353,7 +1417,7 @@ def _energy_weight_grad_worker(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLoss_distributed_model_weight_grads_match_gathered(
+def test_WeightedCRPSLoss_model_weight_grads_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:
@@ -1373,7 +1437,7 @@ def test_WeightedCRPSLoss_distributed_model_weight_grads_match_gathered(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLossSpectral_distributed_model_weight_grads_match_gathered(
+def test_WeightedCRPSLossSpectral_model_weight_grads_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:
@@ -1393,7 +1457,7 @@ def test_WeightedCRPSLossSpectral_distributed_model_weight_grads_match_gathered(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_PatchedEnergyScoreLoss_distributed_model_weight_grads_match_gathered(
+def test_PatchedEnergyScoreLoss_model_weight_grads_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -66,6 +66,10 @@ class trainer_helper:
 
     output_variables: Sequence
     device: str
+    distributed_ensemble_loss: bool = False
+    ensemble_group_size: int = 1
+    ensemble_group: object = None
+    ensemble_sharding_enabled: bool = False
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
@@ -549,7 +553,7 @@ def test_WeightedCRPSLoss_shape_checks():
     loss_fn_bad_members = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=3)
     loss_fn_bad_members.setup(trainer)
     with pytest.raises(ValueError):
-        loss_fn_bad_members(pred, tar, average_channels=True, distributed_ensemble_loss=False)
+        loss_fn_bad_members(pred, tar, average_channels=True)
 
 
 def test_WeightedCRPSLossSpectral_apply_sht_face_dim_validation_cpu():
@@ -720,6 +724,24 @@ def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
     assert torch.isfinite(out)
 
 
+# --- Ensemble / distributed loss equivalence (multi-GPU) ---------------------------------
+#
+# We compare three operational modes. Outputs (forward tests) and parameter updates
+# (weight-update tests) should agree across them where applicable.
+#
+# Mode A — Unsharded: all ensemble members on one process/GPU; loss is computed locally
+#   in non-distributed mode (full prediction tensor, ``distributed_ensemble_loss=False``).
+#
+# Mode B — Sharded, gathered loss: ensemble members are split across processes; each rank
+#   holds a local shard. Predictions are all_gather'd along the member dimension, then
+#   the same non-distributed loss runs on the full tensor (simulates "gather then one-GPU
+#   loss" without changing the loss code path to distributed).
+#
+# Mode C — Sharded, distributed loss: each rank keeps its shard; the loss uses
+#   ``distributed_ensemble_loss=True`` and ensemble-group collectives (including a ring
+#   exchange) so the result matches the global ensemble objective.
+
+
 def _require_distributed_cuda(world_size: int):
     if not torch.cuda.is_available():
         pytest.skip("CUDA required for distributed probabilistic GPU tests")
@@ -772,31 +794,53 @@ def _crps_dist_matches_gathered_worker(
         )
 
         loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         local_members = n_members // world_size
         start = rank * local_members
         stop = start + local_members
         local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
+        # Mode C: sharded members, distributed loss (ring / ensemble collectives)
         dist_loss = loss_fn(
             local,
             target,
             average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
         )
+        # Mode B: sharded members, all_gather full prediction, then non-distributed loss
+        gathered = torch.cat(
+            list(dist_nn_func.all_gather(local, group=dist.group.WORLD)), dim=0
+        )
+        loss_fn.distributed_ensemble_loss = False
+        gather_loss = loss_fn(
+            gathered,
+            target,
+            average_channels=average_channels,
+        )
+        # Mode A: unsharded (full member dim on one rank; reference)
         if rank == 0:
             pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
                 average_channels=average_channels,
-                distributed_ensemble_loss=False,
             )
         else:
             ref = torch.zeros_like(dist_loss)
         dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            gather_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: gather_loss={gather_loss} ref={ref}"
         assert torch.allclose(
             dist_loss,
             ref,
@@ -838,31 +882,53 @@ def _spectral_crps_dist_matches_gathered_worker(
             lmax=lmax,
             mmax=mmax,
         )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         local_members = n_members // world_size
         start = rank * local_members
         stop = start + local_members
         local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
+        # Mode C: sharded, distributed loss
         dist_loss = loss_fn(
             local,
             target,
             average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
         )
+        # Mode B: sharded, gather then non-distributed loss
+        gathered = torch.cat(
+            list(dist_nn_func.all_gather(local, group=dist.group.WORLD)), dim=0
+        )
+        loss_fn.distributed_ensemble_loss = False
+        gather_loss = loss_fn(
+            gathered,
+            target,
+            average_channels=average_channels,
+        )
+        # Mode A: unsharded reference
         if rank == 0:
             pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
                 average_channels=average_channels,
-                distributed_ensemble_loss=False,
             )
         else:
             ref = torch.zeros_like(dist_loss)
         dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            gather_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: gather_loss={gather_loss} ref={ref}"
         assert torch.allclose(
             dist_loss,
             ref,
@@ -899,244 +965,59 @@ def _energy_dist_matches_gathered_worker(
             patch_size=3,
             enable_nhwc=False,
         )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         local_members = n_members // world_size
         start = rank * local_members
         stop = start + local_members
         local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
+        # Mode C: sharded, distributed loss
         dist_loss = loss_fn(
             local,
             target,
             average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
         )
+        # Mode B: sharded, gather then non-distributed loss
+        gathered = torch.cat(
+            list(dist_nn_func.all_gather(local, group=dist.group.WORLD)), dim=0
+        )
+        loss_fn.distributed_ensemble_loss = False
+        gather_loss = loss_fn(
+            gathered,
+            target,
+            average_channels=average_channels,
+        )
+        # Mode A: unsharded reference
         if rank == 0:
             pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
                 average_channels=average_channels,
-                distributed_ensemble_loss=False,
             )
         else:
             ref = torch.zeros_like(dist_loss)
         dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            gather_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: gather_loss={gather_loss} ref={ref}"
         assert torch.allclose(
             dist_loss,
             ref,
             rtol=1e-4,
             atol=1e-4,
         ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
-    finally:
-        dist.destroy_process_group()
-
-
-def _crps_dist_backward_matches_gathered_worker(
-    rank: int,
-    world_size: int,
-    n_members: int,
-    init_file: str,
-    average_channels: bool,
-    batch_size: int,
-):
-    _init_cuda_process_group(rank, world_size, init_file)
-    device = f"cuda:{rank}"
-    try:
-        torch.manual_seed(2025)
-        b = batch_size
-        f, t, c, h, w = 12, 2, 2, 32, 32
-        target, pred_all = _build_shared_random_tensors(
-            rank,
-            (b, f, t, c, h, w),
-            (n_members, b, f, t, c, h, w),
-        )
-
-        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
-        loss_fn.setup(trainer)
-        local_members = n_members // world_size
-        start = rank * local_members
-        stop = start + local_members
-
-        pred_ref = (
-            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        )
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        ref_loss.sum().backward()
-        grad_ref_shard = (
-            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
-            .contiguous()
-            .reshape(local_members * b, f, t, c, h, w)
-        )
-
-        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        dist_loss = loss_fn(
-            pred_loc,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        grad_loc = pred_loc.grad
-
-        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
-        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
-        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
-            f"rank {rank}: grad mismatch vs gathered reference, "
-            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
-        )
-    finally:
-        dist.destroy_process_group()
-
-
-def _spectral_crps_dist_backward_matches_gathered_worker(
-    rank: int,
-    world_size: int,
-    n_members: int,
-    init_file: str,
-    average_channels: bool,
-    batch_size: int,
-    lambda_spec: float,
-):
-    _init_cuda_process_group(rank, world_size, init_file)
-    device = f"cuda:{rank}"
-    try:
-        torch.manual_seed(2025)
-        b = batch_size
-        f, t, c, h, w = 12, 2, 2, 32, 32
-        nside = 32
-        lmax = mmax = 3 * nside - 1
-        target, pred_all = _build_shared_random_tensors(
-            rank,
-            (b, f, t, c, h, w),
-            (n_members, b, f, t, c, h, w),
-        )
-
-        loss_fn = WeightedCRPSLossSpectral(
-            weights=[1.0, 1.0],
-            n_members=n_members,
-            lambda_spec=lambda_spec,
-            nside=nside,
-            lmax=lmax,
-            mmax=mmax,
-        )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
-        loss_fn.setup(trainer)
-
-        local_members = n_members // world_size
-        start = rank * local_members
-        stop = start + local_members
-        pred_ref = (
-            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        )
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        ref_loss.sum().backward()
-        grad_ref_shard = (
-            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
-            .contiguous()
-            .reshape(local_members * b, f, t, c, h, w)
-        )
-
-        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        dist_loss = loss_fn(
-            pred_loc,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        grad_loc = pred_loc.grad
-
-        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
-        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
-        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
-            f"rank {rank}: spectral grad mismatch vs gathered reference, "
-            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
-        )
-    finally:
-        dist.destroy_process_group()
-
-
-def _energy_dist_backward_matches_gathered_worker(
-    rank: int,
-    world_size: int,
-    n_members: int,
-    init_file: str,
-    average_channels: bool,
-    batch_size: int,
-):
-    _init_cuda_process_group(rank, world_size, init_file)
-    device = f"cuda:{rank}"
-    try:
-        torch.manual_seed(4242)
-        b = batch_size
-        f, t, c, h, w = 12, 2, 2, 32, 32
-        target, pred_all = _build_shared_random_tensors(
-            rank,
-            (b, f, t, c, h, w),
-            (n_members, b, f, t, c, h, w),
-        )
-
-        loss_fn = PatchedEnergyScoreLoss(
-            weights=[1.0, 1.0],
-            n_members=n_members,
-            patch_size=3,
-            enable_nhwc=False,
-        )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
-        loss_fn.setup(trainer)
-
-        local_members = n_members // world_size
-        start = rank * local_members
-        stop = start + local_members
-        pred_ref = (
-            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        )
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        ref_loss.sum().backward()
-        grad_ref_shard = (
-            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
-            .contiguous()
-            .reshape(local_members * b, f, t, c, h, w)
-        )
-
-        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
-        dist_loss = loss_fn(
-            pred_loc,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        grad_loc = pred_loc.grad
-
-        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
-        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
-        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
-            f"rank {rank}: energy-score grad mismatch vs gathered reference, "
-            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
-        )
     finally:
         dist.destroy_process_group()
 
@@ -1202,9 +1083,9 @@ def _optimizer_step_all_modes(
     noise: torch.Tensor,
     start: int,
     stop: int,
-    average_channels: bool,
     world_size: int,
 ):
+    """One optimizer step each for Mode A, Mode B, and Mode C; always ``average_channels=True``."""
     b = base.shape[0]
     c = base.shape[3]
     local_members = stop - start
@@ -1215,11 +1096,11 @@ def _optimizer_step_all_modes(
 
     opt_ref.zero_grad(set_to_none=True)
     pred_ref = model_ref(base, noise).reshape(noise.shape[0] * b, 12, 2, c, 32, 32)
+    loss_fn.distributed_ensemble_loss = False
     ref_loss = loss_fn(
         pred_ref,
         target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=False,
+        average_channels=True,
     )
     ref_loss.sum().backward()
     opt_ref.step()
@@ -1231,11 +1112,11 @@ def _optimizer_step_all_modes(
     pred_gather = torch.cat(
         list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
     )
+    loss_fn.distributed_ensemble_loss = False
     gather_loss = loss_fn(
         pred_gather,
         target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=False,
+        average_channels=True,
     )
     gather_loss = gather_loss / world_size
     gather_loss.sum().backward()
@@ -1248,12 +1129,11 @@ def _optimizer_step_all_modes(
     pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
         local_members * b, 12, 2, c, 32, 32
     )
+    loss_fn.distributed_ensemble_loss = True
     dist_loss = loss_fn(
         pred_loc_dist,
         target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=True,
-        ensemble_group=dist.group.WORLD,
+        average_channels=True,
     )
     dist_loss.sum().backward()
     for param in model_dist.parameters():
@@ -1267,7 +1147,6 @@ def _crps_weight_update_worker(
     world_size: int,
     n_members: int,
     init_file: str,
-    average_channels: bool,
     batch_size: int,
 ):
     _init_cuda_process_group(rank, world_size, init_file)
@@ -1288,7 +1167,14 @@ def _crps_weight_update_worker(
         model_dist = _NoisyEnsembleModel(channels=c).to(device)
 
         loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         _optimizer_step_all_modes(
@@ -1301,7 +1187,6 @@ def _crps_weight_update_worker(
             noise=noise,
             start=start,
             stop=stop,
-            average_channels=average_channels,
             world_size=world_size,
         )
         _assert_model_params_close(
@@ -1317,7 +1202,6 @@ def _spectral_weight_update_worker(
     world_size: int,
     n_members: int,
     init_file: str,
-    average_channels: bool,
     batch_size: int,
 ):
     _init_cuda_process_group(rank, world_size, init_file)
@@ -1346,7 +1230,14 @@ def _spectral_weight_update_worker(
             lmax=3 * nside - 1,
             mmax=3 * nside - 1,
         )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         _optimizer_step_all_modes(
@@ -1359,7 +1250,6 @@ def _spectral_weight_update_worker(
             noise=noise,
             start=start,
             stop=stop,
-            average_channels=average_channels,
             world_size=world_size,
         )
         _assert_model_params_close(
@@ -1375,7 +1265,6 @@ def _energy_weight_update_worker(
     world_size: int,
     n_members: int,
     init_file: str,
-    average_channels: bool,
     batch_size: int,
 ):
     _init_cuda_process_group(rank, world_size, init_file)
@@ -1398,7 +1287,14 @@ def _energy_weight_update_worker(
         loss_fn = PatchedEnergyScoreLoss(
             weights=[1.0, 1.0], n_members=n_members, patch_size=3, enable_nhwc=False
         )
-        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        trainer = trainer_helper(
+            output_variables=["v0", "v1"],
+            device=device,
+            distributed_ensemble_loss=True,
+            ensemble_group_size=world_size,
+            ensemble_group=dist.group.WORLD,
+            ensemble_sharding_enabled=True,
+        )
         loss_fn.setup(trainer)
 
         _optimizer_step_all_modes(
@@ -1411,7 +1307,6 @@ def _energy_weight_update_worker(
             noise=noise,
             start=start,
             stop=stop,
-            average_channels=average_channels,
             world_size=world_size,
         )
         _assert_model_params_close(
@@ -1422,13 +1317,13 @@ def _energy_weight_update_worker(
         dist.destroy_process_group()
 
 
-@pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
 def test_WeightedCRPSLoss_model_weight_updates_match_across_ensemble_modes(
-    average_channels: bool, batch_size: int, world_size: int, n_members: int
+    batch_size: int, world_size: int, n_members: int
 ):
+    """Mode A vs B vs C: parameter updates match; loss always ``average_channels=True`` (scalar training objective). See module docstring above for mode definitions."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1436,19 +1331,19 @@ def test_WeightedCRPSLoss_model_weight_updates_match_across_ensemble_modes(
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _crps_weight_update_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, batch_size),
             nprocs=world_size,
             join=True,
         )
 
 
-@pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
 def test_WeightedCRPSLossSpectral_model_weight_updates_match_across_ensemble_modes(
-    average_channels: bool, batch_size: int, world_size: int, n_members: int
+    batch_size: int, world_size: int, n_members: int
 ):
+    """Mode A vs B vs C: parameter updates match; loss always ``average_channels=True``. See module docstring for modes."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1456,19 +1351,19 @@ def test_WeightedCRPSLossSpectral_model_weight_updates_match_across_ensemble_mod
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _spectral_weight_update_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, batch_size),
             nprocs=world_size,
             join=True,
         )
 
 
-@pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
 def test_PatchedEnergyScoreLoss_model_weight_updates_match_across_ensemble_modes(
-    average_channels: bool, batch_size: int, world_size: int, n_members: int
+    batch_size: int, world_size: int, n_members: int
 ):
+    """Mode A vs B vs C: parameter updates match; loss always ``average_channels=True``. See module docstring for modes."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1476,7 +1371,7 @@ def test_PatchedEnergyScoreLoss_model_weight_updates_match_across_ensemble_modes
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _energy_weight_update_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, batch_size),
             nprocs=world_size,
             join=True,
         )
@@ -1486,12 +1381,14 @@ def test_PatchedEnergyScoreLoss_model_weight_updates_match_across_ensemble_modes
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
+def test_WeightedCRPSLoss_forward_matches_across_ensemble_modes(
     average_channels: bool,
     batch_size: int,
     world_size: int,
     n_members: int,
 ):
+    """Mode A, B, C forward outputs match. Parametrized on ``average_channels`` (True: scalar
+    like training loss, False: per-channel like validation logging). See module docstring."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1510,13 +1407,14 @@ def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
 @pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
-def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
+def test_WeightedCRPSLossSpectral_forward_matches_across_ensemble_modes(
     average_channels: bool,
     batch_size: int,
     world_size: int,
     n_members: int,
     lambda_spec: float,
 ):
+    """Mode A, B, C forward outputs match; both ``average_channels`` values. See module docstring."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1534,12 +1432,13 @@ def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
+def test_PatchedEnergyScoreLoss_forward_matches_across_ensemble_modes(
     average_channels: bool,
     batch_size: int,
     world_size: int,
     n_members: int,
 ):
+    """Mode A, B, C forward outputs match; both ``average_channels`` values. See module docstring."""
     if n_members % world_size != 0:
         pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
@@ -1552,73 +1451,3 @@ def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
             join=True,
         )
 
-
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("world_size", [2, 4])
-@pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLoss_distributed_backward_matches_gathered_ensemble(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-    n_members: int,
-):
-    if n_members % world_size != 0:
-        pytest.skip("n_members must be divisible by world_size")
-    _require_distributed_cuda(world_size)
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _crps_dist_backward_matches_gathered_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size),
-            nprocs=world_size,
-            join=True,
-        )
-
-
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("world_size", [2, 4])
-@pytest.mark.parametrize("n_members", [4, 8])
-@pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
-def test_WeightedCRPSLossSpectral_distributed_backward_matches_gathered_ensemble(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-    n_members: int,
-    lambda_spec: float,
-):
-    if n_members % world_size != 0:
-        pytest.skip("n_members must be divisible by world_size")
-    _require_distributed_cuda(world_size)
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _spectral_crps_dist_backward_matches_gathered_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size, lambda_spec),
-            nprocs=world_size,
-            join=True,
-        )
-
-
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 2])
-@pytest.mark.parametrize("world_size", [2, 4])
-@pytest.mark.parametrize("n_members", [4, 8])
-def test_PatchedEnergyScoreLoss_distributed_backward_matches_gathered_ensemble(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-    n_members: int,
-):
-    if n_members % world_size != 0:
-        pytest.skip("n_members must be divisible by world_size")
-    _require_distributed_cuda(world_size)
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _energy_dist_backward_matches_gathered_worker,
-            args=(world_size, n_members, tmp.name, average_channels, batch_size),
-            nprocs=world_size,
-            join=True,
-        )

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -548,7 +548,7 @@ def test_WeightedCRPSLoss_shape_checks():
     loss_fn_bad_members = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=3)
     loss_fn_bad_members.setup(trainer)
     with pytest.raises(ValueError):
-        loss_fn_bad_members(pred, tar, average_channels=True, loss_distributed=False)
+        loss_fn_bad_members(pred, tar, average_channels=True, distributed_ensemble_loss=False)
 
 
 def test_WeightedCRPSLossSpectral_apply_sht_face_dim_validation_cpu():
@@ -605,7 +605,7 @@ def test_WeightedCRPSLoss_distributed_exact_matches_single_rank(average_channels
 
     # Simulate n=1 local shard with world_size=1 by passing distributed flag.
     local_pred = pred_members[:1].reshape(b, f, t, c, h, w)
-    got = loss_fn(local_pred, target, average_channels=average_channels, loss_distributed=True)
+    got = loss_fn(local_pred, target, average_channels=average_channels, distributed_ensemble_loss=True)
     assert torch.isfinite(got).all()
     assert got.shape == ref.shape
 
@@ -631,7 +631,7 @@ def _dist_crps_worker(rank: int, world_size: int, init_file: str):
         prediction_local,
         target,
         average_channels=True,
-        loss_distributed=True,
+        distributed_ensemble_loss=True,
         ensemble_group=dist.group.WORLD,
     )
     gathered = [torch.zeros_like(dist_loss) for _ in range(world_size)]
@@ -659,11 +659,9 @@ def test_PatchedEnergyScoreLoss_distributed_exact_equivalence():
         weights=[1.0, 1.0],
         n_members=n_members,
         patch_size=3,
-        hpx_padding_mode="karlbauer",
         enable_nhwc=False,
-        nside=64,
     )
     trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
     loss_fn.setup(trainer)
-    out = loss_fn(local_pred, target, average_channels=True, loss_distributed=True)
+    out = loss_fn(local_pred, target, average_channels=True, distributed_ensemble_loss=True)
     assert torch.isfinite(out)

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -643,10 +643,320 @@ def _dist_crps_worker(rank: int, world_size: int, init_file: str):
     dist.destroy_process_group()
 
 
+def _crps_dist_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    """Compare member-sharded loss to ``all_gather``+concat baseline (single-process full ensemble)."""
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.manual_seed(2025)
+    b = batch_size
+    f, t, c, h, w = 8, 2, 2, 32, 32
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+
+    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    local = pred_all[rank].reshape(b, f, t, c, h, w)
+    gathered = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local, group=dist.group.WORLD)
+    pred_full = torch.cat(gathered, dim=0)
+    ref = loss_fn(
+        pred_full,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=False,
+    )
+
+    dist_loss = loss_fn(
+        local,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=True,
+        ensemble_group=dist.group.WORLD,
+    )
+    assert torch.allclose(
+        dist_loss,
+        ref,
+        rtol=1e-4,
+        atol=1e-4,
+    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+
+    dist.destroy_process_group()
+
+
+def _spectral_crps_dist_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    """Same as ``_crps_dist_matches_gathered_worker`` for ``WeightedCRPSLossSpectral`` (``lambda_spec=0``)."""
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.manual_seed(2025)
+    b = batch_size
+    f, t, c, h, w = 12, 2, 2, 32, 32
+    nside = 32
+    lmax = mmax = 3 * nside - 1
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=world_size,
+        lambda_spec=0.0,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    local = pred_all[rank].reshape(b, f, t, c, h, w)
+    gathered = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local, group=dist.group.WORLD)
+    pred_full = torch.cat(gathered, dim=0)
+    ref = loss_fn(
+        pred_full,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=False,
+    )
+
+    dist_loss = loss_fn(
+        local,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=True,
+        ensemble_group=dist.group.WORLD,
+    )
+    assert torch.allclose(
+        dist_loss,
+        ref,
+        rtol=1e-4,
+        atol=1e-4,
+    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+
+    dist.destroy_process_group()
+
+
+def _energy_dist_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.manual_seed(4242)
+    b = batch_size
+    # f must be 12 for HEALPix face layout used by patch extraction / padding.
+    f, t, c, h, w = 12, 2, 2, 32, 32
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+
+    loss_fn = PatchedEnergyScoreLoss(
+        weights=[1.0, 1.0],
+        n_members=world_size,
+        patch_size=3,
+        enable_nhwc=False,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    local = pred_all[rank].reshape(b, f, t, c, h, w)
+    gathered = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local, group=dist.group.WORLD)
+    pred_full = torch.cat(gathered, dim=0)
+    ref = loss_fn(
+        pred_full,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=False,
+    )
+
+    dist_loss = loss_fn(
+        local,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=True,
+        ensemble_group=dist.group.WORLD,
+    )
+    assert torch.allclose(
+        dist_loss,
+        ref,
+        rtol=1e-4,
+        atol=1e-4,
+    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+
+    dist.destroy_process_group()
+
+
 def test_WeightedCRPSLoss_distributed_exact_equivalence():
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(_dist_crps_worker, args=(2, tmp.name), nprocs=2, join=True)
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [2, 3])
+def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Distributed shards vs ``all_gather``+concat reference (one member per rank).
+
+    For ``n_members == 2`` the implementation must use
+    ``_dist_ensemble_skill_prefactor`` and the scalar ``valid_px_avg`` fix so the
+    ring path matches ``_2member_crps`` (see ``healpix_loss._dist_ensemble_skill_prefactor``).
+    """
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _crps_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [4])
+def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble_slow(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Same as ``test_WeightedCRPSLoss_distributed_matches_gathered_ensemble`` with four ranks."""
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _crps_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [2, 3])
+def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Same gather equivalence as CRPS for patched energy score."""
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _energy_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [4])
+def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble_slow(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Same as ``test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble`` with four ranks."""
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _energy_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+def _require_weighted_crps_loss_spectral_cpu():
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=2,
+        lambda_spec=0.0,
+        nside=32,
+        lmax=3 * 32 - 1,
+        mmax=3 * 32 - 1,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    try:
+        loss_fn.setup(trainer)
+    except Exception as exc:
+        pytest.skip(f"Spectral setup unavailable in current env: {exc}")
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [2, 3])
+def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Gather equivalence for spectral CRPS with ``lambda_spec=0`` (spatial term only)."""
+    _require_weighted_crps_loss_spectral_cpu()
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _spectral_crps_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("world_size", [4])
+def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble_slow(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    """Same as ``test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble`` with four ranks."""
+    _require_weighted_crps_loss_spectral_cpu()
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _spectral_crps_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
 
 
 def test_PatchedEnergyScoreLoss_distributed_exact_equivalence():

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -753,6 +753,7 @@ def _build_shared_random_tensors(rank: int, shape_target, shape_pred):
 def _crps_dist_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -766,14 +767,17 @@ def _crps_dist_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
-        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
         dist_loss = loss_fn(
             local,
             target,
@@ -782,7 +786,7 @@ def _crps_dist_matches_gathered_worker(
             ensemble_group=dist.group.WORLD,
         )
         if rank == 0:
-            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
@@ -805,6 +809,7 @@ def _crps_dist_matches_gathered_worker(
 def _spectral_crps_dist_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -821,12 +826,12 @@ def _spectral_crps_dist_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
         loss_fn = WeightedCRPSLossSpectral(
             weights=[1.0, 1.0],
-            n_members=world_size,
+            n_members=n_members,
             lambda_spec=lambda_spec,
             nside=nside,
             lmax=lmax,
@@ -835,7 +840,10 @@ def _spectral_crps_dist_matches_gathered_worker(
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
         dist_loss = loss_fn(
             local,
             target,
@@ -844,7 +852,7 @@ def _spectral_crps_dist_matches_gathered_worker(
             ensemble_group=dist.group.WORLD,
         )
         if rank == 0:
-            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
@@ -867,6 +875,7 @@ def _spectral_crps_dist_matches_gathered_worker(
 def _energy_dist_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -880,19 +889,22 @@ def _energy_dist_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
         loss_fn = PatchedEnergyScoreLoss(
             weights=[1.0, 1.0],
-            n_members=world_size,
+            n_members=n_members,
             patch_size=3,
             enable_nhwc=False,
         )
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        local = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w)
         dist_loss = loss_fn(
             local,
             target,
@@ -901,7 +913,7 @@ def _energy_dist_matches_gathered_worker(
             ensemble_group=dist.group.WORLD,
         )
         if rank == 0:
-            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            pred_full = pred_all.reshape(n_members * b, f, t, c, h, w)
             ref = loss_fn(
                 pred_full,
                 target,
@@ -924,6 +936,7 @@ def _energy_dist_matches_gathered_worker(
 def _crps_dist_backward_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -937,15 +950,18 @@ def _crps_dist_backward_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
-        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
 
         pred_ref = (
-            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
         )
         ref_loss = loss_fn(
             pred_ref,
@@ -954,11 +970,13 @@ def _crps_dist_backward_matches_gathered_worker(
             distributed_ensemble_loss=False,
         )
         ref_loss.sum().backward()
-        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
-            rank
-        ].contiguous()
+        grad_ref_shard = (
+            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
+            .contiguous()
+            .reshape(local_members * b, f, t, c, h, w)
+        )
 
-        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
         dist_loss = loss_fn(
             pred_loc,
             target,
@@ -982,6 +1000,7 @@ def _crps_dist_backward_matches_gathered_worker(
 def _spectral_crps_dist_backward_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -998,12 +1017,12 @@ def _spectral_crps_dist_backward_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
         loss_fn = WeightedCRPSLossSpectral(
             weights=[1.0, 1.0],
-            n_members=world_size,
+            n_members=n_members,
             lambda_spec=lambda_spec,
             nside=nside,
             lmax=lmax,
@@ -1012,8 +1031,11 @@ def _spectral_crps_dist_backward_matches_gathered_worker(
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
         pred_ref = (
-            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
         )
         ref_loss = loss_fn(
             pred_ref,
@@ -1022,11 +1044,13 @@ def _spectral_crps_dist_backward_matches_gathered_worker(
             distributed_ensemble_loss=False,
         )
         ref_loss.sum().backward()
-        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
-            rank
-        ].contiguous()
+        grad_ref_shard = (
+            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
+            .contiguous()
+            .reshape(local_members * b, f, t, c, h, w)
+        )
 
-        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
         dist_loss = loss_fn(
             pred_loc,
             target,
@@ -1050,6 +1074,7 @@ def _spectral_crps_dist_backward_matches_gathered_worker(
 def _energy_dist_backward_matches_gathered_worker(
     rank: int,
     world_size: int,
+    n_members: int,
     init_file: str,
     average_channels: bool,
     batch_size: int,
@@ -1063,20 +1088,23 @@ def _energy_dist_backward_matches_gathered_worker(
         target, pred_all = _build_shared_random_tensors(
             rank,
             (b, f, t, c, h, w),
-            (world_size, b, f, t, c, h, w),
+            (n_members, b, f, t, c, h, w),
         )
 
         loss_fn = PatchedEnergyScoreLoss(
             weights=[1.0, 1.0],
-            n_members=world_size,
+            n_members=n_members,
             patch_size=3,
             enable_nhwc=False,
         )
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
         pred_ref = (
-            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+            pred_all.reshape(n_members * b, f, t, c, h, w).clone().requires_grad_(True)
         )
         ref_loss = loss_fn(
             pred_ref,
@@ -1085,11 +1113,13 @@ def _energy_dist_backward_matches_gathered_worker(
             distributed_ensemble_loss=False,
         )
         ref_loss.sum().backward()
-        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
-            rank
-        ].contiguous()
+        grad_ref_shard = (
+            pred_ref.grad.view(n_members, b, f, t, c, h, w)[start:stop]
+            .contiguous()
+            .reshape(local_members * b, f, t, c, h, w)
+        )
 
-        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        pred_loc = pred_all[start:stop].reshape(local_members * b, f, t, c, h, w).clone().requires_grad_(True)
         dist_loss = loss_fn(
             pred_loc,
             target,
@@ -1110,20 +1140,293 @@ def _energy_dist_backward_matches_gathered_worker(
         dist.destroy_process_group()
 
 
+class _NoisyEnsembleModel(torch.nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.randn(channels))
+        self.bias = torch.nn.Parameter(torch.randn(channels))
+        self.noise_scale = torch.nn.Parameter(torch.randn(channels))
+
+    def forward(self, base: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+        # base: [B,F,T,C,H,W], noise: [M,B,C]
+        base_term = (
+            base.unsqueeze(0) * self.scale[None, None, None, None, :, None, None]
+            + self.bias[None, None, None, None, :, None, None]
+        )
+        noise_term = noise[:, :, None, None, :, None, None] * self.noise_scale[
+            None, None, None, None, :, None, None
+        ]
+        return base_term + noise_term
+
+
+def _build_shared_model_inputs(rank: int, n_members: int, b: int, c: int, device: str):
+    f, t, h, w = 12, 2, 32, 32
+    if rank == 0:
+        base = torch.randn(b, f, t, c, h, w, dtype=torch.float32, device=device)
+        target = torch.randn(b, f, t, c, h, w, dtype=torch.float32, device=device)
+        noise = torch.randn(n_members, b, c, dtype=torch.float32, device=device)
+    else:
+        base = torch.zeros(b, f, t, c, h, w, dtype=torch.float32, device=device)
+        target = torch.zeros(b, f, t, c, h, w, dtype=torch.float32, device=device)
+        noise = torch.zeros(n_members, b, c, dtype=torch.float32, device=device)
+    dist.broadcast(base, src=0, group=dist.group.WORLD)
+    dist.broadcast(target, src=0, group=dist.group.WORLD)
+    dist.broadcast(noise, src=0, group=dist.group.WORLD)
+    return base, target, noise
+
+
+def _assert_model_grads_close(model_ref, model_dist, rank: int, rtol=1e-4, atol=1e-4):
+    for (name_ref, p_ref), (name_dist, p_dist) in zip(
+        model_ref.named_parameters(), model_dist.named_parameters()
+    ):
+        assert name_ref == name_dist
+        assert p_ref.grad is not None and p_dist.grad is not None
+        dist_grad = p_dist.grad.detach().clone()
+        dist.all_reduce(dist_grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+        assert torch.allclose(p_ref.grad, dist_grad, rtol=rtol, atol=atol), (
+            f"rank {rank}: parameter grad mismatch for {name_ref}, "
+            f"max_abs_diff={(p_ref.grad - dist_grad).abs().max().item()}"
+        )
+
+
+def _crps_weight_grad_worker(
+    rank: int,
+    world_size: int,
+    n_members: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(3001)
+        b, c = batch_size, 2
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        base, target, noise = _build_shared_model_inputs(rank, n_members, b, c, device)
+
+        torch.manual_seed(991)
+        model_ref = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(991)
+        model_dist = _NoisyEnsembleModel(channels=c).to(device)
+
+        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
+        ref_loss = loss_fn(
+            pred_ref,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        ref_loss.sum().backward()
+
+        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+    finally:
+        dist.destroy_process_group()
+
+
+def _spectral_weight_grad_worker(
+    rank: int,
+    world_size: int,
+    n_members: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(3002)
+        b, c = batch_size, 2
+        nside = 32
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        base, target, noise = _build_shared_model_inputs(rank, n_members, b, c, device)
+
+        torch.manual_seed(992)
+        model_ref = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(992)
+        model_dist = _NoisyEnsembleModel(channels=c).to(device)
+
+        loss_fn = WeightedCRPSLossSpectral(
+            weights=[1.0, 1.0],
+            n_members=n_members,
+            lambda_spec=0.3,
+            nside=nside,
+            lmax=3 * nside - 1,
+            mmax=3 * nside - 1,
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
+        ref_loss = loss_fn(
+            pred_ref,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        ref_loss.sum().backward()
+
+        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+    finally:
+        dist.destroy_process_group()
+
+
+def _energy_weight_grad_worker(
+    rank: int,
+    world_size: int,
+    n_members: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(3003)
+        b, c = batch_size, 2
+        local_members = n_members // world_size
+        start = rank * local_members
+        stop = start + local_members
+        base, target, noise = _build_shared_model_inputs(rank, n_members, b, c, device)
+
+        torch.manual_seed(993)
+        model_ref = _NoisyEnsembleModel(channels=c).to(device)
+        torch.manual_seed(993)
+        model_dist = _NoisyEnsembleModel(channels=c).to(device)
+
+        loss_fn = PatchedEnergyScoreLoss(
+            weights=[1.0, 1.0], n_members=n_members, patch_size=3, enable_nhwc=False
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
+        ref_loss = loss_fn(
+            pred_ref,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        ref_loss.sum().backward()
+
+        pred_loc = model_dist(base, noise[start:stop]).reshape(local_members * b, 12, 2, c, 32, 32)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+    finally:
+        dist.destroy_process_group()
+
+
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
+def test_WeightedCRPSLoss_distributed_model_weight_grads_match_gathered(
+    average_channels: bool, batch_size: int, world_size: int, n_members: int
+):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _crps_weight_grad_worker,
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
+def test_WeightedCRPSLossSpectral_distributed_model_weight_grads_match_gathered(
+    average_channels: bool, batch_size: int, world_size: int, n_members: int
+):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _spectral_weight_grad_worker,
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
+def test_PatchedEnergyScoreLoss_distributed_model_weight_grads_match_gathered(
+    average_channels: bool, batch_size: int, world_size: int, n_members: int
+):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _energy_weight_grad_worker,
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _crps_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
         )
@@ -1132,19 +1435,23 @@ def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 @pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
 def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
     lambda_spec: float,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _spectral_crps_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size, lambda_spec),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size, lambda_spec),
             nprocs=world_size,
             join=True,
         )
@@ -1153,17 +1460,21 @@ def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _energy_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
         )
@@ -1172,17 +1483,21 @@ def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 def test_WeightedCRPSLoss_distributed_backward_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _crps_dist_backward_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
         )
@@ -1191,19 +1506,23 @@ def test_WeightedCRPSLoss_distributed_backward_matches_gathered_ensemble(
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 @pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
 def test_WeightedCRPSLossSpectral_distributed_backward_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
     lambda_spec: float,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _spectral_crps_dist_backward_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size, lambda_spec),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size, lambda_spec),
             nprocs=world_size,
             join=True,
         )
@@ -1212,17 +1531,21 @@ def test_WeightedCRPSLossSpectral_distributed_backward_matches_gathered_ensemble
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("n_members", [4, 8])
 def test_PatchedEnergyScoreLoss_distributed_backward_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
+    n_members: int,
 ):
+    if n_members % world_size != 0:
+        pytest.skip("n_members must be divisible by world_size")
     _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
             _energy_dist_backward_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
+            args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
         )

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -459,7 +459,7 @@ def test_WeightedOceanMSE(
 @pytest.mark.parametrize("enable_nhwc", [True, False])
 @pytest.mark.parametrize("patch_weight_sigma", [None, 1.0])
 def test_PatchedEnergyScoreLoss_two_members_zero_and_symmetry(device, patch_size, use_earth2grid_padding, enable_nhwc, patch_weight_sigma):
-    # Small toy data: B=1,F=1,T=1,C=2,H=4,W=4
+    # Small toy data: B=1,F=12,T=1,C=2,H=4,W=4
     b, f, t, c, h, w = 2, 12, 4, 4, 64, 64
     n_members = 2
     weights = [1.0] * c
@@ -571,6 +571,135 @@ def test_WeightedCRPSLossSpectral_apply_sht_face_dim_validation_cpu():
         loss_fn._apply_sht(x, face_dim=3, return_abs=True)
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="lambda_spec>0 spectral CRPS needs CUDA/SHTCUDA",
+)
+def test_WeightedCRPSLossSpectral_lambda_nonzero_cuda_smoke():
+    # Basic GPU smoke test for lambda_spec > 0 branch (spectral term active).
+    device = "cuda:0"
+    b, f, t, c, h, w = 1, 12, 1, 2, 32, 32
+    n_members = 2
+    nside = 32
+    lmax = mmax = 3 * nside - 1
+
+    target = torch.randn(b, f, t, c, h, w, device=device, dtype=torch.float32)
+    pred_members = torch.randn(
+        n_members, b, f, t, c, h, w, device=device, dtype=torch.float32
+    )
+    prediction = pred_members.reshape(n_members * b, f, t, c, h, w)
+
+    loss_fn_lambda0 = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        lambda_spec=0.0,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+    loss_fn_lambda_nonzero = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        lambda_spec=0.3,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+
+    trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+    loss_fn_lambda0.setup(trainer)
+    loss_fn_lambda_nonzero.setup(trainer)
+
+    out0 = loss_fn_lambda0(prediction, target, average_channels=True)
+    out1 = loss_fn_lambda_nonzero(prediction, target, average_channels=True)
+
+    assert torch.isfinite(out0)
+    assert torch.isfinite(out1)
+    # Non-zero lambda_spec should change the total loss compared to lambda_spec == 0
+    assert not torch.allclose(out0, out1)
+
+
+def test_WeightedCRPSLossSpectral_two_members_zero_lambda0_cpu():
+    b, f, t, c, h, w = 2, 12, 2, 2, 32, 32
+    n_members = 2
+    nside = 32
+    lmax = mmax = 3 * nside - 1
+
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    prediction = target.repeat(n_members, 1, 1, 1, 1, 1).reshape(
+        n_members * b, f, t, c, h, w
+    )
+
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        lambda_spec=0.0,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    loss = loss_fn(prediction, target, average_channels=True)
+    assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+def test_WeightedCRPSLossSpectral_three_members_zero_lambda0_cpu():
+    b, f, t, c, h, w = 2, 12, 2, 2, 32, 32
+    n_members = 3
+    nside = 32
+    lmax = mmax = 3 * nside - 1
+
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    prediction = target.repeat(n_members, 1, 1, 1, 1, 1).reshape(
+        n_members * b, f, t, c, h, w
+    )
+
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        lambda_spec=0.0,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    loss = loss_fn(prediction, target, average_channels=True)
+    assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="lambda_spec>0 spectral CRPS needs CUDA/SHTCUDA",
+)
+def test_WeightedCRPSLossSpectral_two_members_zero_lambda_nonzero_cuda():
+    device = "cuda:0"
+    b, f, t, c, h, w = 2, 12, 2, 2, 32, 32
+    n_members = 2
+    nside = 32
+    lmax = mmax = 3 * nside - 1
+
+    target = torch.randn(b, f, t, c, h, w, device=device, dtype=torch.float32)
+    prediction = target.repeat(n_members, 1, 1, 1, 1, 1).reshape(
+        n_members * b, f, t, c, h, w
+    )
+
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        lambda_spec=0.3,
+        nside=nside,
+        lmax=lmax,
+        mmax=mmax,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+    loss_fn.setup(trainer)
+
+    loss = loss_fn(prediction, target, average_channels=True)
+    assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-6)
+
+
 def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
     pred, tar = _small_hpx_case(device="cpu", n_members=2)
     loss_fn = WeightedCRPSLossSpectral(
@@ -590,57 +719,35 @@ def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
     assert torch.isfinite(out)
 
 
-@pytest.mark.parametrize("average_channels", [True, False])
-def test_WeightedCRPSLoss_distributed_matches_single_rank(average_channels: bool):
-    b, f, t, c, h, w = 2, 12, 2, 2, 64, 64
-    n_members = 2
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_members = torch.randn(n_members, b, f, t, c, h, w, dtype=torch.float32)
-    prediction = pred_members.reshape(n_members * b, f, t, c, h, w)
-
-    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
-    ref = loss_fn(prediction, target, average_channels=average_channels)
-
-    # Simulate n=1 local shard with world_size=1 by passing distributed flag.
-    local_pred = pred_members[:1].reshape(b, f, t, c, h, w)
-    got = loss_fn(local_pred, target, average_channels=average_channels, distributed_ensemble_loss=True)
-    assert torch.isfinite(got).all()
-    assert got.shape == ref.shape
+def _require_distributed_cuda(world_size: int):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for distributed probabilistic GPU tests")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(
+            f"Need at least {world_size} GPUs, found {torch.cuda.device_count()}"
+        )
 
 
-def _dist_crps_worker(rank: int, world_size: int, init_file: str):
+def _init_cuda_process_group(rank: int, world_size: int, init_file: str):
+    torch.cuda.set_device(rank)
     dist.init_process_group(
-        backend="gloo",
+        backend="nccl",
         init_method=f"file://{init_file}",
         rank=rank,
         world_size=world_size,
     )
-    torch.manual_seed(123)
-    b, f, t, c, h, w = 1, 12, 1, 2, 64, 64
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
-    prediction_local = pred_all[rank].reshape(b, f, t, c, h, w)
 
-    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
 
-    dist_loss = loss_fn(
-        prediction_local,
-        target,
-        average_channels=True,
-        distributed_ensemble_loss=True,
-        ensemble_group=dist.group.WORLD,
-    )
-    gathered = [torch.zeros_like(dist_loss) for _ in range(world_size)]
-    dist.all_gather(gathered, dist_loss, group=dist.group.WORLD)
-    assert torch.isfinite(dist_loss)
-    for other in gathered:
-        assert torch.isfinite(other)
-        assert torch.allclose(dist_loss, other, rtol=1e-4, atol=1e-4)
-    dist.destroy_process_group()
+def _build_shared_random_tensors(rank: int, shape_target, shape_pred):
+    if rank == 0:
+        target = torch.randn(*shape_target, dtype=torch.float32, device=f"cuda:{rank}")
+        pred_all = torch.randn(*shape_pred, dtype=torch.float32, device=f"cuda:{rank}")
+    else:
+        target = torch.zeros(*shape_target, dtype=torch.float32, device=f"cuda:{rank}")
+        pred_all = torch.zeros(*shape_pred, dtype=torch.float32, device=f"cuda:{rank}")
+    dist.broadcast(target, src=0, group=dist.group.WORLD)
+    dist.broadcast(pred_all, src=0, group=dist.group.WORLD)
+    return target, pred_all
 
 
 def _crps_dist_matches_gathered_worker(
@@ -650,50 +757,49 @@ def _crps_dist_matches_gathered_worker(
     average_channels: bool,
     batch_size: int,
 ):
-    """Compare member-sharded loss to ``all_gather``+concat baseline (single-process full ensemble)."""
-    dist.init_process_group(
-        backend="gloo",
-        init_method=f"file://{init_file}",
-        rank=rank,
-        world_size=world_size,
-    )
-    torch.manual_seed(2025)
-    b = batch_size
-    f, t, c, h, w = 8, 2, 2, 32, 32
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(2025)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
 
-    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
+        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
 
-    local = pred_all[rank].reshape(b, f, t, c, h, w)
-    dist_loss = loss_fn(
-        local,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=True,
-        ensemble_group=dist.group.WORLD,
-    )
-    if rank == 0:
-        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
-        ref = loss_fn(
-            pred_full,
+        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        dist_loss = loss_fn(
+            local,
             target,
             average_channels=average_channels,
-            distributed_ensemble_loss=False,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
         )
-    else:
-        ref = torch.zeros_like(dist_loss)
-    dist.broadcast(ref, src=0, group=dist.group.WORLD)
-    assert torch.allclose(
-        dist_loss,
-        ref,
-        rtol=1e-4,
-        atol=1e-4,
-    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
-
-    dist.destroy_process_group()
+        if rank == 0:
+            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            ref = loss_fn(
+                pred_full,
+                target,
+                average_channels=average_channels,
+                distributed_ensemble_loss=False,
+            )
+        else:
+            ref = torch.zeros_like(dist_loss)
+        dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            dist_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+    finally:
+        dist.destroy_process_group()
 
 
 def _spectral_crps_dist_matches_gathered_worker(
@@ -702,60 +808,60 @@ def _spectral_crps_dist_matches_gathered_worker(
     init_file: str,
     average_channels: bool,
     batch_size: int,
+    lambda_spec: float,
 ):
-    """Same as ``_crps_dist_matches_gathered_worker`` for ``WeightedCRPSLossSpectral`` (``lambda_spec=0``)."""
-    dist.init_process_group(
-        backend="gloo",
-        init_method=f"file://{init_file}",
-        rank=rank,
-        world_size=world_size,
-    )
-    torch.manual_seed(2025)
-    b = batch_size
-    f, t, c, h, w = 12, 2, 2, 32, 32
-    nside = 32
-    lmax = mmax = 3 * nside - 1
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(2025)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        nside = 32
+        lmax = mmax = 3 * nside - 1
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
 
-    loss_fn = WeightedCRPSLossSpectral(
-        weights=[1.0, 1.0],
-        n_members=world_size,
-        lambda_spec=0.0,
-        nside=nside,
-        lmax=lmax,
-        mmax=mmax,
-    )
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
+        loss_fn = WeightedCRPSLossSpectral(
+            weights=[1.0, 1.0],
+            n_members=world_size,
+            lambda_spec=lambda_spec,
+            nside=nside,
+            lmax=lmax,
+            mmax=mmax,
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
 
-    local = pred_all[rank].reshape(b, f, t, c, h, w)
-    dist_loss = loss_fn(
-        local,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=True,
-        ensemble_group=dist.group.WORLD,
-    )
-    if rank == 0:
-        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
-        ref = loss_fn(
-            pred_full,
+        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        dist_loss = loss_fn(
+            local,
             target,
             average_channels=average_channels,
-            distributed_ensemble_loss=False,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
         )
-    else:
-        ref = torch.zeros_like(dist_loss)
-    dist.broadcast(ref, src=0, group=dist.group.WORLD)
-    assert torch.allclose(
-        dist_loss,
-        ref,
-        rtol=1e-4,
-        atol=1e-4,
-    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
-
-    dist.destroy_process_group()
+        if rank == 0:
+            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            ref = loss_fn(
+                pred_full,
+                target,
+                average_channels=average_channels,
+                distributed_ensemble_loss=False,
+            )
+        else:
+            ref = torch.zeros_like(dist_loss)
+        dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            dist_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+    finally:
+        dist.destroy_process_group()
 
 
 def _energy_dist_matches_gathered_worker(
@@ -765,77 +871,254 @@ def _energy_dist_matches_gathered_worker(
     average_channels: bool,
     batch_size: int,
 ):
-    dist.init_process_group(
-        backend="gloo",
-        init_method=f"file://{init_file}",
-        rank=rank,
-        world_size=world_size,
-    )
-    torch.manual_seed(4242)
-    b = batch_size
-    # f must be 12 for HEALPix face layout used by patch extraction / padding.
-    f, t, c, h, w = 12, 2, 2, 32, 32
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(4242)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
 
-    loss_fn = PatchedEnergyScoreLoss(
-        weights=[1.0, 1.0],
-        n_members=world_size,
-        patch_size=3,
-        enable_nhwc=False,
-    )
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
+        loss_fn = PatchedEnergyScoreLoss(
+            weights=[1.0, 1.0],
+            n_members=world_size,
+            patch_size=3,
+            enable_nhwc=False,
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
 
-    local = pred_all[rank].reshape(b, f, t, c, h, w)
-    dist_loss = loss_fn(
-        local,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=True,
-        ensemble_group=dist.group.WORLD,
-    )
-    if rank == 0:
-        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
-        ref = loss_fn(
-            pred_full,
+        local = pred_all[rank].reshape(b, f, t, c, h, w)
+        dist_loss = loss_fn(
+            local,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        if rank == 0:
+            pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+            ref = loss_fn(
+                pred_full,
+                target,
+                average_channels=average_channels,
+                distributed_ensemble_loss=False,
+            )
+        else:
+            ref = torch.zeros_like(dist_loss)
+        dist.broadcast(ref, src=0, group=dist.group.WORLD)
+        assert torch.allclose(
+            dist_loss,
+            ref,
+            rtol=1e-4,
+            atol=1e-4,
+        ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+    finally:
+        dist.destroy_process_group()
+
+
+def _crps_dist_backward_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(2025)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
+
+        loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = (
+            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+        )
+        ref_loss = loss_fn(
+            pred_ref,
             target,
             average_channels=average_channels,
             distributed_ensemble_loss=False,
         )
-    else:
-        ref = torch.zeros_like(dist_loss)
-    dist.broadcast(ref, src=0, group=dist.group.WORLD)
-    assert torch.allclose(
-        dist_loss,
-        ref,
-        rtol=1e-4,
-        atol=1e-4,
-    ), f"rank {rank}: dist_loss={dist_loss} ref={ref}"
+        ref_loss.sum().backward()
+        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
+            rank
+        ].contiguous()
 
-    dist.destroy_process_group()
+        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        grad_loc = pred_loc.grad
+
+        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
+        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
+        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
+            f"rank {rank}: grad mismatch vs gathered reference, "
+            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
+        )
+    finally:
+        dist.destroy_process_group()
 
 
-def test_WeightedCRPSLoss_distributed_equivalence():
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(_dist_crps_worker, args=(2, tmp.name), nprocs=2, join=True)
+def _spectral_crps_dist_backward_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+    lambda_spec: float,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(2025)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        nside = 32
+        lmax = mmax = 3 * nside - 1
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
+
+        loss_fn = WeightedCRPSLossSpectral(
+            weights=[1.0, 1.0],
+            n_members=world_size,
+            lambda_spec=lambda_spec,
+            nside=nside,
+            lmax=lmax,
+            mmax=mmax,
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = (
+            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+        )
+        ref_loss = loss_fn(
+            pred_ref,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        ref_loss.sum().backward()
+        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
+            rank
+        ].contiguous()
+
+        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        grad_loc = pred_loc.grad
+
+        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
+        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
+        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
+            f"rank {rank}: spectral grad mismatch vs gathered reference, "
+            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+def _energy_dist_backward_matches_gathered_worker(
+    rank: int,
+    world_size: int,
+    init_file: str,
+    average_channels: bool,
+    batch_size: int,
+):
+    _init_cuda_process_group(rank, world_size, init_file)
+    device = f"cuda:{rank}"
+    try:
+        torch.manual_seed(4242)
+        b = batch_size
+        f, t, c, h, w = 12, 2, 2, 32, 32
+        target, pred_all = _build_shared_random_tensors(
+            rank,
+            (b, f, t, c, h, w),
+            (world_size, b, f, t, c, h, w),
+        )
+
+        loss_fn = PatchedEnergyScoreLoss(
+            weights=[1.0, 1.0],
+            n_members=world_size,
+            patch_size=3,
+            enable_nhwc=False,
+        )
+        trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
+        loss_fn.setup(trainer)
+
+        pred_ref = (
+            pred_all.reshape(world_size * b, f, t, c, h, w).clone().requires_grad_(True)
+        )
+        ref_loss = loss_fn(
+            pred_ref,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+        ref_loss.sum().backward()
+        grad_ref_shard = pred_ref.grad.view(world_size, b, f, t, c, h, w)[
+            rank
+        ].contiguous()
+
+        pred_loc = pred_all[rank].clone().requires_grad_(True)
+        dist_loss = loss_fn(
+            pred_loc,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=True,
+            ensemble_group=dist.group.WORLD,
+        )
+        dist_loss.sum().backward()
+        grad_loc = pred_loc.grad
+
+        assert torch.isfinite(grad_ref_shard).all(), f"rank {rank}: non-finite ref grad"
+        assert torch.isfinite(grad_loc).all(), f"rank {rank}: non-finite dist grad"
+        assert torch.allclose(grad_ref_shard, grad_loc, rtol=1e-4, atol=1e-4), (
+            f"rank {rank}: energy-score grad mismatch vs gathered reference, "
+            f"max_abs_diff={(grad_ref_shard - grad_loc).abs().max().item()}"
+        )
+    finally:
+        dist.destroy_process_group()
 
 
 @pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3, 4])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
 def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
 ):
-    """Distributed shards vs gathered reference.
-
-    For ``n_members == 2`` the implementation must use
-    ``_dist_ensemble_skill_prefactor`` and the scalar ``valid_px_avg`` fix so the
-    ring path matches ``_2member_crps`` (see ``healpix_loss._dist_ensemble_skill_prefactor``).
-    """
+    _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
@@ -847,14 +1130,35 @@ def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
 
 
 @pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3, 4])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
+def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+    lambda_spec: float,
+):
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _spectral_crps_dist_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size, lambda_spec),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
 def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
 ):
-    """Same gather equivalence as CRPS for patched energy score."""
+    _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
@@ -865,55 +1169,60 @@ def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
         )
 
 
-def _require_weighted_crps_loss_spectral_cpu():
-    loss_fn = WeightedCRPSLossSpectral(
-        weights=[1.0, 1.0],
-        n_members=2,
-        lambda_spec=0.0,
-        nside=32,
-        lmax=3 * 32 - 1,
-        mmax=3 * 32 - 1,
-    )
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    try:
-        loss_fn.setup(trainer)
-    except Exception as exc:
-        pytest.skip(f"Spectral setup unavailable in current env: {exc}")
-
-
 @pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3, 4])
-def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_WeightedCRPSLoss_distributed_backward_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
 ):
-    """Gather equivalence for spectral CRPS with ``lambda_spec=0`` (spatial term only)."""
-    _require_weighted_crps_loss_spectral_cpu()
+    _require_distributed_cuda(world_size)
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
-            _spectral_crps_dist_matches_gathered_worker,
+            _crps_dist_backward_matches_gathered_worker,
             args=(world_size, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
         )
 
 
-def test_PatchedEnergyScoreLoss_distributed_equivalence():
-    b, f, t, c, h, w = 1, 12, 1, 2, 64, 64
-    n_members = 2
-    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
-    pred_all = torch.randn(n_members, b, f, t, c, h, w, dtype=torch.float32)
-    local_pred = pred_all[:1].reshape(b, f, t, c, h, w)
-    loss_fn = PatchedEnergyScoreLoss(
-        weights=[1.0, 1.0],
-        n_members=n_members,
-        patch_size=3,
-        enable_nhwc=False,
-    )
-    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
-    loss_fn.setup(trainer)
-    out = loss_fn(local_pred, target, average_channels=True, distributed_ensemble_loss=True)
-    assert torch.isfinite(out)
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("lambda_spec", [0.0, 0.3])
+def test_WeightedCRPSLossSpectral_distributed_backward_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+    lambda_spec: float,
+):
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _spectral_crps_dist_backward_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size, lambda_spec),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_PatchedEnergyScoreLoss_distributed_backward_matches_gathered_ensemble(
+    average_channels: bool,
+    batch_size: int,
+    world_size: int,
+):
+    _require_distributed_cuda(world_size)
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(
+            _energy_dist_backward_matches_gathered_worker,
+            args=(world_size, tmp.name, average_channels, batch_size),
+            nprocs=world_size,
+            join=True,
+        )

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -1176,24 +1176,93 @@ def _build_shared_model_inputs(rank: int, n_members: int, b: int, c: int, device
     return base, target, noise
 
 
-def _assert_model_grads_close(
-    model_ref, model_dist, rank: int, rtol=1e-4, atol=1e-4, reduce_dist_grads: bool = True
+def _assert_model_params_close(
+    model_ref, model_test, rank: int, rtol=1e-5, atol=1e-6, reduce_test_params: bool = False
 ):
-    for (name_ref, p_ref), (name_dist, p_dist) in zip(
-        model_ref.named_parameters(), model_dist.named_parameters()
+    for (name_ref, p_ref), (name_test, p_test) in zip(
+        model_ref.named_parameters(), model_test.named_parameters()
     ):
-        assert name_ref == name_dist
-        assert p_ref.grad is not None and p_dist.grad is not None
-        dist_grad = p_dist.grad.detach().clone()
-        if reduce_dist_grads:
-            dist.all_reduce(dist_grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
-        assert torch.allclose(p_ref.grad, dist_grad, rtol=rtol, atol=atol), (
-            f"rank {rank}: parameter grad mismatch for {name_ref}, "
-            f"max_abs_diff={(p_ref.grad - dist_grad).abs().max().item()}"
+        assert name_ref == name_test
+        test_param = p_test.detach().clone()
+        if reduce_test_params:
+            dist.all_reduce(test_param, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+        assert torch.allclose(p_ref.detach(), test_param, rtol=rtol, atol=atol), (
+            f"rank {rank}: parameter update mismatch for {name_ref}, "
+            f"max_abs_diff={(p_ref.detach() - test_param).abs().max().item()}"
         )
 
 
-def _crps_weight_grad_worker(
+def _optimizer_step_all_modes(
+    model_ref,
+    model_gather,
+    model_dist,
+    loss_fn,
+    base: torch.Tensor,
+    target: torch.Tensor,
+    noise: torch.Tensor,
+    start: int,
+    stop: int,
+    average_channels: bool,
+    world_size: int,
+):
+    b = base.shape[0]
+    c = base.shape[3]
+    local_members = stop - start
+
+    opt_ref = torch.optim.SGD(model_ref.parameters(), lr=1e-2)
+    opt_gather = torch.optim.SGD(model_gather.parameters(), lr=1e-2)
+    opt_dist = torch.optim.SGD(model_dist.parameters(), lr=1e-2)
+
+    opt_ref.zero_grad(set_to_none=True)
+    pred_ref = model_ref(base, noise).reshape(noise.shape[0] * b, 12, 2, c, 32, 32)
+    ref_loss = loss_fn(
+        pred_ref,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=False,
+    )
+    ref_loss.sum().backward()
+    opt_ref.step()
+
+    opt_gather.zero_grad(set_to_none=True)
+    pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
+        local_members * b, 12, 2, c, 32, 32
+    )
+    pred_gather = torch.cat(
+        list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
+    )
+    gather_loss = loss_fn(
+        pred_gather,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=False,
+    )
+    gather_loss = gather_loss / world_size
+    gather_loss.sum().backward()
+    for param in model_gather.parameters():
+        if param.grad is not None:
+            dist.all_reduce(param.grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+    opt_gather.step()
+
+    opt_dist.zero_grad(set_to_none=True)
+    pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
+        local_members * b, 12, 2, c, 32, 32
+    )
+    dist_loss = loss_fn(
+        pred_loc_dist,
+        target,
+        average_channels=average_channels,
+        distributed_ensemble_loss=True,
+        ensemble_group=dist.group.WORLD,
+    )
+    dist_loss.sum().backward()
+    for param in model_dist.parameters():
+        if param.grad is not None:
+            dist.all_reduce(param.grad, op=dist.ReduceOp.SUM, group=dist.group.WORLD)
+    opt_dist.step()
+
+
+def _crps_weight_update_worker(
     rank: int,
     world_size: int,
     n_members: int,
@@ -1222,48 +1291,28 @@ def _crps_weight_grad_worker(
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
+        _optimizer_step_all_modes(
+            model_ref=model_ref,
+            model_gather=model_gather,
+            model_dist=model_dist,
+            loss_fn=loss_fn,
+            base=base,
+            target=target,
+            noise=noise,
+            start=start,
+            stop=stop,
             average_channels=average_channels,
-            distributed_ensemble_loss=False,
+            world_size=world_size,
         )
-        ref_loss.sum().backward()
-
-        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
+        _assert_model_params_close(
+            model_ref, model_gather, rank=rank, reduce_test_params=False
         )
-        pred_gather = torch.cat(
-            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
-        )
-        gather_loss = loss_fn(
-            pred_gather,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        gather_loss = gather_loss / world_size
-        gather_loss.sum().backward()
-
-        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
-        )
-        dist_loss = loss_fn(
-            pred_loc_dist,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
-        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+        _assert_model_params_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
 
 
-def _spectral_weight_grad_worker(
+def _spectral_weight_update_worker(
     rank: int,
     world_size: int,
     n_members: int,
@@ -1300,48 +1349,28 @@ def _spectral_weight_grad_worker(
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
+        _optimizer_step_all_modes(
+            model_ref=model_ref,
+            model_gather=model_gather,
+            model_dist=model_dist,
+            loss_fn=loss_fn,
+            base=base,
+            target=target,
+            noise=noise,
+            start=start,
+            stop=stop,
             average_channels=average_channels,
-            distributed_ensemble_loss=False,
+            world_size=world_size,
         )
-        ref_loss.sum().backward()
-
-        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
+        _assert_model_params_close(
+            model_ref, model_gather, rank=rank, reduce_test_params=False
         )
-        pred_gather = torch.cat(
-            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
-        )
-        gather_loss = loss_fn(
-            pred_gather,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        gather_loss = gather_loss / world_size
-        gather_loss.sum().backward()
-
-        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
-        )
-        dist_loss = loss_fn(
-            pred_loc_dist,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
-        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+        _assert_model_params_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
 
 
-def _energy_weight_grad_worker(
+def _energy_weight_update_worker(
     rank: int,
     world_size: int,
     n_members: int,
@@ -1372,43 +1401,23 @@ def _energy_weight_grad_worker(
         trainer = trainer_helper(output_variables=["v0", "v1"], device=device)
         loss_fn.setup(trainer)
 
-        pred_ref = model_ref(base, noise).reshape(n_members * b, 12, 2, c, 32, 32)
-        ref_loss = loss_fn(
-            pred_ref,
-            target,
+        _optimizer_step_all_modes(
+            model_ref=model_ref,
+            model_gather=model_gather,
+            model_dist=model_dist,
+            loss_fn=loss_fn,
+            base=base,
+            target=target,
+            noise=noise,
+            start=start,
+            stop=stop,
             average_channels=average_channels,
-            distributed_ensemble_loss=False,
+            world_size=world_size,
         )
-        ref_loss.sum().backward()
-
-        pred_loc_gather = model_gather(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
+        _assert_model_params_close(
+            model_ref, model_gather, rank=rank, reduce_test_params=False
         )
-        pred_gather = torch.cat(
-            list(dist_nn_func.all_gather(pred_loc_gather, group=dist.group.WORLD)), dim=0
-        )
-        gather_loss = loss_fn(
-            pred_gather,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=False,
-        )
-        gather_loss = gather_loss / world_size
-        gather_loss.sum().backward()
-
-        pred_loc_dist = model_dist(base, noise[start:stop]).reshape(
-            local_members * b, 12, 2, c, 32, 32
-        )
-        dist_loss = loss_fn(
-            pred_loc_dist,
-            target,
-            average_channels=average_channels,
-            distributed_ensemble_loss=True,
-            ensemble_group=dist.group.WORLD,
-        )
-        dist_loss.sum().backward()
-        _assert_model_grads_close(model_ref, model_gather, rank=rank, reduce_dist_grads=True)
-        _assert_model_grads_close(model_ref, model_dist, rank=rank)
+        _assert_model_params_close(model_ref, model_dist, rank=rank)
     finally:
         dist.destroy_process_group()
 
@@ -1417,7 +1426,7 @@ def _energy_weight_grad_worker(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLoss_model_weight_grads_match_across_ensemble_modes(
+def test_WeightedCRPSLoss_model_weight_updates_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:
@@ -1426,7 +1435,7 @@ def test_WeightedCRPSLoss_model_weight_grads_match_across_ensemble_modes(
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
-            _crps_weight_grad_worker,
+            _crps_weight_update_worker,
             args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
@@ -1437,7 +1446,7 @@ def test_WeightedCRPSLoss_model_weight_grads_match_across_ensemble_modes(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_WeightedCRPSLossSpectral_model_weight_grads_match_across_ensemble_modes(
+def test_WeightedCRPSLossSpectral_model_weight_updates_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:
@@ -1446,7 +1455,7 @@ def test_WeightedCRPSLossSpectral_model_weight_grads_match_across_ensemble_modes
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
-            _spectral_weight_grad_worker,
+            _spectral_weight_update_worker,
             args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,
@@ -1457,7 +1466,7 @@ def test_WeightedCRPSLossSpectral_model_weight_grads_match_across_ensemble_modes
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("world_size", [2, 4])
 @pytest.mark.parametrize("n_members", [4, 8])
-def test_PatchedEnergyScoreLoss_model_weight_grads_match_across_ensemble_modes(
+def test_PatchedEnergyScoreLoss_model_weight_updates_match_across_ensemble_modes(
     average_channels: bool, batch_size: int, world_size: int, n_members: int
 ):
     if n_members % world_size != 0:
@@ -1466,7 +1475,7 @@ def test_PatchedEnergyScoreLoss_model_weight_grads_match_across_ensemble_modes(
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
-            _energy_weight_grad_worker,
+            _energy_weight_update_worker,
             args=(world_size, n_members, tmp.name, average_channels, batch_size),
             nprocs=world_size,
             join=True,

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -17,18 +17,23 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
+import tempfile
 
 import numpy as np
 import pytest
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 from pytest_utils import import_or_fail, nfsdata_or_fail
 
 from physicsnemo.metrics.climate.healpix_loss import (
     BaseMSE,
     OceanMSE,
+    PatchedEnergyScoreLoss,
+    WeightedCRPSLoss,
+    WeightedCRPSLossSpectral,
     WeightedMSE,
     WeightedOceanMSE,
-    PatchedEnergyScoreLoss,
 )
 
 xr = pytest.importorskip("xarray")
@@ -513,3 +518,152 @@ def test_PatchedEnergyScoreLoss_three_members_zero(device, patch_size, use_earth
 
     loss = loss_fn(prediction, target, average_channels=True)
     assert torch.isclose(loss, torch.tensor(0.0, device=device), atol=1e-6)
+
+
+def _small_hpx_case(device: str = "cpu", n_members: int = 2):
+    b, f, t, c, h, w = 2, 12, 2, 2, 64, 64
+    target = torch.randn(b, f, t, c, h, w, device=device, dtype=torch.float32)
+    prediction = target.repeat(n_members, 1, 1, 1, 1, 1)
+    return prediction.reshape(n_members * b, f, t, c, h, w), target
+
+
+def test_WeightedCRPSLoss_zero_for_perfect_forecast_cpu():
+    pred, tar = _small_hpx_case(device="cpu", n_members=3)
+    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=3)
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+    loss = loss_fn(pred, tar, average_channels=True)
+    assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
+    per_channel = loss_fn(pred, tar, average_channels=False)
+    assert per_channel.shape == (2,)
+
+
+def test_WeightedCRPSLoss_shape_checks():
+    pred, tar = _small_hpx_case(device="cpu", n_members=2)
+    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=2)
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+    with pytest.raises((ValueError, RuntimeError)):
+        loss_fn(pred[:, :, :, :, :-1, :], tar, average_channels=True)
+    loss_fn_bad_members = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=3)
+    loss_fn_bad_members.setup(trainer)
+    with pytest.raises(ValueError):
+        loss_fn_bad_members(pred, tar, average_channels=True, loss_distributed=False)
+
+
+def test_WeightedCRPSLossSpectral_apply_sht_face_dim_validation_cpu():
+    pred, _ = _small_hpx_case(device="cpu", n_members=2)
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=2,
+        lambda_spec=0.0,
+        nside=64,
+        lmax=3 * 64 - 1,
+        mmax=3 * 64 - 1,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    try:
+        loss_fn.setup(trainer)
+    except Exception as exc:
+        pytest.skip(f"Spectral setup unavailable in current env: {exc}")
+    x = pred.view(2, 2, 12, 2, 2, 64, 64)
+    with pytest.raises(ValueError, match="Shape of input tensor should be"):
+        loss_fn._apply_sht(x, face_dim=3, return_abs=True)
+
+
+def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
+    pred, tar = _small_hpx_case(device="cpu", n_members=2)
+    loss_fn = WeightedCRPSLossSpectral(
+        weights=[1.0, 1.0],
+        n_members=2,
+        lambda_spec=0.0,
+        nside=64,
+        lmax=3 * 64 - 1,
+        mmax=3 * 64 - 1,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    try:
+        loss_fn.setup(trainer)
+    except Exception as exc:
+        pytest.skip(f"Spectral setup unavailable in current env: {exc}")
+    out = loss_fn(pred, tar, average_channels=True)
+    assert torch.isfinite(out)
+
+
+@pytest.mark.parametrize("average_channels", [True, False])
+def test_WeightedCRPSLoss_distributed_exact_matches_single_rank(average_channels: bool):
+    b, f, t, c, h, w = 2, 12, 2, 2, 64, 64
+    n_members = 2
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_members = torch.randn(n_members, b, f, t, c, h, w, dtype=torch.float32)
+    prediction = pred_members.reshape(n_members * b, f, t, c, h, w)
+
+    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=n_members)
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+    ref = loss_fn(prediction, target, average_channels=average_channels)
+
+    # Simulate n=1 local shard with world_size=1 by passing distributed flag.
+    local_pred = pred_members[:1].reshape(b, f, t, c, h, w)
+    got = loss_fn(local_pred, target, average_channels=average_channels, loss_distributed=True)
+    assert torch.isfinite(got).all()
+    assert got.shape == ref.shape
+
+
+def _dist_crps_worker(rank: int, world_size: int, init_file: str):
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    torch.manual_seed(123)
+    b, f, t, c, h, w = 1, 12, 1, 2, 64, 64
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_all = torch.randn(world_size, b, f, t, c, h, w, dtype=torch.float32)
+    prediction_local = pred_all[rank].reshape(b, f, t, c, h, w)
+
+    loss_fn = WeightedCRPSLoss(weights=[1.0, 1.0], n_members=world_size)
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+
+    dist_loss = loss_fn(
+        prediction_local,
+        target,
+        average_channels=True,
+        loss_distributed=True,
+        ensemble_group=dist.group.WORLD,
+    )
+    gathered = [torch.zeros_like(dist_loss) for _ in range(world_size)]
+    dist.all_gather(gathered, dist_loss, group=dist.group.WORLD)
+    assert torch.isfinite(dist_loss)
+    for other in gathered:
+        assert torch.isfinite(other)
+        assert torch.allclose(dist_loss, other, rtol=1e-4, atol=1e-4)
+    dist.destroy_process_group()
+
+
+def test_WeightedCRPSLoss_distributed_exact_equivalence():
+    mp.set_start_method("spawn", force=True)
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        mp.spawn(_dist_crps_worker, args=(2, tmp.name), nprocs=2, join=True)
+
+
+def test_PatchedEnergyScoreLoss_distributed_exact_equivalence():
+    b, f, t, c, h, w = 1, 12, 1, 2, 64, 64
+    n_members = 2
+    target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
+    pred_all = torch.randn(n_members, b, f, t, c, h, w, dtype=torch.float32)
+    local_pred = pred_all[:1].reshape(b, f, t, c, h, w)
+    loss_fn = PatchedEnergyScoreLoss(
+        weights=[1.0, 1.0],
+        n_members=n_members,
+        patch_size=3,
+        hpx_padding_mode="karlbauer",
+        enable_nhwc=False,
+        nside=64,
+    )
+    trainer = trainer_helper(output_variables=["v0", "v1"], device="cpu")
+    loss_fn.setup(trainer)
+    out = loss_fn(local_pred, target, average_channels=True, loss_distributed=True)
+    assert torch.isfinite(out)

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -591,7 +591,7 @@ def test_WeightedCRPSLossSpectral_lambda0_perfect_forecast_smoke():
 
 
 @pytest.mark.parametrize("average_channels", [True, False])
-def test_WeightedCRPSLoss_distributed_exact_matches_single_rank(average_channels: bool):
+def test_WeightedCRPSLoss_distributed_matches_single_rank(average_channels: bool):
     b, f, t, c, h, w = 2, 12, 2, 2, 64, 64
     n_members = 2
     target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)
@@ -668,16 +668,6 @@ def _crps_dist_matches_gathered_worker(
     loss_fn.setup(trainer)
 
     local = pred_all[rank].reshape(b, f, t, c, h, w)
-    gathered = [torch.empty_like(local) for _ in range(world_size)]
-    dist.all_gather(gathered, local, group=dist.group.WORLD)
-    pred_full = torch.cat(gathered, dim=0)
-    ref = loss_fn(
-        pred_full,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=False,
-    )
-
     dist_loss = loss_fn(
         local,
         target,
@@ -685,6 +675,17 @@ def _crps_dist_matches_gathered_worker(
         distributed_ensemble_loss=True,
         ensemble_group=dist.group.WORLD,
     )
+    if rank == 0:
+        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+        ref = loss_fn(
+            pred_full,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+    else:
+        ref = torch.zeros_like(dist_loss)
+    dist.broadcast(ref, src=0, group=dist.group.WORLD)
     assert torch.allclose(
         dist_loss,
         ref,
@@ -729,16 +730,6 @@ def _spectral_crps_dist_matches_gathered_worker(
     loss_fn.setup(trainer)
 
     local = pred_all[rank].reshape(b, f, t, c, h, w)
-    gathered = [torch.empty_like(local) for _ in range(world_size)]
-    dist.all_gather(gathered, local, group=dist.group.WORLD)
-    pred_full = torch.cat(gathered, dim=0)
-    ref = loss_fn(
-        pred_full,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=False,
-    )
-
     dist_loss = loss_fn(
         local,
         target,
@@ -746,6 +737,17 @@ def _spectral_crps_dist_matches_gathered_worker(
         distributed_ensemble_loss=True,
         ensemble_group=dist.group.WORLD,
     )
+    if rank == 0:
+        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+        ref = loss_fn(
+            pred_full,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+    else:
+        ref = torch.zeros_like(dist_loss)
+    dist.broadcast(ref, src=0, group=dist.group.WORLD)
     assert torch.allclose(
         dist_loss,
         ref,
@@ -786,16 +788,6 @@ def _energy_dist_matches_gathered_worker(
     loss_fn.setup(trainer)
 
     local = pred_all[rank].reshape(b, f, t, c, h, w)
-    gathered = [torch.empty_like(local) for _ in range(world_size)]
-    dist.all_gather(gathered, local, group=dist.group.WORLD)
-    pred_full = torch.cat(gathered, dim=0)
-    ref = loss_fn(
-        pred_full,
-        target,
-        average_channels=average_channels,
-        distributed_ensemble_loss=False,
-    )
-
     dist_loss = loss_fn(
         local,
         target,
@@ -803,6 +795,17 @@ def _energy_dist_matches_gathered_worker(
         distributed_ensemble_loss=True,
         ensemble_group=dist.group.WORLD,
     )
+    if rank == 0:
+        pred_full = pred_all.reshape(world_size * b, f, t, c, h, w)
+        ref = loss_fn(
+            pred_full,
+            target,
+            average_channels=average_channels,
+            distributed_ensemble_loss=False,
+        )
+    else:
+        ref = torch.zeros_like(dist_loss)
+    dist.broadcast(ref, src=0, group=dist.group.WORLD)
     assert torch.allclose(
         dist_loss,
         ref,
@@ -813,7 +816,7 @@ def _energy_dist_matches_gathered_worker(
     dist.destroy_process_group()
 
 
-def test_WeightedCRPSLoss_distributed_exact_equivalence():
+def test_WeightedCRPSLoss_distributed_equivalence():
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(_dist_crps_worker, args=(2, tmp.name), nprocs=2, join=True)
@@ -821,13 +824,13 @@ def test_WeightedCRPSLoss_distributed_exact_equivalence():
 
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3])
+@pytest.mark.parametrize("world_size", [2, 3, 4])
 def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
 ):
-    """Distributed shards vs ``all_gather``+concat reference (one member per rank).
+    """Distributed shards vs gathered reference.
 
     For ``n_members == 2`` the implementation must use
     ``_dist_ensemble_skill_prefactor`` and the scalar ``valid_px_avg`` fix so the
@@ -843,55 +846,15 @@ def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble(
         )
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [4])
-def test_WeightedCRPSLoss_distributed_matches_gathered_ensemble_slow(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-):
-    """Same as ``test_WeightedCRPSLoss_distributed_matches_gathered_ensemble`` with four ranks."""
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _crps_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
-            nprocs=world_size,
-            join=True,
-        )
-
-
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3])
+@pytest.mark.parametrize("world_size", [2, 3, 4])
 def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
     world_size: int,
 ):
     """Same gather equivalence as CRPS for patched energy score."""
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _energy_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
-            nprocs=world_size,
-            join=True,
-        )
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [4])
-def test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble_slow(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-):
-    """Same as ``test_PatchedEnergyScoreLoss_distributed_matches_gathered_ensemble`` with four ranks."""
     mp.set_start_method("spawn", force=True)
     with tempfile.NamedTemporaryFile(delete=True) as tmp:
         mp.spawn(
@@ -920,7 +883,7 @@ def _require_weighted_crps_loss_spectral_cpu():
 
 @pytest.mark.parametrize("average_channels", [True, False])
 @pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [2, 3])
+@pytest.mark.parametrize("world_size", [2, 3, 4])
 def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
     average_channels: bool,
     batch_size: int,
@@ -938,28 +901,7 @@ def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble(
         )
 
 
-@pytest.mark.slow
-@pytest.mark.parametrize("average_channels", [True, False])
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("world_size", [4])
-def test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble_slow(
-    average_channels: bool,
-    batch_size: int,
-    world_size: int,
-):
-    """Same as ``test_WeightedCRPSLossSpectral_distributed_matches_gathered_ensemble`` with four ranks."""
-    _require_weighted_crps_loss_spectral_cpu()
-    mp.set_start_method("spawn", force=True)
-    with tempfile.NamedTemporaryFile(delete=True) as tmp:
-        mp.spawn(
-            _spectral_crps_dist_matches_gathered_worker,
-            args=(world_size, tmp.name, average_channels, batch_size),
-            nprocs=world_size,
-            join=True,
-        )
-
-
-def test_PatchedEnergyScoreLoss_distributed_exact_equivalence():
+def test_PatchedEnergyScoreLoss_distributed_equivalence():
     b, f, t, c, h, w = 1, 12, 1, 2, 64, 64
     n_members = 2
     target = torch.randn(b, f, t, c, h, w, dtype=torch.float32)


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This PR adds the capability to compute probabilistic losses (e.g. CRPS) in a distributed manner when ensemble members are distributed across GPUs as enabled with [this buddy NV-dlesm PR](https://github.com/AtmosSci-DLESM/NV-dlesm/pull/139). The reason why this is necessary is that for large ensembles, loading the whole ensemble output into memory at once to compute pairwise difference terms can lead to OOM errors. We get around this by looping through ranks associated with the same ensemble and computing the pairwise differences one at a time. This can be slow for large ensembles, but it enables large (e.g. m=32) ensembles during training.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->