### PR TITLE
Extend diagnostic variable and residual prediction wiring to HEALPixUNet

### DIFF
--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -392,7 +392,7 @@ class HEALPixUNet(Module):
             decodings = self.decoder(encodings, **kwargs)
 
             # Residual prediction applies only to prognostics; diagnostics are
-            # absolute (same split as HEALPixRecUNet / PR #41).
+            # absolute (same split as HEALPixRecUNet).
             combined = self._reshape_outputs(decodings)
             prognostics = combined[:, :, :, : self.input_channels]
             if self.residual_prediction:

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -366,13 +366,20 @@ class HEALPixUNet(Module):
                 else:
                     input_tensor = self._reshape_inputs(inputs, step)
             else:
+                # Autoregressive steps only feed prognostics back; diagnostic
+                # channels (e.g. tp6, msl) are outputs-only, matching RecUNet.
                 if len(self.couplings) > 0:
                     input_tensor = self._reshape_inputs(
-                        [outputs[-1]] + list(inputs[1:3]) + [inputs[3][step]], step
+                        [outputs[-1][:, :, :, : self.input_channels]]
+                        + list(inputs[1:3])
+                        + [inputs[3][step]],
+                        step,
                     )
                 else:
                     input_tensor = self._reshape_inputs(
-                        [outputs[-1]] + list(inputs[1:]), step
+                        [outputs[-1][:, :, :, : self.input_channels]]
+                        + list(inputs[1:]),
+                        step,
                     )
 
             kwargs = {}
@@ -384,21 +391,23 @@ class HEALPixUNet(Module):
             encodings = self.encoder(input_tensor, **kwargs)
             decodings = self.decoder(encodings, **kwargs)
 
+            # Residual prediction applies only to prognostics; diagnostics are
+            # absolute (same split as HEALPixRecUNet / PR #41).
+            combined = self._reshape_outputs(decodings)
+            prognostics = combined[:, :, :, : self.input_channels]
             if self.residual_prediction:
-                prediction = input_tensor[:, : self.input_channels * self.input_time_dim] + decodings
-            else:
-                prediction = decodings
-            
-            reshaped = self._reshape_outputs(
-                prediction
-            )
+                prognostics += self._reshape_outputs(
+                    input_tensor[:, : self.input_channels * self.input_time_dim]
+                )
+            diagnostics = combined[:, :, :, self.input_channels :]
+            out = th.cat([prognostics, diagnostics], dim=3)
 
             # Apply constraints
             if self.constraints is not None:
                 for constraint in self.constraints:
-                    reshaped = constraint(reshaped)
+                    out = constraint(out)
 
-            outputs.append(reshaped)
+            outputs.append(out)
 
         if output_only_last:
             res = outputs[-1]


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description

Extend RecUNet diagnostic variable and residual prediction wiring to the non-recurrent `HEALPixUNet`.

Autoregressive steps feed only prognostics back; residuals apply to prognostics only; diagnostics stay absolute. RecUNet/datapipe support already lives on `dev`; this mirrors that behavior for `HEALPixUNet`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None.
