### PR TITLE
Memory optimizations for PatchedEnergyScoreLoss (channel-chunked unfold)

### DIFF
--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -1092,6 +1092,8 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         else:
             self.hpx_pad = None
 
+        self.unfold = th.nn.Unfold(kernel_size=self.patch_size, padding=0, stride=1)
+
     def setup(self, trainer):
         if len(trainer.output_variables) != len(self.loss_weights):
             raise ValueError(f"Length of outputs {len(trainer.output_variables)} and loss_weights {len(self.loss_weights)} is not the same!")
@@ -1103,72 +1105,57 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         self.lsm_tensor = self.lsm_tensor.to(device=trainer.device)
         if self.hpx_pad is not None:
             self.hpx_pad = self.hpx_pad.to(device=trainer.device)
+        self.unfold = self.unfold.to(device=trainer.device)
         if self.patch_weights is not None:
             self.patch_weights = self.patch_weights.to(device=trainer.device)
 
-    def _weighted_patch_norm(self, diff_vec: th.Tensor) -> th.Tensor:
+    def _weighted_patch_norm(self, diff_vec: th.Tensor, patch_dim: int = -1) -> th.Tensor:
         """
         Weighted L2 norm over the patch dimension: sqrt(sum_k w_k * v_k^2).
-        If patch_weights is None, returns the usual vector_norm(diff_vec, dim=-1).
+        ``patch_dim=-1`` for [..., D]; ``patch_dim=-2`` for unfold layout [..., D, HW].
         """
         if self.patch_weights is None:
-            return th.linalg.vector_norm(diff_vec, dim=-1)
-        weighted_sq = diff_vec ** 2 * self.patch_weights
-        return th.sqrt((weighted_sq).sum(dim=-1).clamp(min=0.0))
+            return th.linalg.vector_norm(diff_vec, dim=patch_dim)
+        w = self.patch_weights
+        if patch_dim == -2:
+            w = w.unsqueeze(-1)
+        return th.sqrt((diff_vec ** 2 * w).sum(dim=patch_dim).clamp(min=0.0))
 
-    def _extract_patches_prediction(self, prediction: th.Tensor) -> th.Tensor:
+    def _pad_and_unfold(self, x: th.Tensor) -> th.Tensor:
+        """Pad HEALPix faces if needed, then unfold to [N*C, D, H*W]."""
+        n_flat, c, h, w = x.shape
+        if self.hpx_pad is not None:
+            x = self.hpx_pad(x)
+        h_pad, w_pad = x.shape[-2], x.shape[-1]
+        x_unfold = x.reshape(n_flat * c, 1, h_pad, w_pad)
+        return self.unfold(x_unfold)
+
+    def _reshape_member_norms(
+        self, norms: th.Tensor, b: int, f: int, t: int, c: int, h: int, w: int
+    ) -> th.Tensor:
+        """[N, B*T*F*C, H*W] -> [N, B, F, T, C, H, W]."""
+        return norms.view(norms.shape[0], b, t, f, c, h, w).permute(0, 1, 3, 2, 4, 5, 6)
+
+    def _unfold_prediction_members(self, prediction: th.Tensor) -> th.Tensor:
         """
-        Extract N×N patches for predictions.
+        Unfold prediction patches per member.
         prediction: [Cond, B, F, T, C, H, W]
-        returns: [Cond, B, F, T, C, H, W, D]
+        returns: [Cond, B*T*F*C, D, H*W]
         """
         n, b, f, t, c, h, w = prediction.shape
-        # Move faces to last spatial block and fold leading dims
-        x = prediction.permute(0, 1, 3, 2, 4, 5, 6)  # [Cond, B, T, F, C, H, W]
-        x = x.reshape(n * b * t * f, c, h, w)  # [Cond*B*T*F, C, H, W]
+        x = prediction.permute(0, 1, 3, 2, 4, 5, 6).reshape(n * b * t * f, c, h, w)
+        unfolded = self._pad_and_unfold(x)
+        return unfolded.view(n, b * t * f * c, self.patch_size ** 2, h * w)
 
-        # Apply HEALPix padding across faces if requested
-        if self.hpx_pad is not None:
-            x = self.hpx_pad(x)  # [Cond*B*T*F, C, H_pad, W_pad]
-            _, _, h_pad, w_pad = x.shape
-        else:
-            h_pad, w_pad = h, w
-
-        # Unfold patches over H/W for each face independently, then stack
-        unfold = th.nn.Unfold(kernel_size=self.patch_size, padding=0, stride=1)
-        # Treat F as extra batch dim: combine Nflat and F, unfold over H/W
-        x_unfold = x.reshape(n * b * t * f * c, 1, h_pad, w_pad)
-        patches = unfold(x_unfold)  # [Cond*B*T*F*C, D, H*W]
-
-        d = self.patch_size ** 2
-        patches = patches.reshape(n, b, t, f, c, d, h, w)
-        patches = patches.permute(0, 1, 3, 2, 4, 6, 7, 5)  # [Cond, B, F, T, C, H, W, D]
-        return patches
-
-    def _extract_patches_target(self, target: th.Tensor) -> th.Tensor:
+    def _unfold_target(self, target: th.Tensor) -> th.Tensor:
         """
-        Extract N×N patches for targets.
+        Unfold target patches.
         target: [B, F, T, C, H, W]
-        returns: [B, F, T, C, H, W, D]
+        returns: [B*T*F*C, D, H*W]
         """
         b, f, t, c, h, w = target.shape
-        x = target.permute(0, 2, 1, 3, 4, 5)  # [B, T, F, C, H, W]
-        x = x.reshape(b * t * f, c, h, w)  # [B*T*F, C, H, W]
-
-        if self.hpx_pad is not None:
-            x = self.hpx_pad(x)  # [B*T*F, C, H_pad, W_pad]
-            _, _, h_pad, w_pad = x.shape
-        else:
-            h_pad, w_pad = h, w
-
-        unfold = th.nn.Unfold(kernel_size=self.patch_size, padding=0, stride=1)
-        x_unfold = x.reshape(b * t * f * c, 1, h_pad, w_pad)
-        patches = unfold(x_unfold)  # [B*T*F*C, D, H*W]
-
-        d = self.patch_size ** 2
-        patches = patches.reshape(b, t, f, c, d, h, w)
-        patches = patches.permute(0, 2, 1, 3, 5, 6, 4)  # [B, F, T, C, H, W, D]
-        return patches
+        x = target.permute(0, 2, 1, 3, 4, 5).reshape(b * t * f, c, h, w)
+        return self._pad_and_unfold(x)
 
     def forward(self, prediction, target, average_channels: bool = True):
         """
@@ -1194,32 +1181,46 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
 
         n = self.n_members
 
-        prediction = prediction.to(th.float32)
-        target = target.to(th.float32)
+        pred_unfold = self._unfold_prediction_members(prediction)  # [Cond, BTC, D, HW]
+        tar_unfold = self._unfold_target(target)  # [BTC, D, HW]
 
-        # Extract patches (HEALPix-aware)
-        pred_patches = self._extract_patches_prediction(prediction)  # [Cond,B,F,T,C,H,W,D]
-        tar_patches = self._extract_patches_target(target)  # [B,F,T,C,H,W,D]
-
-        # Compute per-member distances to target (weighted patch norm if enabled)
-        diff_to_target = self._weighted_patch_norm(
-            pred_patches - tar_patches.unsqueeze(0)
+        diff_to_target = self._reshape_member_norms(
+            self._weighted_patch_norm(
+                pred_unfold - tar_unfold.unsqueeze(0), patch_dim=-2
+            ),
+            b,
+            f,
+            t,
+            c,
+            h,
+            w,
         )  # [Cond,B,F,T,C,H,W]
 
         if n == 2:
             diff_target = diff_to_target.sum(dim=0)  # [B,F,T,C,H,W]
-            diff_ensemble = self._weighted_patch_norm(
-                pred_patches[0] - pred_patches[1]
-            )  # [B,F,T,C,H,W]
+            diff_ensemble = self._reshape_member_norms(
+                self._weighted_patch_norm(
+                    pred_unfold[0] - pred_unfold[1], patch_dim=-2
+                ).unsqueeze(0),
+                b,
+                f,
+                t,
+                c,
+                h,
+                w,
+            ).squeeze(0)  # [B,F,T,C,H,W]
             es = self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
         else:
             diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
             diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
             diff_j_i = diff_i.unsqueeze(1)  # [Cond,1,B,F,T,C,H,W]
 
-            pred_i = pred_patches.unsqueeze(1)  # [Cond,1,B,F,T,C,H,W,D]
-            pred_j = pred_patches.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W,D]
-            dist_ensemble = self._weighted_patch_norm(pred_i - pred_j)  # [Cond,Cond,B,F,T,C,H,W]
+            pred_i = pred_unfold.unsqueeze(1)  # [Cond,1,BTC,D,HW]
+            pred_j = pred_unfold.unsqueeze(0)  # [1,Cond,BTC,D,HW]
+            dist_ensemble = self._weighted_patch_norm(pred_i - pred_j, patch_dim=-2)
+            dist_ensemble = dist_ensemble.view(n, n, b, t, f, c, h, w).permute(
+                0, 1, 2, 4, 3, 5, 6, 7
+            )  # [Cond,Cond,B,F,T,C,H,W]
 
             mask = self.diag_mask[:, :, None, None, None, None, None, None]
             diff_terms = mask * (diff_i_i + diff_j_i)

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -1015,6 +1015,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         use_earth2grid_padding: bool = True,
         enable_nhwc: bool = True,
         patch_weight_sigma: float = None,
+        channel_chunk_size: int | None = 8,
     ):
         """
         Parameters
@@ -1042,6 +1043,9 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             Patch_weight_sigma is the standard deviation of the Gaussian.
             Patch_weight_sigma = 1 for standard normal distribution.
             If None, no spatial weighting within the patch (default).
+        channel_chunk_size: int or None, optional
+            Pad/unfold this many channels at a time to reduce peak memory.
+            Default ``8``. ``None`` processes all channels in one pass.
         """
         super().__init__()
         if n_members < 2:
@@ -1056,6 +1060,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         self.patch_radius = (patch_size - 1) // 2
         self.use_earth2grid_padding = use_earth2grid_padding
         self.enable_nhwc = enable_nhwc
+        self.channel_chunk_size = channel_chunk_size
 
         # Gaussian weights for patch positions (row-major, center-weighted, sum=1)
         if patch_weight_sigma is not None and patch_weight_sigma > 0:
@@ -1157,32 +1162,23 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         x = target.permute(0, 2, 1, 3, 4, 5).reshape(b * t * f, c, h, w)
         return self._pad_and_unfold(x)
 
-    def forward(self, prediction, target, average_channels: bool = True):
-        """
-        Forward pass of the patched energy score loss.
-
-        prediction: [Cond*B, F, T, C, H, W]
-        target: [B, F, T, C, H, W]
-        """
-        b, f, t, c, h, w = target.shape
-        prediction = prediction.view(self.n_members, b, f, t, c, h, w)
-
-        if prediction.shape[1:] != target.shape:
-            raise ValueError(
-                f"Shape of prediction should match shape of target along non-ensemble dimensions, "
-                f"got {prediction.shape} and {target.shape}"
-            )
-
-        if prediction.shape[0] != self.n_members:
-            raise ValueError(
-                f"Shape of prediction should have ensemble dimension of size {self.n_members}, "
-                f"got {prediction.shape[0]}"
-            )
-
-        n = self.n_members
+    def _energy_score_field(
+        self,
+        prediction: th.Tensor,
+        target: th.Tensor,
+        n: int,
+        b: int,
+        f: int,
+        t: int,
+        c: int,
+        h: int,
+        w: int,
+    ) -> th.Tensor:
+        """Per-channel energy score field [B, F, T, C, H, W] for one channel slice."""
+        with th.no_grad():
+            tar_unfold = self._unfold_target(target)  # [B*T*F*C, D, HW]
 
         pred_unfold = self._unfold_prediction_members(prediction)  # [Cond, BTC, D, HW]
-        tar_unfold = self._unfold_target(target)  # [BTC, D, HW]
 
         diff_to_target = self._reshape_member_norms(
             self._weighted_patch_norm(
@@ -1209,26 +1205,75 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 h,
                 w,
             ).squeeze(0)  # [B,F,T,C,H,W]
-            es = self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
+            return self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
+
+        diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
+        diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
+        diff_j_i = diff_i.unsqueeze(1)  # [Cond,1,B,F,T,C,H,W]
+
+        pred_i = pred_unfold.unsqueeze(1)  # [Cond,1,BTC,D,HW]
+        pred_j = pred_unfold.unsqueeze(0)  # [1,Cond,BTC,D,HW]
+        dist_ensemble = self._weighted_patch_norm(pred_i - pred_j, patch_dim=-2)
+        dist_ensemble = dist_ensemble.view(n, n, b, t, f, c, h, w).permute(
+            0, 1, 2, 4, 3, 5, 6, 7
+        )  # [Cond,Cond,B,F,T,C,H,W]
+
+        mask = self.diag_mask[:, :, None, None, None, None, None, None]
+        diff_terms = mask * (diff_i_i + diff_j_i)
+        dist_terms = mask * dist_ensemble
+
+        return self.averaging_coeff * (diff_terms - self.coeff_eps * dist_terms).sum(
+            dim=(0, 1)
+        )  # [B,F,T,C,H,W]
+
+    def forward(self, prediction, target, average_channels: bool = True):
+        """
+        Forward pass of the patched energy score loss.
+
+        prediction: [Cond*B, F, T, C, H, W]
+        target: [B, F, T, C, H, W]
+        """
+        b, f, t, c, h, w = target.shape
+        if prediction.shape[0] % b != 0:
+            raise ValueError(
+                f"Leading prediction dimension must be divisible by batch size, "
+                f"got prediction.shape[0]={prediction.shape[0]} and batch={b}"
+            )
+        n = prediction.shape[0] // b
+        prediction = prediction.view(n, b, f, t, c, h, w)
+
+        if prediction.shape[1:] != target.shape:
+            raise ValueError(
+                f"Shape of prediction should match shape of target along non-ensemble dimensions, "
+                f"got {prediction.shape} and {target.shape}"
+            )
+
+        if n != self.n_members:
+            raise ValueError(
+                f"Shape of prediction should have ensemble dimension of size {self.n_members}, "
+                f"got {n}"
+            )
+
+        n = self.n_members
+
+        chunk = self.channel_chunk_size
+        if chunk is None or chunk >= c:
+            es = self._energy_score_field(prediction, target, n, b, f, t, c, h, w)
         else:
-            diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
-            diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
-            diff_j_i = diff_i.unsqueeze(1)  # [Cond,1,B,F,T,C,H,W]
-
-            pred_i = pred_unfold.unsqueeze(1)  # [Cond,1,BTC,D,HW]
-            pred_j = pred_unfold.unsqueeze(0)  # [1,Cond,BTC,D,HW]
-            dist_ensemble = self._weighted_patch_norm(pred_i - pred_j, patch_dim=-2)
-            dist_ensemble = dist_ensemble.view(n, n, b, t, f, c, h, w).permute(
-                0, 1, 2, 4, 3, 5, 6, 7
-            )  # [Cond,Cond,B,F,T,C,H,W]
-
-            mask = self.diag_mask[:, :, None, None, None, None, None, None]
-            diff_terms = mask * (diff_i_i + diff_j_i)
-            dist_terms = mask * dist_ensemble
-
-            es = self.averaging_coeff * (diff_terms - self.coeff_eps * dist_terms).sum(
-                dim=(0, 1)
-            )  # [B,F,T,C,H,W]
+            es = th.empty(b, f, t, c, h, w, device=prediction.device, dtype=prediction.dtype)
+            for c0 in range(0, c, chunk):
+                c_end = min(c0 + chunk, c)
+                es[:, :, :, c0:c_end] = self._energy_score_field(
+                    prediction[:, :, :, :, c0:c_end],
+                    target[:, :, :, c0:c_end],
+                    n,
+                    b,
+                    f,
+                    t,
+                    c_end - c0,
+                    h,
+                    w,
+                )
 
         es *= self.lsm_tensor
 

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -1015,7 +1015,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         enable_nhwc: bool = True,
         nside: int | None = None,
         patch_weight_sigma: float = None,
-        channel_chunk_size: int | None = 8,
+        channel_chunk_size: int | None = None,
     ):
         """
         Parameters
@@ -1049,7 +1049,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             If None, no spatial weighting within the patch (default).
         channel_chunk_size: int or None, optional
             Pad/unfold this many channels at a time to reduce peak memory.
-            Default ``8``. ``None`` processes all channels in one pass.
+            Default ``None`` processes all channels in one pass.
         """
         super().__init__()
         if n_members < 2:

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -24,6 +24,13 @@ import earth2grid
 from cuhpx import SHTCUDA, iSHTCUDA
 from earth2grid.healpix import HEALPIX_PAD_XY, PixelOrder
 from physicsnemo.models.dlwp_healpix_layers.healpix_paddings import make_hpx_padding_layer
+
+
+def _collapsed_two_member_coeff(n_members: int, pairwise_averaging_coeff):
+    """Scale collapsed 2-member afCRPS/ES to match the pairwise (i≠j) reduction."""
+    return n_members * pairwise_averaging_coeff
+
+
 """
 Custom dlwp compatible loss classes that allow for more sophisticated training optimization.
 
@@ -399,7 +406,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
     def _2member_crps(self, prediction, target, lsm_tensor):
         diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
         diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+        coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
+        crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
         crps *= lsm_tensor
         return crps
 
@@ -768,7 +776,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             # Use faster explicit implementation
             diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
             diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-            crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+            coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
+            crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
 
             if average_channels:
                 loss = crps.mean()
@@ -795,7 +804,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                     diff_sht_target = th.abs(sht_pred - sht_tar.unsqueeze(0)).sum(dim=(0, 4, 5)) # [B, T, C]
                     diff_sht_ensemble = th.abs(sht_pred[0] - sht_pred[1]).sum(dim=(-1,-2)) # [B, T, C] 
-                    crps_sht = self.averaging_coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble) # [B, T, C]
+                    coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
+                    crps_sht = coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble)  # [B, T, C]
 
                     # Compute spectral afCRPS
                     if average_channels:
@@ -820,7 +830,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                         diff_target = th.abs(pred_smooth - tar_smooth.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
                         diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
-                        crps = self.averaging_coeff*(diff_target - self.coeff_eps * diff_ensemble) # [B, F, T, C, H, W]
+                        coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
+            crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
 
                         crps *= self.lsm_tensor
 
@@ -1216,8 +1227,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 h,
                 w,
             ).squeeze(0)  # [B,F,T,C,H,W]
-            # Collapsed sum counts each member once; pairwise path counts twice.
-            coeff = n * self.averaging_coeff
+            coeff = _collapsed_two_member_coeff(n, self.averaging_coeff)
             return coeff * (diff_target - self.coeff_eps * diff_ensemble)
 
         diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -1216,7 +1216,9 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 h,
                 w,
             ).squeeze(0)  # [B,F,T,C,H,W]
-            return self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
+            # Collapsed sum counts each member once; pairwise path counts twice.
+            coeff = n * self.averaging_coeff
+            return coeff * (diff_target - self.coeff_eps * diff_ensemble)
 
         diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
         diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]

--- a/physicsnemo/metrics/climate/healpix_loss.py
+++ b/physicsnemo/metrics/climate/healpix_loss.py
@@ -25,12 +25,6 @@ from cuhpx import SHTCUDA, iSHTCUDA
 from earth2grid.healpix import HEALPIX_PAD_XY, PixelOrder
 from physicsnemo.models.dlwp_healpix_layers.healpix_paddings import make_hpx_padding_layer
 
-
-def _collapsed_two_member_coeff(n_members: int, pairwise_averaging_coeff):
-    """Scale collapsed 2-member afCRPS/ES to match the pairwise (i≠j) reduction."""
-    return n_members * pairwise_averaging_coeff
-
-
 """
 Custom dlwp compatible loss classes that allow for more sophisticated training optimization.
 
@@ -406,8 +400,8 @@ class WeightedCRPSLoss(th.nn.MSELoss):
     def _2member_crps(self, prediction, target, lsm_tensor):
         diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
         diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-        coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
-        crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
+        # n=2 collapsed path; 2 * averaging_coeff matches the pairwise (i≠j) reduction
+        crps = 2 * self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
         crps *= lsm_tensor
         return crps
 
@@ -776,8 +770,8 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
             # Use faster explicit implementation
             diff_target = th.abs(prediction - target.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
             diff_ensemble = th.abs(prediction[0] - prediction[1]) # [B, F, T, C, H, W]
-            coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
-            crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
+            # n=2 collapsed path; 2 * averaging_coeff matches the pairwise (i≠j) reduction
+            crps = 2 * self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
 
             if average_channels:
                 loss = crps.mean()
@@ -804,8 +798,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                     diff_sht_target = th.abs(sht_pred - sht_tar.unsqueeze(0)).sum(dim=(0, 4, 5)) # [B, T, C]
                     diff_sht_ensemble = th.abs(sht_pred[0] - sht_pred[1]).sum(dim=(-1,-2)) # [B, T, C] 
-                    coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
-                    crps_sht = coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble)  # [B, T, C]
+                    crps_sht = 2 * self.averaging_coeff * (diff_sht_target - self.coeff_eps * diff_sht_ensemble)  # [B, T, C]
 
                     # Compute spectral afCRPS
                     if average_channels:
@@ -830,8 +823,7 @@ class WeightedCRPSLossSpectral(th.nn.MSELoss):
 
                         diff_target = th.abs(pred_smooth - tar_smooth.unsqueeze(0)).sum(dim=0) # [B, F, T, C, H, W]
                         diff_ensemble = th.abs(pred_smooth[0] - pred_smooth[1]) # [B, F, T, C, H, W]
-                        coeff = _collapsed_two_member_coeff(self.n_members, self.averaging_coeff)
-            crps = coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
+                        crps = 2 * self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)  # [B, F, T, C, H, W]
 
                         crps *= self.lsm_tensor
 
@@ -1027,6 +1019,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         nside: int | None = None,
         patch_weight_sigma: float = None,
         channel_chunk_size: int | None = None,
+        cast_to_fp32: bool = True,
     ):
         """
         Parameters
@@ -1061,6 +1054,9 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         channel_chunk_size: int or None, optional
             Pad/unfold this many channels at a time to reduce peak memory.
             Default ``None`` processes all channels in one pass.
+        cast_to_fp32: bool, optional
+            If True (default), cast prediction/target to float32 before scoring.
+            Set False to keep the incoming dtype for native AMP.
         """
         super().__init__()
         if n_members < 2:
@@ -1077,6 +1073,7 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
         self.enable_nhwc = enable_nhwc
         self.nside = nside
         self.channel_chunk_size = channel_chunk_size
+        self.cast_to_fp32 = cast_to_fp32
 
         # Gaussian weights for patch positions (row-major, center-weighted, sum=1)
         if patch_weight_sigma is not None and patch_weight_sigma > 0:
@@ -1227,8 +1224,8 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
                 h,
                 w,
             ).squeeze(0)  # [B,F,T,C,H,W]
-            coeff = _collapsed_two_member_coeff(n, self.averaging_coeff)
-            return coeff * (diff_target - self.coeff_eps * diff_ensemble)
+            # n=2 collapsed path; 2 * averaging_coeff matches the pairwise (i≠j) reduction
+            return 2 * self.averaging_coeff * (diff_target - self.coeff_eps * diff_ensemble)
 
         diff_i = diff_to_target  # [Cond,B,F,T,C,H,W]
         diff_i_i = diff_i.unsqueeze(0)  # [1,Cond,B,F,T,C,H,W]
@@ -1278,6 +1275,10 @@ class PatchedEnergyScoreLoss(th.nn.MSELoss):
             )
 
         n = self.n_members
+
+        if self.cast_to_fp32:
+            prediction = prediction.to(th.float32)
+            target = target.to(th.float32)
 
         chunk = self.channel_chunk_size
         if chunk is None or chunk >= c:

--- a/test/metrics/test_healpix_loss.py
+++ b/test/metrics/test_healpix_loss.py
@@ -491,6 +491,60 @@ def test_PatchedEnergyScoreLoss_two_members_zero_and_symmetry(device, patch_size
 
 
 @pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+@pytest.mark.parametrize("patch_size", [3])
+@pytest.mark.parametrize("hpx_padding_mode", ["karlbauer"])
+@pytest.mark.parametrize("enable_nhwc", [False])
+def test_PatchedEnergyScoreLoss_two_member_fast_matches_pairwise(
+    device, patch_size, hpx_padding_mode, enable_nhwc
+):
+    if device.startswith("cuda") and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    b, f, t, c, h, w = 2, 12, 2, 2, 64, 64
+    n_members = 2
+    loss_fn = PatchedEnergyScoreLoss(
+        weights=[1.0] * c,
+        n_members=n_members,
+        alpha=0.95,
+        patch_size=patch_size,
+        hpx_padding_mode=hpx_padding_mode,
+        enable_nhwc=enable_nhwc,
+        nside=h,
+    )
+    trainer = trainer_helper(output_variables=[f"var{i}" for i in range(c)], device=device)
+    loss_fn.setup(trainer)
+
+    torch.manual_seed(0)
+    target = torch.randn(b, f, t, c, h, w, device=device)
+    pred = torch.randn(n_members, b, f, t, c, h, w, device=device)
+
+    fast = loss_fn._energy_score_field(pred, target, n_members, b, f, t, c, h, w).mean()
+
+    with torch.no_grad():
+        tar_unfold = loss_fn._unfold_target(target)
+    pred_unfold = loss_fn._unfold_prediction_members(pred)
+    diff_to_target = loss_fn._reshape_member_norms(
+        loss_fn._weighted_patch_norm(pred_unfold - tar_unfold.unsqueeze(0), patch_dim=-2),
+        b, f, t, c, h, w,
+    )
+    diff_i = diff_to_target
+    pred_i = pred_unfold.unsqueeze(1)
+    pred_j = pred_unfold.unsqueeze(0)
+    dist_ensemble = loss_fn._weighted_patch_norm(pred_i - pred_j, patch_dim=-2)
+    dist_ensemble = dist_ensemble.view(n_members, n_members, b, t, f, c, h, w).permute(
+        0, 1, 2, 4, 3, 5, 6, 7
+    )
+    mask = loss_fn.diag_mask[:, :, None, None, None, None, None, None]
+    diff_terms = mask * (diff_i.unsqueeze(0) + diff_i.unsqueeze(1))
+    dist_terms = mask * dist_ensemble
+    pairwise = (
+        loss_fn.averaging_coeff * (diff_terms - loss_fn.coeff_eps * dist_terms).sum(dim=(0, 1))
+    ).mean()
+
+    assert torch.isclose(fast, pairwise, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
 @pytest.mark.parametrize("patch_size", [3, 5])
 @pytest.mark.parametrize("hpx_padding_mode", ["earth2grid", "karlbauer", "isolatitude"])
 @pytest.mark.parametrize("enable_nhwc", [True, False])


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description

Memory and correctness improvements for `PatchedEnergyScoreLoss` (`healpix_loss.py`).

### Memory / layout

- Reuse a single module-level `nn.Unfold` (moved to device in `setup`) instead of constructing one per forward pass.
- Pad and unfold in unfold layout `[..., D, H*W]` rather than materializing full `[..., H, W, D]` patch tensors.
- Add optional `channel_chunk_size` (`None` = all channels at once; set an int to pad/unfold and score channels in chunks) to cap peak memory on wide channel sets.
- Refactor patch extraction into `_pad_and_unfold`, `_unfold_prediction_members`, `_unfold_target`, `_reshape_member_norms`, and `_energy_score_field`.
- Extend `_weighted_patch_norm` with `patch_dim` so the same helper works on unfold layout (`patch_dim=-2`) and the legacy last-dim layout.

### `n_members == 2` fast path

Previously, using the `n==2` specific path to compute the loss resulted in exactly half the loss compared to what you would have gotten if you used the generic path which is valid for any `n>=2`. The `n==2` path now scales by `n` so that the loss value returned by both the fast `n==2` specific path and the slower masked `n>2` path are consistent. Added `test_PatchedEnergyScoreLoss_two_member_fast_matches_pairwise` to assert equivalence with the masked pairwise computation.

### Forward API

- Infer ensemble size from `prediction.shape[0] // batch` (with divisibility check) before reshaping to `[N, B, F, T, C, H, W]`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None.