### PR TITLE
fix setting cln layers to 0

### DIFF
--- a/physicsnemo/models/dlwp_healpix_layers/normalization.py
+++ b/physicsnemo/models/dlwp_healpix_layers/normalization.py
@@ -85,13 +85,10 @@ class ConditionalLayerNorm(th.nn.Module):
             [2 * h for h in self.hidden_dims],
             2 * self.channel_depth,
             self.activation,
+            init_cln_to_zero,
         )
         self.n_faces = n_faces
         self.scale_center = scale_center
-
-        if init_cln_to_zero:
-            self.gamma_beta_mlp[-1].weight.data.zero_()
-            self.gamma_beta_mlp[-1].bias.data.zero_()
 
         if norm_op == "torch":
             self.norm = th.nn.LayerNorm(channel_depth, elementwise_affine=False)
@@ -100,15 +97,23 @@ class ConditionalLayerNorm(th.nn.Module):
                 raise ImportError("Apex FusedLayerNorm requested but apex is not available, please install it from https://github.com/NVIDIA/apex")
             self.norm = FusedLayerNorm(channel_depth, elementwise_affine=False)
 
-    def _make_mlp(self, in_dim: int, hidden_dims: List[int], out_dim: int, activation: th.nn.Module) -> th.nn.Sequential:
+    def _make_mlp(self, in_dim: int, hidden_dims: List[int], out_dim: int, activation: th.nn.Module, init_cln_to_zero: bool) -> th.nn.Sequential:
 
         layers = []
         for hdim in hidden_dims:
             layers.append(th.nn.Linear(in_dim, hdim))
+            if init_cln_to_zero:
+                layers[-1].weight.data.zero_()
+                layers[-1].bias.data.zero_()
+
             if activation:
                 layers.append(activation)
             in_dim = hdim
+
         layers.append(th.nn.Linear(in_dim, out_dim))
+        if init_cln_to_zero:
+            layers[-1].weight.data.zero_()
+            layers[-1].bias.data.zero_()
         return th.nn.Sequential(*layers)
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Pull Request

## Description
This fixes a bug with initializing the CLNs in the dlesym model to zero. The existing code only set the last layer of the MLP to zero, if there were any hidden layers they would not be set to zero. This updates the behavior to set all layers of the MLP to zero.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.
- [ ] If I am implementing a new model or modifying any existing model, I have followed the [Models Implementation Coding Standards](https://github.com/NVIDIA/physicsnemo/wiki/Coding-standards-for-models-implementation).

## Dependencies

<!-- Call out any new dependencies needed if any -->

## Review Process

**All PRs are reviewed by the PhysicsNeMo team before merging.**

Depending on which files are changed, GitHub may automatically assign a maintainer for review.

We are also testing AI-based code review tools (e.g., Greptile), which may add automated comments with a confidence score.
This score reflects the AI’s assessment of merge readiness and is **not** a qualitative judgment of your work, nor is
it an indication that the PR will be accepted / rejected.

AI-generated feedback should be reviewed critically for usefulness.
You are not required to respond to every AI comment, but they are intended to help both authors and reviewers.
Please react to Greptile comments with 👍 or 👎 to provide feedback on their accuracy.
