### PR TITLE
Fix constant coupler to copy all vars instead of broadcasting last

### DIFF
--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -357,10 +357,6 @@ class ConstantCoupler(BaseCoupler):
             the right side of a averaging_window window.
             This is highly recommended for training, default True
         """
-        # It doesn't make sense to have more than one input time for a constant coupler
-        if len(input_times) != 1:
-            raise ValueError("ConstantCoupler only supports one input time")
-
         super().__init__(
             dataset=dataset,
             batch_size=batch_size,

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -105,14 +105,19 @@ class BaseCoupler(ABC):
             self.use_zarr = False
         elif type(self.ds) == zr.Group:
             self.use_zarr = True
+            # Iterate over self.variables in the outer loop so selected indices
+            # follow the order of self.variables (matching the xarray path's
+            # `.sel(channel_in=self.variables)`), not the dataset's native
+            # channel_in order. Downstream code (e.g. coupled_scaling built
+            # from self.variables in set_scaling) assumes the coupled channel
+            # axis is ordered by self.variables.
+            # Use `[:]` so zarr v3 yields hashable scalar strings, not Array views.
+            channel_in = list(self.ds["channel_in"][:])
             self.ds_variable_indices = [
-                i
-                for i, ic in enumerate(self.ds["channel_in"])
-                for v in self.variables
-                if ic == v
+                i for v in self.variables for i, ic in enumerate(channel_in) if ic == v
             ]
             # Check if any of the requested variables are not in the dataset
-            missing_variables = set(self.variables) - set(list(self.ds["channel_in"][:]))
+            missing_variables = set(self.variables) - set(channel_in)
             if len(missing_variables) > 0:
                 raise ValueError(f"Missing variables in dataset for coupling: {missing_variables}")
         else:

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -357,6 +357,10 @@ class ConstantCoupler(BaseCoupler):
             the right side of a averaging_window window.
             This is highly recommended for training, default True
         """
+        # It doesn't make sense to have more than one input time for a constant coupler
+        if len(input_times) != 1:
+            raise ValueError("ConstantCoupler only supports one input time")
+
         super().__init__(
             dataset=dataset,
             batch_size=batch_size,
@@ -413,10 +417,9 @@ class ConstantCoupler(BaseCoupler):
             + list(self.spatial_dims[1:])
         )
         # we use a constant set of values so we just copy time 0
-        for i in range(self.coupled_integration_dim):
-            self.preset_coupled_fields[:, :, i, :, :, :] = coupled_fields[
-                :, :, 0, -1:, :, :
-            ]
+
+        # broadcast the first time step to the entire coupled integration dimension
+        self.preset_coupled_fields[:, :, :, :, :, :] = coupled_fields[:, :, :1, :, :, :]
         if self.time_first:
             self.preset_coupled_fields = self.preset_coupled_fields.permute(2, 0, 3, 1, 4, 5)
         # flag for construct integrated coupling method to use this array

--- a/test/datapipes/test_healpix_couple.py
+++ b/test/datapipes/test_healpix_couple.py
@@ -184,8 +184,19 @@ def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
     expected = np.expand_dims(coupled_scaling["std"].to_numpy(), (0, 2, 3, 4))
     assert np.array_equal(expected, coupler.coupled_scaling["std"])
 
-    # test incorrect batch size
-    # coupler.coupled_channel_indices = [0, 1]
+    # set_coupled_fields sizes its buffer from the provided field batch dim
+    coupled_fields_batch_size = batch_size * 2
+    coupled_fields_timedim = 2
+    coupled_fields = th.rand(
+        coupled_fields_batch_size,
+        coupler.spatial_dims[0],
+        coupled_fields_timedim,
+        len(coupler.coupled_channel_indices),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    coupler.set_coupled_fields(coupled_fields)
+    assert coupler.preset_coupled_fields.shape[1] == coupled_fields_batch_size
 
     coupled_fields_batch_size = batch_size
     coupled_fields_timedim = 4
@@ -206,20 +217,20 @@ def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
     assert coupler.coupled_mode
     assert list(coupler.construct_integrated_couplings().shape) == expected_shape
 
-    # verify that the data is being properly transformed
-    expected = coupled_fields[:, :, :, coupler.coupled_channel_indices, :, :].permute(
-        2, 0, 3, 1, 4, 5
-    )
-    expected = expected[0, :, -1:, :, :, :]
-    expected = expected.unsqueeze(0)
-    expected = expected.repeat(
-        coupler.coupled_integration_dim, 1, coupled_fields_batch_size, 1, 1, 1
-    )
+    # broadcast the first time step of every channel across the integration dim
+    expected = coupled_fields[:, :, :, coupler.coupled_channel_indices, :, :]
+    expected = expected[:, :, :1, :, :, :]
+    expected = expected.permute(2, 0, 3, 1, 4, 5)
     assert th.equal(expected, coupler.construct_integrated_couplings())
 
     # test coupler reset
     coupler.reset_coupler()
     assert coupler.coupled_mode is False
+
+    with pytest.raises(
+        ValueError, match=("batch and bsize must be provided when not in coupled_mode")
+    ):
+        coupler.construct_integrated_couplings()
 
     # test loading from the dataset
     coupled_scaling = {
@@ -232,6 +243,12 @@ def test_ConstantCoupler(data_dir, dataset_name, scaling_dict, pytestconfig):
         batch=batch, bsize=batch_size
     )
     assert np.array_equal(expected, coupled_field[0])
+
+    scaling_missing_var = scaling_da.drop_sel(index="z1000")
+    with pytest.raises(
+        KeyError, match=("Coupled variable\\(s\\) not found in scaling values")
+    ):
+        coupler.set_scaling(scaling_missing_var)
 
     zarr_ds.close()
     DistributedManager.cleanup()
@@ -371,6 +388,19 @@ def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconf
     coupler.averaging_slices = averaging_slices
     coupler.coupled_channel_indices = [0, 1]
 
+    coupled_fields_batch_size = batch_size * 2
+    coupled_fields_timedim = 4
+    coupled_fields = th.rand(
+        coupled_fields_batch_size,
+        coupler.spatial_dims[0],
+        coupled_fields_timedim,
+        len(coupler.coupled_channel_indices),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    coupler.set_coupled_fields(coupled_fields)
+    assert coupler.preset_coupled_fields.shape[1] == coupled_fields_batch_size
+
     coupled_fields_batch_size = batch_size
     coupled_fields_timedim = 4
     expected_shape = [
@@ -393,6 +423,122 @@ def test_TrailingAverageCoupler(data_dir, dataset_name, scaling_dict, pytestconf
     assert coupler.coupled_mode
     coupler.reset_coupler()
     assert coupler.coupled_mode is False
+
+    zarr_ds.close()
+    DistributedManager.cleanup()
+
+
+@import_or_fail("omegaconf")
+@import_or_fail("netCDF4")
+@import_or_fail("pandas")
+@import_or_fail("xarray")
+@nfsdata_or_fail
+def test_TrailingAverageCoupler_multiple_variables(data_dir, dataset_name, pytestconfig):
+    from physicsnemo.datapipes.healpix.couplers import TrailingAverageCoupler
+
+    variables = ["z500", "z1000", "z250"]
+    input_times = ["6h", "12h"]
+    input_time_dim = 2
+    output_time_dim = 2
+    batch_size = 2
+    averaging_window = "6h"
+    ds_path = Path(data_dir, dataset_name + ".zarr")
+    zarr_ds = xr.open_zarr(ds_path)
+
+    coupler = TrailingAverageCoupler(
+        dataset=zarr_ds,
+        batch_size=batch_size,
+        variables=variables,
+        presteps=0,
+        averaging_window=averaging_window,
+        input_times=input_times,
+        input_time_dim=input_time_dim,
+        output_time_dim=output_time_dim,
+    )
+    coupler.coupled_channel_indices = list(range(len(variables)))
+
+    data_time_step = "3h"
+    averaging_window_max_indices = [
+        i // pd.Timedelta(data_time_step) for i in input_times
+    ]
+    di = averaging_window_max_indices[0]
+    averaging_slices = []
+    for j in range(coupler.coupled_integration_dim):
+        averaging_slices.append([])
+        for i, r in enumerate(averaging_window_max_indices):
+            averaging_slices[j].append(
+                slice(
+                    coupler.input_time_dim * j * di + i * di,
+                    coupler.input_time_dim * j * di + r,
+                )
+            )
+    coupler.averaging_slices = averaging_slices
+
+    channel_values = [100.0, 200.0, 300.0]
+    coupled_fields = th.empty(
+        batch_size,
+        coupler.spatial_dims[0],
+        4,
+        len(variables),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    for i, value in enumerate(channel_values):
+        coupled_fields[:, :, :, i, :, :] = value
+
+    coupler.set_coupled_fields(coupled_fields)
+    result = coupler.construct_integrated_couplings()
+    assert list(result.shape) == [
+        coupler.coupled_integration_dim,
+        batch_size,
+        coupler.timevar_dim,
+    ] + list(coupler.spatial_dims)
+
+    for period in range(len(input_times)):
+        for var_idx, value in enumerate(channel_values):
+            timevar_idx = period * len(variables) + var_idx
+            slice_result = result[:, :, timevar_idx, :, :, :]
+            assert th.allclose(slice_result, th.full_like(slice_result, value))
+
+    zarr_ds.close()
+    DistributedManager.cleanup()
+
+
+@import_or_fail("omegaconf")
+@import_or_fail("netCDF4")
+@import_or_fail("pandas")
+@import_or_fail("xarray")
+@nfsdata_or_fail
+def test_ConstantCoupler_multiple_variables_order(data_dir, dataset_name, pytestconfig):
+    from physicsnemo.datapipes.healpix.couplers import ConstantCoupler
+
+    ds_path = Path(data_dir, dataset_name + ".zarr")
+    zarr_ds = xr.open_zarr(ds_path)
+
+    native_order = list(zarr_ds.channel_in.values)
+    variables = ["z250", "z1000", "z500"]
+    assert [native_order.index(v) for v in variables] == sorted(
+        [native_order.index(v) for v in variables], reverse=True
+    )
+
+    batch_size = 2
+    batch = {"time": slice(0, 2)}
+    coupler = ConstantCoupler(
+        dataset=zarr_ds,
+        batch_size=batch_size,
+        variables=variables,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler.compute_coupled_indices(interval=2, data_time_step="3h")
+
+    coupled_field = coupler.construct_integrated_couplings(
+        batch=batch, bsize=batch_size
+    )
+    for i, var in enumerate(variables):
+        expected_var = zarr_ds.sel(channel_in=var).inputs[:2].values
+        assert np.array_equal(expected_var, coupled_field[0][:, i])
 
     zarr_ds.close()
     DistributedManager.cleanup()
@@ -1182,7 +1328,9 @@ def test_CoupledTimeSeriesDataset_next_integration(
 
     spatial_dims = [12, 32, 32]
     input_variables = ["z500", "z1000"]
-    coupled_channel_indices = [0, 1]
+    # length must match len(coupled_variables) (i.e. the coupler's timevar_dim);
+    # values are arbitrary since this synthetic setup bypasses setup_coupling()
+    coupled_channel_indices = [0]
     coupled_variables = ["z250"]
     num_variables = len(input_variables)
     input_time_dim = 1
@@ -1245,12 +1393,11 @@ def test_CoupledTimeSeriesDataset_next_integration(
         spatial_dims[2],
     )
 
-    expected_coupling = coupled_fields[:, :, :, coupled_channel_indices, :, :].permute(
-        2, 0, 3, 1, 4, 5
-    )
-    expected_coupling = expected_coupling[0, :, -1, :, :, :]
-    expected_coupling = expected_coupling.unsqueeze(0).unsqueeze(0)
-    expected_coupling = expected_coupling.repeat(1, batch_size, 1, 1, 1, 1)
+    # mirrors set_coupled_fields: broadcast the first time step across the
+    # integration dim and permute to [integration_dim, batch, timevar, face, height, width]
+    expected_coupling = coupled_fields[:, :, :, coupled_channel_indices, :, :]
+    expected_coupling = expected_coupling[:, :, :1, :, :, :]
+    expected_coupling = expected_coupling.permute(2, 0, 3, 1, 4, 5)
 
     # need to grab at least 1 sample to properly intialize everything
     timeseries_ds[0]

--- a/test/datapipes/test_healpix_couple_zarr.py
+++ b/test/datapipes/test_healpix_couple_zarr.py
@@ -225,6 +225,19 @@ def test_ConstantCoupler(dataset_path, scaling_dict, pytestconfig):
     expected = np.expand_dims(coupled_scaling["std"].to_numpy(), (0, 2, 3, 4))
     assert np.array_equal(expected, coupler.coupled_scaling["std"])
 
+    coupled_fields_batch_size = batch_size * 2
+    coupled_fields_timedim = 2
+    coupled_fields = th.rand(
+        coupled_fields_batch_size,
+        coupler.spatial_dims[0],
+        coupled_fields_timedim,
+        len(coupler.coupled_channel_indices),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    coupler.set_coupled_fields(coupled_fields)
+    assert coupler.preset_coupled_fields.shape[1] == coupled_fields_batch_size
+
     coupled_fields_batch_size = batch_size
     coupled_fields_timedim = 4
     expected_shape = [
@@ -244,30 +257,32 @@ def test_ConstantCoupler(dataset_path, scaling_dict, pytestconfig):
     assert coupler.coupled_mode
     assert list(coupler.construct_integrated_couplings().shape) == expected_shape
 
-    # verify that the data is being properly transformed
-    expected = coupled_fields[:, :, :, coupler.coupled_channel_indices, :, :].permute(
-        2, 0, 3, 1, 4, 5
-    )
-    expected = expected[0, :, -1:, :, :, :]
-    expected = expected.unsqueeze(0)
-    expected = expected.repeat(
-        coupler.coupled_integration_dim, 1, coupled_fields_batch_size, 1, 1, 1
-    )
-    result = coupler.construct_integrated_couplings()
+    # broadcast the first time step of every channel across the integration dim
+    expected = coupled_fields[:, :, :, coupler.coupled_channel_indices, :, :]
+    expected = expected[:, :, :1, :, :, :]
+    expected = expected.permute(2, 0, 3, 1, 4, 5)
     assert th.equal(expected, coupler.construct_integrated_couplings())
 
     # verify that dimensions aren't reordered when time_first is false
     coupler.time_first = False
     coupler.set_coupled_fields(coupled_fields)
-    # [T, B, C, F, H, W]
-    expected = expected.permute(1, 3, 0, 2, 4, 5)
-    result = coupler.construct_integrated_couplings()
-    assert th.equal(expected, result)
+    expected = coupled_fields[:, :, :, coupler.coupled_channel_indices, :, :]
+    expected = (
+        expected[:, :, :1, :, :, :]
+        .expand(-1, -1, coupler.coupled_integration_dim, -1, -1, -1)
+        .contiguous()
+    )
+    assert th.equal(expected, coupler.construct_integrated_couplings())
     coupler.time_first = True
 
     # test coupler reset
     coupler.reset_coupler()
     assert coupler.coupled_mode is False
+
+    with pytest.raises(
+        ValueError, match=("batch and bsize must be provided when not in coupled_mode")
+    ):
+        coupler.construct_integrated_couplings()
 
     # test loading from the dataset
     coupled_scaling = {
@@ -280,6 +295,12 @@ def test_ConstantCoupler(dataset_path, scaling_dict, pytestconfig):
         batch=batch, bsize=batch_size
     )
     assert np.array_equal(expected, coupled_field[0])
+
+    scaling_missing_var = scaling_da.drop_sel(index="z1000")
+    with pytest.raises(
+        KeyError, match=("Coupled variable\\(s\\) not found in scaling values")
+    ):
+        coupler.set_scaling(scaling_missing_var)
 
     DistributedManager.cleanup()
 
@@ -345,6 +366,10 @@ def test_TrailingAverageCoupler(dataset_path, scaling_dict, pytestconfig):
         output_time_dim=output_time_dim,
     )
     assert isinstance(coupler, TrailingAverageCoupler)
+
+    # Zarr-backed datasets store time as CF-encoded integers; verify decode
+    expected_time_da = xr.open_zarr(dataset_path).time.values
+    assert np.array_equal(coupler.time_da, expected_time_da)
 
     mock_coupled_module = coupler_helper(
         output_variables=["not_coupled", "z500"],
@@ -416,6 +441,19 @@ def test_TrailingAverageCoupler(dataset_path, scaling_dict, pytestconfig):
     coupler.averaging_slices = averaging_slices
     coupler.coupled_channel_indices = [0, 1]
 
+    coupled_fields_batch_size = batch_size * 2
+    coupled_fields_timedim = 4
+    coupled_fields = th.rand(
+        coupled_fields_batch_size,
+        coupler.spatial_dims[0],
+        coupled_fields_timedim,
+        len(coupler.coupled_channel_indices),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    coupler.set_coupled_fields(coupled_fields)
+    assert coupler.preset_coupled_fields.shape[1] == coupled_fields_batch_size
+
     coupled_fields_batch_size = batch_size
     coupled_fields_timedim = 4
     expected_shape = [
@@ -438,6 +476,145 @@ def test_TrailingAverageCoupler(dataset_path, scaling_dict, pytestconfig):
     assert coupler.coupled_mode
     coupler.reset_coupler()
     assert coupler.coupled_mode is False
+
+    DistributedManager.cleanup()
+
+
+@import_or_fail("omegaconf")
+@import_or_fail("netCDF4")
+@import_or_fail("pandas")
+@import_or_fail("xarray")
+@nfsdata_or_fail
+def test_TrailingAverageCoupler_multiple_variables(dataset_path, pytestconfig):
+    from physicsnemo.datapipes.healpix.couplers import TrailingAverageCoupler
+
+    variables = ["z500", "z1000", "z250"]
+    input_times = ["6h", "12h"]
+    input_time_dim = 2
+    output_time_dim = 2
+    batch_size = 2
+    averaging_window = "6h"
+    zarr_ds = zarr.open(dataset_path)
+
+    coupler = TrailingAverageCoupler(
+        dataset=zarr_ds,
+        batch_size=batch_size,
+        variables=variables,
+        presteps=0,
+        averaging_window=averaging_window,
+        input_times=input_times,
+        input_time_dim=input_time_dim,
+        output_time_dim=output_time_dim,
+    )
+    coupler.coupled_channel_indices = list(range(len(variables)))
+
+    data_time_step = "3h"
+    averaging_window_max_indices = [
+        i // pd.Timedelta(data_time_step) for i in input_times
+    ]
+    di = averaging_window_max_indices[0]
+    averaging_slices = []
+    for j in range(coupler.coupled_integration_dim):
+        averaging_slices.append([])
+        for i, r in enumerate(averaging_window_max_indices):
+            averaging_slices[j].append(
+                slice(
+                    coupler.input_time_dim * j * di + i * di,
+                    coupler.input_time_dim * j * di + r,
+                )
+            )
+    coupler.averaging_slices = averaging_slices
+
+    channel_values = [100.0, 200.0, 300.0]
+    coupled_fields = th.empty(
+        batch_size,
+        coupler.spatial_dims[0],
+        4,
+        len(variables),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    for i, value in enumerate(channel_values):
+        coupled_fields[:, :, :, i, :, :] = value
+
+    coupler.set_coupled_fields(coupled_fields)
+    result = coupler.construct_integrated_couplings()
+    assert list(result.shape) == [
+        coupler.coupled_integration_dim,
+        batch_size,
+        coupler.timevar_dim,
+    ] + list(coupler.spatial_dims)
+
+    for period in range(len(input_times)):
+        for var_idx, value in enumerate(channel_values):
+            timevar_idx = period * len(variables) + var_idx
+            slice_result = result[:, :, timevar_idx, :, :, :]
+            assert th.allclose(slice_result, th.full_like(slice_result, value))
+
+    DistributedManager.cleanup()
+
+
+@import_or_fail("omegaconf")
+@import_or_fail("netCDF4")
+@import_or_fail("pandas")
+@import_or_fail("xarray")
+@nfsdata_or_fail
+def test_ConstantCoupler_multiple_variables_order(dataset_path, pytestconfig):
+    from physicsnemo.datapipes.healpix.couplers import ConstantCoupler
+
+    xr_ds = xr.open_zarr(dataset_path)
+    zarr_ds = zarr.open(dataset_path)
+
+    native_order = list(xr_ds.channel_in.values)
+    variables = ["z250", "z1000", "z500"]
+    assert [native_order.index(v) for v in variables] == sorted(
+        [native_order.index(v) for v in variables], reverse=True
+    )
+
+    batch_size = 2
+    batch = {"time": slice(0, 2)}
+
+    coupler_xr = ConstantCoupler(
+        dataset=xr_ds,
+        batch_size=batch_size,
+        variables=variables,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler_zarr = ConstantCoupler(
+        dataset=zarr_ds,
+        batch_size=batch_size,
+        variables=variables,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+
+    interval = 2
+    data_time_step = "3h"
+    coupler_xr.compute_coupled_indices(interval, data_time_step)
+    coupler_zarr.compute_coupled_indices(interval, data_time_step)
+
+    coupled_xr = coupler_xr.construct_integrated_couplings(
+        batch=batch, bsize=batch_size
+    )
+    coupled_zarr = coupler_zarr.construct_integrated_couplings(
+        batch=batch, bsize=batch_size
+    )
+
+    input_indices = [
+        int(np.where(zarr_ds["channel_in"][:] == v)[0][0]) for v in variables
+    ]
+    expected = zarr_ds["inputs"][:2][:, input_indices]
+    assert np.array_equal(expected, coupled_xr[0])
+    assert np.array_equal(expected, coupled_zarr[0])
+
+    for i, var in enumerate(variables):
+        var_index = int(np.where(zarr_ds["channel_in"][:] == var)[0][0])
+        expected_var = zarr_ds["inputs"][:2][:, var_index]
+        assert np.array_equal(expected_var, coupled_zarr[0][:, i])
+        assert np.array_equal(expected_var, coupled_xr[0][:, i])
 
     DistributedManager.cleanup()
 
@@ -1127,7 +1304,9 @@ def test_CoupledTimeSeriesDatasetZarr_next_integration(
 
     spatial_dims = [12, 32, 32]
     input_variables = ["z500", "z1000"]
-    coupled_channel_indices = [0, 1]
+    # length must match len(coupled_variables) (i.e. the coupler's timevar_dim);
+    # values are arbitrary since this synthetic setup bypasses setup_coupling()
+    coupled_channel_indices = [0]
     coupled_variables = ["z250"]
     num_variables = len(input_variables)
     input_time_dim = 1
@@ -1189,12 +1368,11 @@ def test_CoupledTimeSeriesDatasetZarr_next_integration(
         spatial_dims[2],
     )
 
-    expected_coupling = coupled_fields[:, :, :, coupled_channel_indices, :, :].permute(
-        2, 0, 3, 1, 4, 5
-    )
-    expected_coupling = expected_coupling[0, :, -1, :, :, :]
-    expected_coupling = expected_coupling.unsqueeze(0).unsqueeze(0)
-    expected_coupling = expected_coupling.repeat(1, batch_size, 1, 1, 1, 1)
+    # mirrors set_coupled_fields: broadcast the first time step across the
+    # integration dim and permute to [integration_dim, batch, timevar, face, height, width]
+    expected_coupling = coupled_fields[:, :, :, coupled_channel_indices, :, :]
+    expected_coupling = expected_coupling[:, :, :1, :, :, :]
+    expected_coupling = expected_coupling.permute(2, 0, 3, 1, 4, 5)
 
     # need to grab at least 1 sample to properly intialize everything
     timeseries_ds[0]

--- a/test/datapipes/test_healpix_couplers.py
+++ b/test/datapipes/test_healpix_couplers.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-contained regression tests for HEALPix couplers."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+xr = pytest.importorskip("xarray")
+
+from physicsnemo.datapipes.healpix.couplers import ConstantCoupler
+
+_FACE, _HEIGHT, _WIDTH = 2, 3, 4
+_N_CHANNELS = 2
+
+
+def _make_coupler_dataset(channel_in, n_time=8):
+    return xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("time", "channel_in", "face", "height", "width"),
+                np.zeros(
+                    (n_time, len(channel_in), _FACE, _HEIGHT, _WIDTH),
+                    dtype="float32",
+                ),
+            )
+        },
+        coords={
+            "time": pd.date_range("1979-01-01", periods=n_time, freq="3h"),
+            "channel_in": list(channel_in),
+            "face": np.arange(_FACE),
+            "height": np.arange(_HEIGHT),
+            "width": np.arange(_WIDTH),
+        },
+    )
+
+
+def _make_coupler(batch_size, output_time_dim=1):
+    coupler = ConstantCoupler(
+        dataset=_make_coupler_dataset(["c0", "c1", "x"]),
+        batch_size=batch_size,
+        variables=["c0", "c1"],
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=output_time_dim,
+        presteps=0,
+    )
+    # Normally assigned by setup_coupling().
+    coupler.coupled_channel_indices = [0, 1]
+    return coupler
+
+
+def _coupled_fields(batch, timedim=3):
+    """Return fields in [B, F, T, C, H, W] layout."""
+    return torch.rand(batch, _FACE, timedim, _N_CHANNELS, _HEIGHT, _WIDTH)
+
+
+def test_set_coupled_fields_adapts_to_provided_batch_size():
+    """CRPS-style batch expansion must not be rejected or truncated."""
+    configured_batch_size = 2
+    provided_batch = configured_batch_size * 2
+    coupler = _make_coupler(batch_size=configured_batch_size)
+
+    # timedim deliberately differs from batch to catch axis mixups.
+    coupler.set_coupled_fields(_coupled_fields(provided_batch, timedim=3))
+
+    assert coupler.coupled_mode
+    assert coupler.preset_coupled_fields.shape[1] == provided_batch
+
+
+def test_set_coupled_fields_matches_configured_batch_size():
+    coupler = _make_coupler(batch_size=3)
+    coupler.set_coupled_fields(_coupled_fields(3, timedim=5))
+
+    assert coupler.preset_coupled_fields.shape[1] == 3
+
+
+def test_set_coupled_fields_broadcasts_all_channels_from_first_time():
+    """Constant coupling must preserve every channel, not only the last one."""
+    integration_steps = 3
+    batch, timedim = 2, 4
+    coupler = _make_coupler(
+        batch_size=batch,
+        output_time_dim=integration_steps,
+    )
+    fields = torch.zeros(batch, _FACE, timedim, _N_CHANNELS, _HEIGHT, _WIDTH)
+    fields[:, :, 0, 0, :, :] = 1.0
+    fields[:, :, 0, 1, :, :] = 2.0
+    fields[:, :, 1:, :, :, :] = 99.0
+
+    coupler.set_coupled_fields(fields)
+    out = coupler.construct_integrated_couplings()
+
+    assert out.shape == (
+        integration_steps,
+        batch,
+        _N_CHANNELS,
+        _FACE,
+        _HEIGHT,
+        _WIDTH,
+    )
+    assert torch.equal(out[:, :, 0], torch.ones_like(out[:, :, 0]))
+    assert torch.equal(out[:, :, 1], torch.full_like(out[:, :, 1], 2.0))

--- a/test/datapipes/test_healpix_couplers.py
+++ b/test/datapipes/test_healpix_couplers.py
@@ -22,8 +22,12 @@ import pytest
 import torch
 
 xr = pytest.importorskip("xarray")
+zarr = pytest.importorskip("zarr")
 
-from physicsnemo.datapipes.healpix.couplers import ConstantCoupler
+from physicsnemo.datapipes.healpix.couplers import (  # noqa: E402
+    ConstantCoupler,
+    TrailingAverageCoupler,
+)
 
 _FACE, _HEIGHT, _WIDTH = 2, 3, 4
 _N_CHANNELS = 2
@@ -68,6 +72,18 @@ def _make_coupler(batch_size, output_time_dim=1):
 def _coupled_fields(batch, timedim=3):
     """Return fields in [B, F, T, C, H, W] layout."""
     return torch.rand(batch, _FACE, timedim, _N_CHANNELS, _HEIGHT, _WIDTH)
+
+
+def test_base_coupler_invalid_dataset_type():
+    with pytest.raises(
+        TypeError,
+        match=("Coupler only supports xarray Datasets or zarr Groups"),
+    ):
+        ConstantCoupler(
+            dataset={"inputs": np.zeros((4, 12, 1, 4, 4))},
+            batch_size=1,
+            variables=["z500"],
+        )
 
 
 def test_set_coupled_fields_adapts_to_provided_batch_size():
@@ -116,3 +132,163 @@ def test_set_coupled_fields_broadcasts_all_channels_from_first_time():
     )
     assert torch.equal(out[:, :, 0], torch.ones_like(out[:, :, 0]))
     assert torch.equal(out[:, :, 1], torch.full_like(out[:, :, 1], 2.0))
+
+
+def test_reset_coupler_requires_batch_and_bsize():
+    coupler = _make_coupler(batch_size=2)
+    coupler.set_coupled_fields(_coupled_fields(2, timedim=3))
+    coupler.reset_coupler()
+
+    with pytest.raises(
+        ValueError,
+        match=("batch and bsize must be provided when not in coupled_mode"),
+    ):
+        coupler.construct_integrated_couplings()
+
+
+def test_set_scaling_missing_variable_raises():
+    coupler = _make_coupler(batch_size=1)
+    scaling_da = (
+        pd.DataFrame({"mean": [0.0], "std": [1.0]}, index=["c0"])
+        .rename_axis("index")
+        .to_xarray()
+        .astype("float32")
+    )
+
+    with pytest.raises(
+        KeyError,
+        match=("Coupled variable\\(s\\) not found in scaling values"),
+    ):
+        coupler.set_scaling(scaling_da)
+
+
+def test_zarr_variable_order_matches_requested_variables(tmp_path):
+    """Zarr path must honor `variables` order, not native channel_in order."""
+    native_channels = ["a", "b", "c"]
+    requested = ["c", "a"]
+    n_time = 4
+    data = np.arange(
+        n_time * len(native_channels) * _FACE * _HEIGHT * _WIDTH,
+        dtype="float32",
+    ).reshape(n_time, len(native_channels), _FACE, _HEIGHT, _WIDTH)
+
+    ds = xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("time", "channel_in", "face", "height", "width"),
+                data,
+            )
+        },
+        coords={
+            "time": pd.date_range("1979-01-01", periods=n_time, freq="3h"),
+            "channel_in": native_channels,
+            "face": np.arange(_FACE),
+            "height": np.arange(_HEIGHT),
+            "width": np.arange(_WIDTH),
+        },
+    )
+    dataset_path = tmp_path / "order.zarr"
+    ds.to_zarr(dataset_path)
+
+    xr_ds = xr.open_zarr(dataset_path)
+    zarr_ds = zarr.open(str(dataset_path))
+    batch_size = 2
+    batch = {"time": slice(0, 2)}
+
+    coupler_xr = ConstantCoupler(
+        dataset=xr_ds,
+        batch_size=batch_size,
+        variables=requested,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler_zarr = ConstantCoupler(
+        dataset=zarr_ds,
+        batch_size=batch_size,
+        variables=requested,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler_xr.compute_coupled_indices(interval=1, data_time_step="3h")
+    coupler_zarr.compute_coupled_indices(interval=1, data_time_step="3h")
+
+    coupled_xr = coupler_xr.construct_integrated_couplings(
+        batch=batch, bsize=batch_size
+    )
+    coupled_zarr = coupler_zarr.construct_integrated_couplings(
+        batch=batch, bsize=batch_size
+    )
+
+    input_indices = [native_channels.index(v) for v in requested]
+    expected = zarr_ds["inputs"][:2][:, input_indices]
+    assert np.array_equal(expected, coupled_xr[0])
+    assert np.array_equal(expected, coupled_zarr[0])
+    assert coupler_zarr.ds_variable_indices == input_indices
+
+    for i, var in enumerate(requested):
+        expected_var = zarr_ds["inputs"][:2][:, native_channels.index(var)]
+        assert np.array_equal(expected_var, coupled_zarr[0][:, i])
+        assert np.array_equal(expected_var, coupled_xr[0][:, i])
+
+
+def test_trailing_average_preserves_all_coupled_variables():
+    """TrailingAverageCoupler must keep every coupled variable through averaging."""
+    variables = ["c0", "c1", "c2"]
+    input_times = ["6h", "12h"]
+    batch_size = 2
+    coupler = TrailingAverageCoupler(
+        dataset=_make_coupler_dataset(variables + ["x"], n_time=16),
+        batch_size=batch_size,
+        variables=variables,
+        presteps=0,
+        averaging_window="6h",
+        input_times=input_times,
+        input_time_dim=2,
+        output_time_dim=2,
+    )
+    coupler.coupled_channel_indices = list(range(len(variables)))
+
+    data_time_step = "3h"
+    averaging_window_max_indices = [
+        pd.Timedelta(t) // pd.Timedelta(data_time_step) for t in input_times
+    ]
+    di = averaging_window_max_indices[0]
+    averaging_slices = []
+    for j in range(coupler.coupled_integration_dim):
+        averaging_slices.append([])
+        for i, r in enumerate(averaging_window_max_indices):
+            averaging_slices[j].append(
+                slice(
+                    coupler.input_time_dim * j * di + i * di,
+                    coupler.input_time_dim * j * di + r,
+                )
+            )
+    coupler.averaging_slices = averaging_slices
+
+    channel_values = [100.0, 200.0, 300.0]
+    coupled_fields = torch.empty(
+        batch_size,
+        coupler.spatial_dims[0],
+        4,
+        len(variables),
+        coupler.spatial_dims[1],
+        coupler.spatial_dims[2],
+    )
+    for i, value in enumerate(channel_values):
+        coupled_fields[:, :, :, i, :, :] = value
+
+    coupler.set_coupled_fields(coupled_fields)
+    result = coupler.construct_integrated_couplings()
+    assert list(result.shape) == [
+        coupler.coupled_integration_dim,
+        batch_size,
+        coupler.timevar_dim,
+    ] + list(coupler.spatial_dims)
+
+    for period in range(len(input_times)):
+        for var_idx, value in enumerate(channel_values):
+            timevar_idx = period * len(variables) + var_idx
+            slice_result = result[:, :, timevar_idx, :, :, :]
+            assert torch.allclose(slice_result, torch.full_like(slice_result, value))

--- a/test/datapipes/test_healpix_zarr.py
+++ b/test/datapipes/test_healpix_zarr.py
@@ -89,6 +89,65 @@ def scaling_double_dict():
     return omegaconf.DictConfig(scaling)
 
 
+def test_object_store_path_helpers(tmp_path):
+    from physicsnemo.datapipes.healpix.base_timeseries_dataset_zarr import (
+        _check_availability,
+        _is_object_store_path,
+    )
+
+    assert _is_object_store_path("s3://bucket/data.zarr")
+    assert _is_object_store_path("simplecache::s3://bucket/data.zarr")
+    assert not _is_object_store_path(str(tmp_path / "local.zarr"))
+
+    existing_path = tmp_path / "exists.zarr"
+    existing_path.mkdir()
+    _check_availability(str(existing_path))
+
+    with pytest.raises(FileNotFoundError, match=("Dataset not found at")):
+        _check_availability(str(tmp_path / "missing.zarr"))
+
+    if importlib.util.find_spec("fsspec"):
+        _check_availability("s3://bucket-that-does-not-exist/missing.zarr")
+    else:
+        with pytest.raises(
+            ImportError, match=("fsspec is required to access object store paths")
+        ):
+            _check_availability("s3://bucket-that-does-not-exist/missing.zarr")
+
+
+def test_TimeSeriesDataset_missing_time(tmp_path):
+    from physicsnemo.datapipes.healpix.timeseries_dataset_zarr import (
+        TimeSeriesDatasetZarr,
+    )
+
+    no_time_ds = xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("t", "channel_in", "face", "height", "width"),
+                np.zeros((3, 1, 1, 2, 2), dtype="float32"),
+            ),
+            "targets": (
+                ("t", "channel_out", "face", "height", "width"),
+                np.zeros((3, 1, 1, 2, 2), dtype="float32"),
+            ),
+        },
+        coords={
+            "channel_in": ["z500"],
+            "channel_out": ["z500"],
+        },
+    )
+    dataset_path = tmp_path / "no_time.zarr"
+    no_time_ds.to_zarr(dataset_path)
+
+    with pytest.raises(KeyError, match=("Dataset missing time")):
+        TimeSeriesDatasetZarr(
+            dataset_path=str(dataset_path),
+            input_variables=["z500"],
+            start_date="1979-01-01",
+            end_date="1979-01-02",
+        )
+
+
 @import_or_fail("omegaconf")
 @import_or_fail("netCDF4")
 @nfsdata_or_fail


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
Fix incorrect handling of constant coupler in DLESyM coupling code

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->