### PR TITLE
Composable soft physical constraints for HEALPix losses

### DIFF
--- a/physicsnemo/metrics/climate/healpix_soft_constraints.py
+++ b/physicsnemo/metrics/climate/healpix_soft_constraints.py
@@ -55,7 +55,6 @@ class SoftConstraint(torch.nn.Module):
         *,
         input: Optional[torch.Tensor] = None,
         average_channels: bool = True,
-        **kwargs,
     ) -> torch.Tensor:
         raise NotImplementedError
 
@@ -242,7 +241,6 @@ class HydrostasySoftConstraint(SoftConstraint):
         *,
         input: Optional[torch.Tensor] = None,
         average_channels: bool = True,
-        **kwargs,
     ) -> torch.Tensor:
         with torch.amp.autocast("cuda", enabled=False):
             prediction = prediction.float()
@@ -355,7 +353,6 @@ class DryAirMassSoftConstraint(SoftConstraint):
         *,
         input: Optional[torch.Tensor] = None,
         average_channels: bool = True,
-        **kwargs,
     ) -> torch.Tensor:
         if input is None:
             raise ValueError(
@@ -394,6 +391,10 @@ class LossWithSoftConstraints(torch.nn.Module):
     Loss-agnostic wrapper that adds zero or more soft constraints to a data loss.
 
     Compatible with the DLWP trainer ``setup`` / ``average_channels`` conventions.
+
+    ``needs_input`` is True if any child soft constraint requires the prognostic
+    input tensor. Trainers should use that flag (rather than unconditionally
+    forwarding ``input=``) so ordinary data losses need not accept ``**kwargs``.
     """
 
     def __init__(
@@ -407,6 +408,11 @@ class LossWithSoftConstraints(torch.nn.Module):
             constraints = []
         self.constraints = torch.nn.ModuleList(list(constraints))
 
+    @property
+    def needs_input(self) -> bool:
+        """Whether any attached soft constraint requires prognostic input."""
+        return any(getattr(c, "needs_input", False) for c in self.constraints)
+
     def setup(self, trainer) -> None:
         if hasattr(self.data_loss, "setup"):
             self.data_loss.setup(trainer)
@@ -419,13 +425,13 @@ class LossWithSoftConstraints(torch.nn.Module):
         target: torch.Tensor,
         average_channels: bool = True,
         input: Optional[torch.Tensor] = None,
-        **kwargs,
     ) -> torch.Tensor:
+        # Call the data loss with the standard criterion signature only. Do not
+        # forward soft-constraint kwargs into unrelated losses.
         data = self.data_loss(
             prediction,
             target,
             average_channels=average_channels,
-            **kwargs,
         )
         if len(self.constraints) == 0:
             return data
@@ -436,7 +442,6 @@ class LossWithSoftConstraints(torch.nn.Module):
                 target,
                 input=input,
                 average_channels=average_channels,
-                **kwargs,
             )
             for c in self.constraints
         ]

--- a/physicsnemo/metrics/climate/healpix_soft_constraints.py
+++ b/physicsnemo/metrics/climate/healpix_soft_constraints.py
@@ -40,7 +40,12 @@ def _error_tolerant(error: torch.Tensor) -> torch.Tensor:
 
 
 class SoftConstraint(torch.nn.Module):
-    """Base class for soft constraints composed by :class:`LossWithSoftConstraints`."""
+    """Base class for soft constraints composed by :class:`LossWithSoftConstraints`.
+
+    Subclasses set ``needs_input`` and must match that flag in ``constraint_loss``:
+    if ``needs_input`` is False, do not accept an ``input`` argument; if True,
+    require ``input`` as a keyword-only argument.
+    """
 
     needs_input: bool = False
 
@@ -53,7 +58,6 @@ class SoftConstraint(torch.nn.Module):
         prediction: torch.Tensor,
         target: torch.Tensor,
         *,
-        input: Optional[torch.Tensor] = None,
         average_channels: bool = True,
     ) -> torch.Tensor:
         raise NotImplementedError
@@ -239,7 +243,6 @@ class HydrostasySoftConstraint(SoftConstraint):
         prediction: torch.Tensor,
         target: torch.Tensor,
         *,
-        input: Optional[torch.Tensor] = None,
         average_channels: bool = True,
     ) -> torch.Tensor:
         with torch.amp.autocast("cuda", enabled=False):
@@ -351,7 +354,7 @@ class DryAirMassSoftConstraint(SoftConstraint):
         prediction: torch.Tensor,
         target: torch.Tensor,
         *,
-        input: Optional[torch.Tensor] = None,
+        input: torch.Tensor,
         average_channels: bool = True,
     ) -> torch.Tensor:
         if input is None:
@@ -392,10 +395,10 @@ class LossWithSoftConstraints(torch.nn.Module):
 
     Compatible with the DLWP trainer ``setup`` / ``average_channels`` conventions.
 
-    ``needs_input`` is True if any child soft constraint requires the prognostic
-    input tensor. Trainers should use that flag (rather than unconditionally
-    forwarding ``input=``) so ordinary data losses can keep a plain
-    ``(prediction, target, average_channels=...)`` signature.
+    ``needs_input`` is True iff any child soft constraint requires prognostic
+    input. When True, ``forward`` accepts required keyword ``input=``; when
+    False, ``forward`` does not accept ``input``. Trainers should gate passing
+    prognostic tensors solely on ``needs_input``.
     """
 
     def __init__(
@@ -408,11 +411,16 @@ class LossWithSoftConstraints(torch.nn.Module):
         if constraints is None:
             constraints = []
         self.constraints = torch.nn.ModuleList(list(constraints))
-
-    @property
-    def needs_input(self) -> bool:
-        """Whether any attached soft constraint requires prognostic input."""
-        return any(getattr(c, "needs_input", False) for c in self.constraints)
+        # Instance attribute (not a property) so trainers can use getattr(..., False).
+        self.needs_input = any(
+            getattr(c, "needs_input", False) for c in self.constraints
+        )
+        # Bind a forward whose signature matches needs_input: include ``input``
+        # only when at least one soft constraint requires it.
+        if self.needs_input:
+            self.forward = self._forward_with_input
+        else:
+            self.forward = self._forward_without_input
 
     def setup(self, trainer) -> None:
         if hasattr(self.data_loss, "setup"):
@@ -420,38 +428,86 @@ class LossWithSoftConstraints(torch.nn.Module):
         for constraint in self.constraints:
             constraint.setup(trainer)
 
-    def forward(
+    def _constraint_parts(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        average_channels: bool,
+        input: Optional[torch.Tensor],
+    ) -> list[torch.Tensor]:
+        parts = []
+        for constraint in self.constraints:
+            if constraint.needs_input:
+                parts.append(
+                    constraint.constraint_loss(
+                        prediction,
+                        target,
+                        input=input,
+                        average_channels=average_channels,
+                    )
+                )
+            else:
+                parts.append(
+                    constraint.constraint_loss(
+                        prediction,
+                        target,
+                        average_channels=average_channels,
+                    )
+                )
+        return parts
+
+    def _combine(
+        self,
+        data: torch.Tensor,
+        parts: list[torch.Tensor],
+        average_channels: bool,
+    ) -> torch.Tensor:
+        if not parts:
+            return data
+        if average_channels:
+            total = data
+            for p in parts:
+                total = total + p
+            return total
+        pieces = [data]
+        for p in parts:
+            pieces.append(p if p.dim() > 0 else p.unsqueeze(0))
+        return torch.cat(pieces)
+
+    def _forward_without_input(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        average_channels: bool = True,
+    ) -> torch.Tensor:
+        data = self.data_loss(
+            prediction,
+            target,
+            average_channels=average_channels,
+        )
+        parts = self._constraint_parts(
+            prediction, target, average_channels, input=None
+        )
+        return self._combine(data, parts, average_channels)
+
+    def _forward_with_input(
         self,
         prediction: torch.Tensor,
         target: torch.Tensor,
         average_channels: bool = True,
         input: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # Call the data loss with the standard criterion signature only.
+        if input is None:
+            raise ValueError(
+                "LossWithSoftConstraints requires prognostic input because a "
+                "soft constraint has needs_input=True (pass input=inputs[0])."
+            )
         data = self.data_loss(
             prediction,
             target,
             average_channels=average_channels,
         )
-        if len(self.constraints) == 0:
-            return data
-
-        parts = [
-            c.constraint_loss(
-                prediction,
-                target,
-                input=input,
-                average_channels=average_channels,
-            )
-            for c in self.constraints
-        ]
-        if average_channels:
-            total = data
-            for p in parts:
-                total = total + p
-            return total
-
-        pieces = [data]
-        for p in parts:
-            pieces.append(p if p.dim() > 0 else p.unsqueeze(0))
-        return torch.cat(pieces)
+        parts = self._constraint_parts(
+            prediction, target, average_channels, input=input
+        )
+        return self._combine(data, parts, average_channels)

--- a/physicsnemo/metrics/climate/healpix_soft_constraints.py
+++ b/physicsnemo/metrics/climate/healpix_soft_constraints.py
@@ -23,11 +23,13 @@ from typing import Dict, Optional, Sequence
 
 import numpy as np
 import torch
-import xarray as xr
 
 from physicsnemo.distributed import DistributedManager
 from physicsnemo.launch.logging import RankZeroLoggingWrapper
-from physicsnemo.metrics.climate.hydrostasy import DifferentialHydrostaticBalanceConstraint
+from physicsnemo.metrics.climate.hydrostasy import (
+    DifferentialHydrostaticBalanceConstraint,
+    _load_topography,
+)
 
 logger = logging.getLogger(__name__)
 if DistributedManager.is_initialized():
@@ -174,19 +176,13 @@ class HydrostasySoftConstraint(SoftConstraint):
         self.T_level_mapping = torch.tensor(list(self.T_pressure_levels.keys()))
         self.q_level_mapping = torch.tensor(list(self.q_pressure_levels.keys()))
 
-        ds = xr.open_zarr(dataset_path)
-        self.topography = (
-            surface_geopotential_std
-            * ds["constants"].sel(channel_c=surface_geopotential_name).values
-            + surface_geopotential_mean
-        )
-        if self.convert_topography_to_meters:
-            self.topography /= self.g0
-        self.topography = torch.tensor(
-            self.topography[np.newaxis, :, np.newaxis, :, :], dtype=torch.float
-        )
-        logger.info(
-            f"Min/Max topography (m): {self.topography.min()}/{self.topography.max()}"
+        self.topography = _load_topography(
+            dataset_path,
+            surface_geopotential_name,
+            surface_geopotential_mean,
+            surface_geopotential_std,
+            self.g0,
+            self.convert_topography_to_meters,
         )
         if self.topography.min() < -1000.0 or self.topography.max() > 10000.0:
             raise ValueError("Topography values fall outside realistic range!")

--- a/physicsnemo/metrics/climate/healpix_soft_constraints.py
+++ b/physicsnemo/metrics/climate/healpix_soft_constraints.py
@@ -394,7 +394,8 @@ class LossWithSoftConstraints(torch.nn.Module):
 
     ``needs_input`` is True if any child soft constraint requires the prognostic
     input tensor. Trainers should use that flag (rather than unconditionally
-    forwarding ``input=``) so ordinary data losses need not accept ``**kwargs``.
+    forwarding ``input=``) so ordinary data losses can keep a plain
+    ``(prediction, target, average_channels=...)`` signature.
     """
 
     def __init__(
@@ -426,8 +427,7 @@ class LossWithSoftConstraints(torch.nn.Module):
         average_channels: bool = True,
         input: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # Call the data loss with the standard criterion signature only. Do not
-        # forward soft-constraint kwargs into unrelated losses.
+        # Call the data loss with the standard criterion signature only.
         data = self.data_loss(
             prediction,
             target,

--- a/physicsnemo/metrics/climate/healpix_soft_constraints.py
+++ b/physicsnemo/metrics/climate/healpix_soft_constraints.py
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Composable soft physical constraints for HEALPix DLWP training losses."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+import torch
+import xarray as xr
+
+from physicsnemo.distributed import DistributedManager
+from physicsnemo.launch.logging import RankZeroLoggingWrapper
+from physicsnemo.metrics.climate.hydrostasy import DifferentialHydrostaticBalanceConstraint
+
+logger = logging.getLogger(__name__)
+if DistributedManager.is_initialized():
+    logger = RankZeroLoggingWrapper(logger, DistributedManager())
+
+
+def _error_tolerant(error: torch.Tensor) -> torch.Tensor:
+    """Error-tolerant map used by hydrostasy soft losses: e / (1 + exp(1 - e))."""
+    return error / (1.0 + torch.exp(1.0 - error))
+
+
+class SoftConstraint(torch.nn.Module):
+    """Base class for soft constraints composed by :class:`LossWithSoftConstraints`."""
+
+    needs_input: bool = False
+
+    def setup(self, trainer) -> None:
+        """Move buffers to trainer device. Override as needed."""
+        pass
+
+    def constraint_loss(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        *,
+        input: Optional[torch.Tensor] = None,
+        average_channels: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class HydrostasySoftConstraint(SoftConstraint):
+    """
+    Soft differential hydrostatic-balance constraint.
+
+    Logic mirrors :class:`~physicsnemo.metrics.climate.hydrostasy.LossWithHydrostasy`
+    (Tv-only weights), so it can wrap an arbitrary data loss.
+    """
+
+    needs_input = False
+
+    def __init__(
+        self,
+        hPa_levels: Sequence[float],
+        channels: Sequence[str],
+        weights: Sequence[float],
+        alpha: Sequence[float],
+        scaling: Dict[str, Dict[str, float]],
+        dataset_path: str,
+        surface_geopotential_name: str,
+        surface_geopotential_mean: float = -597.7115478515625,
+        surface_geopotential_std: float = 55658.21484375,
+        convert_topography_to_meters: bool = True,
+        R: float = 287,
+        g0: float = 9.81,
+        topography_masking: bool = True,
+    ):
+        super().__init__()
+        self.g0 = g0
+        self.convert_topography_to_meters = convert_topography_to_meters
+        self.topography_masking = topography_masking
+        self.loss_weights = torch.tensor(weights, dtype=torch.float32)
+
+        self.pressure_levels = sorted(hPa_levels)
+        self.z_pressure_levels = {
+            channels.index(f"z{int(pl)}"): pl for pl in self.pressure_levels
+        }
+        self.T_pressure_levels = {
+            channels.index(f"t{int(pl)}"): pl for pl in self.pressure_levels
+        }
+        self.q_pressure_levels = {
+            channels.index(f"q{int(pl)}"): pl
+            for pl in self.pressure_levels
+            if f"q{int(pl)}" in channels
+        }
+        for i, pl in enumerate(self.pressure_levels):
+            if f"q{int(pl)}" in channels:
+                self.q_index_offset = i
+                break
+        else:
+            raise ValueError("No humidity (q) channels found for hydrostasy soft constraint")
+
+        self.z_constraint_pressure_levels = {
+            i: pl for i, pl in enumerate(self.pressure_levels)
+        }
+        self.Tv_constraint_pressure_levels = {
+            len(self.z_constraint_pressure_levels) + i: pl
+            for i, pl in enumerate(self.pressure_levels)
+        }
+
+        self.z_mean = torch.Tensor(
+            [scaling[f"z{int(pl)}"]["mean"] for pl in self.pressure_levels]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.z_std = torch.Tensor(
+            [scaling[f"z{int(pl)}"]["std"] for pl in self.pressure_levels]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.T_mean = torch.Tensor(
+            [scaling[f"t{int(pl)}"]["mean"] for pl in self.pressure_levels]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.T_std = torch.Tensor(
+            [scaling[f"t{int(pl)}"]["std"] for pl in self.pressure_levels]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.q_mean = torch.Tensor(
+            [
+                scaling[f"q{int(pl)}"]["mean"]
+                for pl in self.q_pressure_levels.values()
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+        self.q_std = torch.Tensor(
+            [
+                scaling[f"q{int(pl)}"]["std"]
+                for pl in self.q_pressure_levels.values()
+            ]
+        ).reshape((1, 1, 1, -1, 1, 1))
+
+        if len(alpha) != len(hPa_levels) - 1:
+            raise AssertionError(
+                f"Incorrect number of alpha values. Expected len(hPa_levels)-1 "
+                f"[{len(hPa_levels) - 1}], got {len(alpha)}"
+            )
+        if len(weights) != len(hPa_levels) - 1:
+            raise AssertionError(
+                f"Incorrect number of hydrostasy weights. Expected len(hPa_levels)-1 "
+                f"[{len(hPa_levels) - 1}], got {len(weights)}"
+            )
+        self.alpha = torch.Tensor(alpha).reshape((1, 1, -1, 1, 1))
+        self.Mw_ratio = 28.97 / 18.016 - 1.0
+
+        self.constraint = DifferentialHydrostaticBalanceConstraint(
+            self.z_constraint_pressure_levels,
+            self.Tv_constraint_pressure_levels,
+            0,
+            len(self.z_pressure_levels),
+            R,
+            self.g0,
+        )
+        self.num_z_levels = len(self.z_constraint_pressure_levels)
+        self.num_Tv_levels = len(self.Tv_constraint_pressure_levels)
+        self.z_level_mapping = torch.tensor(list(self.z_pressure_levels.keys()))
+        self.T_level_mapping = torch.tensor(list(self.T_pressure_levels.keys()))
+        self.q_level_mapping = torch.tensor(list(self.q_pressure_levels.keys()))
+
+        ds = xr.open_zarr(dataset_path)
+        self.topography = (
+            surface_geopotential_std
+            * ds["constants"].sel(channel_c=surface_geopotential_name).values
+            + surface_geopotential_mean
+        )
+        if self.convert_topography_to_meters:
+            self.topography /= self.g0
+        self.topography = torch.tensor(
+            self.topography[np.newaxis, :, np.newaxis, :, :], dtype=torch.float
+        )
+        logger.info(
+            f"Min/Max topography (m): {self.topography.min()}/{self.topography.max()}"
+        )
+        if self.topography.min() < -1000.0 or self.topography.max() > 10000.0:
+            raise ValueError("Topography values fall outside realistic range!")
+
+    def setup(self, trainer) -> None:
+        if len(self.z_pressure_levels) - 1 != len(self.loss_weights):
+            raise ValueError(
+                "Length of loss_weights is not one less than number of pressure levels!"
+            )
+        device = trainer.device
+        self.loss_weights = self.loss_weights.to(device=device)
+        self.z_mean = self.z_mean.to(device=device)
+        self.z_std = self.z_std.to(device=device)
+        self.T_mean = self.T_mean.to(device=device)
+        self.T_std = self.T_std.to(device=device)
+        self.q_mean = self.q_mean.to(device=device)
+        self.q_std = self.q_std.to(device=device)
+        self.alpha = self.alpha.to(device=device)
+        self.z_level_mapping = self.z_level_mapping.to(device=device)
+        self.T_level_mapping = self.T_level_mapping.to(device=device)
+        self.q_level_mapping = self.q_level_mapping.to(device=device)
+        self.topography = self.topography.to(device=device)
+
+    def scale(self, x: torch.Tensor) -> torch.Tensor:
+        """Scale to physical units and virtual temperature. Shape [N, F, B, C, H, W]."""
+        N, F, B, C, H, W = x.shape
+        C_scaled = self.num_z_levels + self.num_Tv_levels
+        x_scaled = torch.zeros(
+            (N, F, B, C_scaled, H, W),
+            device=x.device,
+            dtype=torch.float,
+        )
+        x_scaled[:, :, :, : self.num_z_levels, :, :] = (
+            x[:, :, :, self.z_level_mapping, :, :] * self.z_std + self.z_mean
+        ) / self.g0
+        x_scaled[:, :, :, self.num_z_levels :, :, :] = (
+            x[:, :, :, self.T_level_mapping, :, :] * self.T_std + self.T_mean
+        )
+        x_scaled[
+            :,
+            :,
+            :,
+            (self.num_z_levels + self.q_index_offset) :,
+            :,
+            :,
+        ] *= 1.0 + self.Mw_ratio * (
+            x[:, :, :, self.q_level_mapping, :, :] * self.q_std + self.q_mean
+        )
+        x_scaled = x_scaled.transpose(1, 2)
+        return x_scaled.reshape((-1, F, C_scaled, H, W))
+
+    def constraint_loss(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        *,
+        input: Optional[torch.Tensor] = None,
+        average_channels: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        with torch.amp.autocast("cuda", enabled=False):
+            prediction = prediction.float()
+            if prediction.ndim != 6:
+                raise AssertionError("Expected predictions to have 6 dimensions")
+
+            x = self.scale(prediction)
+            Tv_avg, Tv_model_avg = self.constraint(x)
+            Tv_error = ((Tv_avg - Tv_model_avg) / self.alpha) ** 2
+            if self.topography_masking:
+                Tv_error[x[:, :, 1 : self.num_z_levels, :, :] < self.topography] = 0.0
+
+            Tv_loss = self.loss_weights * _error_tolerant(Tv_error).mean(
+                dim=(0, 1, 3, 4)
+            )
+            if average_channels:
+                return torch.mean(Tv_loss)
+            return Tv_loss
+
+
+class DryAirMassSoftConstraint(SoftConstraint):
+    """
+    Soft dry-air-mass conservation constraint.
+
+    Penalizes step-to-step changes in the global-mean dry surface pressure
+    ``sp_dry = sp - g0 * tcwv``. The prognostic input anchors the first
+    predicted timestep; later terms compare consecutive predicted timesteps.
+    """
+
+    needs_input = True
+
+    def __init__(
+        self,
+        channels: Sequence[str],
+        scaling: Dict[str, Dict[str, float]],
+        weight: float = 0.001,
+        alpha: float = 0.383431,
+        g0: float = 9.81,
+    ):
+        super().__init__()
+        self.channels = list(channels)
+        self.sp_channel_index = self.channels.index("sp")
+        self.tcwv_channel_index = self.channels.index("tcwv")
+        self.weight = float(weight)
+        self.g0 = float(g0)
+
+        self.register_buffer(
+            "ps_mean",
+            torch.tensor(scaling["sp"]["mean"], dtype=torch.float32),
+            persistent=False,
+        )
+        self.register_buffer(
+            "ps_std",
+            torch.tensor(scaling["sp"]["std"], dtype=torch.float32),
+            persistent=False,
+        )
+        self.register_buffer(
+            "tcwv_mean",
+            torch.tensor(scaling["tcwv"]["mean"], dtype=torch.float32),
+            persistent=False,
+        )
+        self.register_buffer(
+            "tcwv_std",
+            torch.tensor(scaling["tcwv"]["std"], dtype=torch.float32),
+            persistent=False,
+        )
+        self.register_buffer(
+            "alpha",
+            torch.tensor(float(alpha), dtype=torch.float32),
+            persistent=False,
+        )
+
+    def setup(self, trainer) -> None:
+        device = trainer.device
+        self.ps_mean = self.ps_mean.to(device=device)
+        self.ps_std = self.ps_std.to(device=device)
+        self.tcwv_mean = self.tcwv_mean.to(device=device)
+        self.tcwv_std = self.tcwv_std.to(device=device)
+        self.alpha = self.alpha.to(device=device)
+
+    def _global_mean_sp_dry(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Global-mean dry surface pressure.
+
+        Parameters
+        ----------
+        tensor : torch.Tensor
+            Shape ``[B, F, T, C, H, W]`` (normalized).
+
+        Returns
+        -------
+        torch.Tensor
+            Shape ``[B, F, T, 1, 1, 1]`` in Pa.
+        """
+        sp = tensor[
+            :, :, :, self.sp_channel_index : self.sp_channel_index + 1, :, :
+        ]
+        sp = sp * self.ps_std + self.ps_mean
+        tcwv = tensor[
+            :, :, :, self.tcwv_channel_index : self.tcwv_channel_index + 1, :, :
+        ]
+        tcwv = tcwv * self.tcwv_std + self.tcwv_mean
+        sp_dry = sp - self.g0 * tcwv
+        return sp_dry.mean(dim=(1, 4, 5), keepdim=True)
+
+    def constraint_loss(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        *,
+        input: Optional[torch.Tensor] = None,
+        average_channels: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        if input is None:
+            raise ValueError(
+                "DryAirMassSoftConstraint requires prognostic input "
+                "(pass input=inputs[0] from the trainer)."
+            )
+        with torch.amp.autocast("cuda", enabled=False):
+            prediction = prediction.float()
+            input = input.float()
+            if prediction.ndim != 6:
+                raise AssertionError("Expected predictions to have 6 dimensions")
+
+            sp_dry_pred = self._global_mean_sp_dry(prediction)
+            sp_dry_input = self._global_mean_sp_dry(input[:, :, -1:])
+
+            # [B, F, T, 1, 1, 1] transitions: t=0 vs input, then consecutive preds
+            T = sp_dry_pred.shape[2]
+            prev = sp_dry_input
+            losses = []
+            for t in range(T):
+                curr = sp_dry_pred[:, :, t : t + 1]
+                violation = curr - prev
+                error = (violation / self.alpha) ** 2
+                losses.append(_error_tolerant(error))
+                prev = curr
+
+            stacked = torch.cat(losses, dim=2)
+            loss = self.weight * stacked.mean()
+            if average_channels:
+                return loss
+            return loss.reshape(())
+
+
+class LossWithSoftConstraints(torch.nn.Module):
+    """
+    Loss-agnostic wrapper that adds zero or more soft constraints to a data loss.
+
+    Compatible with the DLWP trainer ``setup`` / ``average_channels`` conventions.
+    """
+
+    def __init__(
+        self,
+        data_loss: torch.nn.Module,
+        constraints: Optional[Sequence[SoftConstraint]] = None,
+    ):
+        super().__init__()
+        self.data_loss = data_loss
+        if constraints is None:
+            constraints = []
+        self.constraints = torch.nn.ModuleList(list(constraints))
+
+    def setup(self, trainer) -> None:
+        if hasattr(self.data_loss, "setup"):
+            self.data_loss.setup(trainer)
+        for constraint in self.constraints:
+            constraint.setup(trainer)
+
+    def forward(
+        self,
+        prediction: torch.Tensor,
+        target: torch.Tensor,
+        average_channels: bool = True,
+        input: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        data = self.data_loss(
+            prediction,
+            target,
+            average_channels=average_channels,
+            **kwargs,
+        )
+        if len(self.constraints) == 0:
+            return data
+
+        parts = [
+            c.constraint_loss(
+                prediction,
+                target,
+                input=input,
+                average_channels=average_channels,
+                **kwargs,
+            )
+            for c in self.constraints
+        ]
+        if average_channels:
+            total = data
+            for p in parts:
+                total = total + p
+            return total
+
+        pieces = [data]
+        for p in parts:
+            pieces.append(p if p.dim() > 0 else p.unsqueeze(0))
+        return torch.cat(pieces)

--- a/physicsnemo/metrics/climate/hydrostasy.py
+++ b/physicsnemo/metrics/climate/hydrostasy.py
@@ -100,12 +100,26 @@ def _load_topography(
     convert_topography_to_meters: bool,
 ) -> torch.Tensor:
     """Load denormalized topography [1, F, 1, H, W] from a constants zarr store."""
-    ds = xr.open_zarr(dataset_path)
-    topography = (
-        surface_geopotential_std
-        * ds["constants"].sel(channel_c=surface_geopotential_name).values
-        + surface_geopotential_mean
+    from physicsnemo.datapipes.healpix.zarr_layout import (
+        is_monolithic_layout,
+        is_named_arrays_layout,
+        load_constant_fields,
     )
+
+    ds = xr.open_zarr(dataset_path)
+    if is_monolithic_layout(ds) or (
+        not is_named_arrays_layout(ds) and "constants" in ds
+    ):
+        topography = (
+            surface_geopotential_std
+            * ds["constants"].sel(channel_c=surface_geopotential_name).values
+            + surface_geopotential_mean
+        )
+    else:
+        const = load_constant_fields(ds, [surface_geopotential_name], n_threads=1)
+        topography = (
+            surface_geopotential_std * const[0] + surface_geopotential_mean
+        )
     if convert_topography_to_meters:
         topography = topography / g0
 

--- a/test/metrics/test_healpix_soft_constraints.py
+++ b/test/metrics/test_healpix_soft_constraints.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from physicsnemo.metrics.climate.healpix_loss import WeightedMSE
+from physicsnemo.metrics.climate.healpix_soft_constraints import (
+    DryAirMassSoftConstraint,
+    HydrostasySoftConstraint,
+    LossWithSoftConstraints,
+)
+from physicsnemo.metrics.climate.hydrostasy import LossWithHydrostasy
+
+
+@dataclass
+class _DummyTrainer:
+    device: torch.device
+    output_variables: Sequence[str]
+
+
+def _dry_air_scaling():
+    return {
+        "sp": {"mean": 100000.0, "std": 5000.0},
+        "tcwv": {"mean": 25.0, "std": 15.0},
+    }
+
+
+def _make_conserved_batch(channels, scaling, B=2, F=1, T=3, H=4, W=4, g0=9.81):
+    """Build input/pred with constant global dry-air mass across steps."""
+    sp_idx = channels.index("sp")
+    tcwv_idx = channels.index("tcwv")
+    C = len(channels)
+    torch.manual_seed(0)
+    inp = torch.randn(B, F, 1, C, H, W)
+    sp_phys = (
+        inp[:, :, -1:, sp_idx : sp_idx + 1] * scaling["sp"]["std"]
+        + scaling["sp"]["mean"]
+    )
+    tcwv_phys = (
+        inp[:, :, -1:, tcwv_idx : tcwv_idx + 1] * scaling["tcwv"]["std"]
+        + scaling["tcwv"]["mean"]
+    )
+    sp_dry = (sp_phys - g0 * tcwv_phys).mean(dim=(1, 4, 5), keepdim=True)
+
+    pred = torch.randn(B, F, T, C, H, W)
+    tcwv_const = torch.full(
+        (B, F, T, 1, H, W),
+        (20.0 - scaling["tcwv"]["mean"]) / scaling["tcwv"]["std"],
+    )
+    pred[:, :, :, tcwv_idx : tcwv_idx + 1] = tcwv_const
+    tcwv_phys_pred = tcwv_const * scaling["tcwv"]["std"] + scaling["tcwv"]["mean"]
+    sp_phys_needed = sp_dry + g0 * tcwv_phys_pred.mean(dim=(1, 4, 5), keepdim=True)
+    sp_norm = (sp_phys_needed - scaling["sp"]["mean"]) / scaling["sp"]["std"]
+    pred[:, :, :, sp_idx : sp_idx + 1] = sp_norm.expand(B, F, T, 1, H, W)
+    return inp, pred
+
+
+def test_dry_air_mass_soft_constraint_zero_when_conserved():
+    channels = ["t2m", "tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    mod = DryAirMassSoftConstraint(
+        channels=channels, scaling=scaling, weight=1.0, alpha=0.383431
+    )
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    mod.setup(trainer)
+    inp, pred = _make_conserved_batch(channels, scaling)
+    target = pred.clone()
+    loss = mod.constraint_loss(pred, target, input=inp)
+    assert loss.shape == ()
+    assert float(loss) == pytest.approx(0.0, abs=1e-5)
+
+
+def test_dry_air_mass_soft_constraint_step_to_step():
+    channels = ["tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    mod = DryAirMassSoftConstraint(
+        channels=channels, scaling=scaling, weight=1.0, alpha=0.383431
+    )
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    mod.setup(trainer)
+
+    B, F, T, H, W = 1, 1, 3, 2, 2
+    C = len(channels)
+    sp_idx = channels.index("sp")
+
+    inp = torch.zeros(B, F, 1, C, H, W)
+    pred = torch.zeros(B, F, T, C, H, W)
+    # t=0 matches input; later steps drift in global dry mass
+    pred[:, :, 1:, sp_idx] = 1.0
+    loss_step = mod.constraint_loss(pred, pred.clone(), input=inp)
+    assert float(loss_step) > 0.0
+
+    # Anchor violation: all predicted steps differ from input
+    pred2 = torch.zeros(B, F, T, C, H, W)
+    pred2[:, :, :, sp_idx] = 1.0
+    loss_anchor = mod.constraint_loss(pred2, pred2.clone(), input=inp)
+    assert float(loss_anchor) > 0.0
+
+
+def test_dry_air_mass_soft_constraint_requires_input():
+    channels = ["tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    mod = DryAirMassSoftConstraint(channels=channels, scaling=scaling)
+    pred = torch.randn(1, 1, 2, 2, 2, 2)
+    with pytest.raises(ValueError, match="requires prognostic input"):
+        mod.constraint_loss(pred, pred, input=None)
+
+
+def test_dry_air_mass_soft_constraint_gradients():
+    channels = ["tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    mod = DryAirMassSoftConstraint(channels=channels, scaling=scaling, weight=1.0)
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    mod.setup(trainer)
+    inp = torch.randn(1, 1, 1, 2, 3, 3)
+    pred = torch.randn(1, 1, 2, 2, 3, 3, requires_grad=True)
+    loss = mod.constraint_loss(pred, pred.detach(), input=inp)
+    loss.backward()
+    assert pred.grad is not None
+    assert torch.isfinite(pred.grad).all()
+    assert pred.grad[..., 0, :, :].abs().sum() > 0
+    assert pred.grad[..., 1, :, :].abs().sum() > 0
+
+
+def test_loss_with_soft_constraints_no_constraints():
+    weights = [1.0, 2.0]
+    data_loss = WeightedMSE(weights=weights)
+    wrapper = LossWithSoftConstraints(data_loss=data_loss, constraints=[])
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=["a", "b"])
+    wrapper.setup(trainer)
+    pred = torch.randn(1, 1, 1, 2, 4, 4)
+    target = torch.randn(1, 1, 1, 2, 4, 4)
+    assert torch.allclose(wrapper(pred, target), data_loss(pred, target))
+    per = wrapper(pred, target, average_channels=False)
+    assert per.shape == (2,)
+
+
+def test_hydrostasy_soft_constraint_matches_loss_with_hydrostasy(tmp_path):
+    """Tv soft-constraint term matches LossWithHydrostasy Tv contribution."""
+    hPa_levels = [500.0, 700.0, 850.0]
+    channels = [
+        "z500",
+        "z700",
+        "z850",
+        "t500",
+        "t700",
+        "t850",
+        "q500",
+        "q700",
+        "q850",
+    ]
+    scaling = {
+        f"z{int(p)}": {"mean": 5000.0 * i, "std": 100.0}
+        for i, p in enumerate(hPa_levels)
+    }
+    scaling.update({f"t{int(p)}": {"mean": 250.0, "std": 10.0} for p in hPa_levels})
+    scaling.update({f"q{int(p)}": {"mean": 0.001, "std": 0.0005} for p in hPa_levels})
+    alpha = [0.2, 0.3]
+    tv_weights = [0.001, 0.002]
+
+    faces, hh, ww = 12, 4, 4
+    topo = np.zeros((faces, hh, ww), dtype=np.float32)
+    ds = xr.Dataset(
+        {
+            "constants": (
+                ("face", "channel_c", "height", "width"),
+                topo[:, None, :, :],
+            )
+        },
+        coords={"channel_c": ["z"]},
+    )
+    zarr_path = tmp_path / "topo.zarr"
+    ds.to_zarr(zarr_path)
+
+    soft = HydrostasySoftConstraint(
+        hPa_levels=hPa_levels,
+        channels=channels,
+        weights=tv_weights,
+        alpha=alpha,
+        scaling=scaling,
+        dataset_path=str(zarr_path),
+        surface_geopotential_name="z",
+        surface_geopotential_mean=0.0,
+        surface_geopotential_std=1.0,
+        convert_topography_to_meters=True,
+        topography_masking=False,
+    )
+    data_loss = WeightedMSE(weights=[1.0] * len(channels))
+    legacy = LossWithHydrostasy(
+        data_loss=data_loss,
+        hPa_levels=hPa_levels,
+        channels=channels,
+        weights=tv_weights,
+        alpha=alpha,
+        scaling=scaling,
+        dataset_path=str(zarr_path),
+        surface_geopotential_name="z",
+        surface_geopotential_mean=0.0,
+        surface_geopotential_std=1.0,
+        convert_topography_to_meters=True,
+        topography_masking=False,
+    )
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    soft.setup(trainer)
+    legacy.setup(trainer)
+
+    torch.manual_seed(1)
+    # Layout [N, F, B, C, H, W] with F = faces (matches hydrostasy scale/topography)
+    pred = torch.randn(1, faces, 1, len(channels), hh, ww)
+    target = torch.randn_like(pred)
+
+    soft_tv = soft.constraint_loss(pred, target, average_channels=True)
+    legacy_total = legacy(pred, target, average_channels=True)
+    data_only = data_loss(pred, target, average_channels=True)
+    legacy_tv = legacy_total - data_only
+    assert torch.allclose(soft_tv, legacy_tv, rtol=1e-5, atol=1e-6)
+
+    soft_per = soft.constraint_loss(pred, target, average_channels=False)
+    legacy_per = legacy(pred, target, average_channels=False)
+    assert soft_per.shape == (len(hPa_levels) - 1,)
+    assert torch.allclose(soft_per, legacy_per[len(channels) :], rtol=1e-5, atol=1e-6)
+
+
+def test_loss_with_soft_constraints_composes_dry_air():
+    channels = ["tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    data_loss = WeightedMSE(weights=[1.0, 1.0])
+    dry = DryAirMassSoftConstraint(channels=channels, scaling=scaling, weight=1.0)
+    wrapper = LossWithSoftConstraints(data_loss=data_loss, constraints=[dry])
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    wrapper.setup(trainer)
+
+    inp, pred = _make_conserved_batch(channels, scaling, T=2, H=3, W=3)
+    target = pred + 0.1
+    out = wrapper(pred, target, input=inp)
+    assert out.shape == ()
+    assert torch.allclose(out, data_loss(pred, target), rtol=1e-3, atol=1e-4)
+
+    per = wrapper(pred, target, average_channels=False, input=inp)
+    assert per.shape[0] == 3  # 2 data channels + 1 dry-air term
+
+
+def test_loss_with_soft_constraints_hydra(tmp_path):
+    """Hydra-style instantiate of LossWithSoftConstraints with dry-air only."""
+    from hydra.utils import instantiate
+    from omegaconf import OmegaConf
+
+    channels = ["tcwv", "sp"]
+    scaling = _dry_air_scaling()
+    cfg = OmegaConf.create(
+        {
+            "_target_": "physicsnemo.metrics.climate.healpix_soft_constraints.LossWithSoftConstraints",
+            "data_loss": {
+                "_target_": "physicsnemo.metrics.climate.healpix_loss.WeightedMSE",
+                "weights": [1.0, 1.0],
+            },
+            "constraints": [
+                {
+                    "_target_": "physicsnemo.metrics.climate.healpix_soft_constraints.DryAirMassSoftConstraint",
+                    "channels": channels,
+                    "scaling": scaling,
+                    "weight": 0.001,
+                    "alpha": 0.383431,
+                    "g0": 9.81,
+                }
+            ],
+        }
+    )
+    loss = instantiate(cfg)
+    trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
+    loss.setup(trainer)
+    inp, pred = _make_conserved_batch(channels, scaling, T=2, H=2, W=2)
+    out = loss(pred, pred.clone(), input=inp)
+    assert out.shape == ()
+    assert out.requires_grad is False
+    pred_g = pred.clone().requires_grad_(True)
+    out_g = loss(pred_g, pred.clone(), input=inp)
+    out_g.backward()
+    assert pred_g.grad is not None

--- a/test/metrics/test_healpix_soft_constraints.py
+++ b/test/metrics/test_healpix_soft_constraints.py
@@ -121,6 +121,8 @@ def test_dry_air_mass_soft_constraint_requires_input():
     scaling = _dry_air_scaling()
     mod = DryAirMassSoftConstraint(channels=channels, scaling=scaling)
     pred = torch.randn(1, 1, 2, 2, 2, 2)
+    with pytest.raises(TypeError):
+        mod.constraint_loss(pred, pred)
     with pytest.raises(ValueError, match="requires prognostic input"):
         mod.constraint_loss(pred, pred, input=None)
 
@@ -145,6 +147,7 @@ def test_loss_with_soft_constraints_no_constraints():
     weights = [1.0, 2.0]
     data_loss = WeightedMSE(weights=weights)
     wrapper = LossWithSoftConstraints(data_loss=data_loss, constraints=[])
+    assert wrapper.needs_input is False
     trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=["a", "b"])
     wrapper.setup(trainer)
     pred = torch.randn(1, 1, 1, 2, 4, 4)
@@ -152,6 +155,8 @@ def test_loss_with_soft_constraints_no_constraints():
     assert torch.allclose(wrapper(pred, target), data_loss(pred, target))
     per = wrapper(pred, target, average_channels=False)
     assert per.shape == (2,)
+    with pytest.raises(TypeError):
+        wrapper(pred, target, input=pred)
 
 
 def test_hydrostasy_soft_constraint_matches_loss_with_hydrostasy(tmp_path):
@@ -246,11 +251,14 @@ def test_loss_with_soft_constraints_composes_dry_air():
     data_loss = WeightedMSE(weights=[1.0, 1.0])
     dry = DryAirMassSoftConstraint(channels=channels, scaling=scaling, weight=1.0)
     wrapper = LossWithSoftConstraints(data_loss=data_loss, constraints=[dry])
+    assert wrapper.needs_input is True
     trainer = _DummyTrainer(device=torch.device("cpu"), output_variables=channels)
     wrapper.setup(trainer)
 
     inp, pred = _make_conserved_batch(channels, scaling, T=2, H=3, W=3)
     target = pred + 0.1
+    with pytest.raises(ValueError, match="requires prognostic input"):
+        wrapper(pred, target)
     out = wrapper(pred, target, input=inp)
     assert out.shape == ()
     assert torch.allclose(out, data_loss(pred, target), rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description
Adds composable soft physical constraints for HEALPix training losses via `LossWithSoftConstraints`, with:

- `HydrostasySoftConstraint` — pressure-level virtual-temperature hydrostatic balance (mirrors the Tv term of `LossWithHydrostasy`)
- `DryAirMassSoftConstraint` — soft dry surface-pressure / column-mass conservation (`needs_input=True` for prognostic input)
- `needs_input` gating so prognostic tensors are only required when a child constraint needs them (no kwargs leaked into the data loss)

New files only: `healpix_soft_constraints.py` + unit tests. Orthogonal to hard model constraints (`DryAirMassConstraint` / nonnegative STE).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

- Prefer merging after [#57](https://github.com/AtmosSci-DLESM/modulus-uw/pull/57) (`wy/hydrostasy_topo_options`) so soft hydrostasy topography handling stays aligned with the hard-loss topo API (`dataset_path`, range warnings, etc.).
- This PR does **not** hard-depend on #57: it only adds new files on current `dev` and can merge independently.
- Distinct from [#37](https://github.com/AtmosSci-DLESM/modulus-uw/pull/37) (hard `nn.Module` constraints / two-arg call sites).