### PR TITLE
HEALPix zarr dataloader options (persistent_workers, prefetch_factor, in_order, drop_last fix)

### DIFF
--- a/physicsnemo/datapipes/healpix/data_modules_zarr.py
+++ b/physicsnemo/datapipes/healpix/data_modules_zarr.py
@@ -62,6 +62,7 @@ class TimeSeriesDataModuleZarr:
         add_insolation: bool = False,
         num_workers: int = 4,
         pin_memory: bool = True,
+        persistent_workers: bool = False,
         forecast_init_times: Optional[Sequence] = None,
         add_train_noise: Optional[bool] = False,
         train_noise_params: Optional[DictConfig] = None,
@@ -113,6 +114,8 @@ class TimeSeriesDataModuleZarr:
             Number of parallel data loading workers, default 4
         pin_memory: bool, optional
             Whether pinned (page locked) memory should be used to store the tensors, improves GPU I/O, default True
+        persistent_workers: bool, optional
+            Keep dataloader workers alive between epochs, default False
         forecast_init_times: Sequence, optional
             A Sequence of pandas Timestamps dictating the specific initialization times
             to produce inputs for. default None
@@ -147,6 +150,7 @@ class TimeSeriesDataModuleZarr:
         self.add_insolation = add_insolation
         self.num_workers = num_workers
         self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
         self.forecast_init_times = forecast_init_times
         self.add_train_noise = add_train_noise
         self.train_noise_params = train_noise_params
@@ -320,16 +324,18 @@ class TimeSeriesDataModuleZarr:
             shuffle = False
             drop_last = False
 
-        loader = DataLoader(
-            dataset=dataset,
-            pin_memory=self.pin_memory,
-            num_workers=self.num_workers,
-            shuffle=shuffle,
-            drop_last=drop_last,
-            sampler=sampler,
-            collate_fn=self.collate_fn,
-            batch_size=self.dataloader_batch_size,
-        )
+        dataloader_kwargs = {
+            "dataset": dataset,
+            "pin_memory": self.pin_memory,
+            "num_workers": self.num_workers,
+            "persistent_workers": (self.persistent_workers and self.num_workers > 0),
+            "shuffle": shuffle,
+            "drop_last": drop_last,
+            "sampler": sampler,
+            "collate_fn": self.collate_fn,
+            "batch_size": self.dataloader_batch_size,
+        }
+        loader = DataLoader(**dataloader_kwargs)
 
         return loader, sampler
 
@@ -430,6 +436,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
         add_insolation: bool = False,
         num_workers: int = 4,
         pin_memory: bool = True,
+        persistent_workers: bool = False,
         forecast_init_times: Optional[Sequence] = None,
         couplings: Sequence = None,
         add_train_noise: Optional[bool] = False,
@@ -482,6 +489,8 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             Number of parallel data loading workers, default 4
         pin_memory: bool, optional
             Whether pinned (page locked) memory should be used to store the tensors, improves GPU I/O, default True
+        persistent_workers: bool, optional
+            Keep dataloader workers alive between epochs, default False
         forecast_init_times: Sequence, optional
             A Sequence of pandas Timestamps dictating the specific initialization times
             to produce inputs for. default None
@@ -521,6 +530,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             add_insolation,
             num_workers,
             pin_memory,
+            persistent_workers,
             forecast_init_times,
             add_train_noise,
             train_noise_params,

--- a/physicsnemo/datapipes/healpix/data_modules_zarr.py
+++ b/physicsnemo/datapipes/healpix/data_modules_zarr.py
@@ -322,7 +322,6 @@ class TimeSeriesDataModuleZarr:
         DataLoader: The configured dataloader
         """
         sampler = None
-        drop_last = False
         if num_shards > 1:
             sampler = DistributedSampler(
                 dataset,
@@ -332,7 +331,6 @@ class TimeSeriesDataModuleZarr:
                 drop_last=drop_last,
             )
             shuffle = False
-            drop_last = False
 
         dataloader_kwargs = {
             "dataset": dataset,
@@ -373,7 +371,7 @@ class TimeSeriesDataModuleZarr:
             num_shards=num_shards,
             shard_id=shard_id,
             shuffle=self.shuffle,
-            drop_last=True,
+            drop_last=self.drop_last,
         )
 
     def val_dataloader(self, num_shards=1, shard_id=0) -> DataLoader:
@@ -396,7 +394,7 @@ class TimeSeriesDataModuleZarr:
             num_shards=num_shards,
             shard_id=shard_id,
             shuffle=False,
-            drop_last=True,
+            drop_last=self.drop_last,
         )
 
     def test_dataloader(self, num_shards=1, shard_id=0) -> DataLoader:
@@ -419,7 +417,7 @@ class TimeSeriesDataModuleZarr:
             num_shards=num_shards,
             shard_id=shard_id,
             shuffle=False,
-            drop_last=True,
+            drop_last=False,
         )
 
 

--- a/physicsnemo/datapipes/healpix/data_modules_zarr.py
+++ b/physicsnemo/datapipes/healpix/data_modules_zarr.py
@@ -68,6 +68,7 @@ class TimeSeriesDataModuleZarr:
         add_train_noise: Optional[bool] = False,
         train_noise_params: Optional[DictConfig] = None,
         train_noise_seed: Optional[int] = 42,
+        in_order: Optional[bool] = None,
     ):
         """
         Parameters
@@ -133,6 +134,9 @@ class TimeSeriesDataModuleZarr:
             Dictionary containing parameters for adding noise to the training data
         train_noise_seed: int, optional
             Seed for the random number generator for adding noise to the training data, default 42
+        in_order: bool, optional
+            Passed to torch.utils.data.DataLoader when set (requires PyTorch with ``in_order`` support).
+            If None, DataLoader default applies.
         """
         super().__init__()
         self.dataset_path = Path(dataset_path)
@@ -160,6 +164,7 @@ class TimeSeriesDataModuleZarr:
         self.add_train_noise = add_train_noise
         self.train_noise_params = train_noise_params
         self.train_noise_seed = train_noise_seed
+        self.in_order = in_order
 
         self.train_dataset = None
         self.val_dataset = None
@@ -342,6 +347,8 @@ class TimeSeriesDataModuleZarr:
         }
         if self.prefetch_factor is not None and self.num_workers > 0:
             dataloader_kwargs["prefetch_factor"] = self.prefetch_factor
+        if self.in_order is not None:
+            dataloader_kwargs["in_order"] = self.in_order
         loader = DataLoader(**dataloader_kwargs)
 
         return loader, sampler
@@ -450,6 +457,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
         add_train_noise: Optional[bool] = False,
         train_noise_params: Optional[DictConfig] = None,
         train_noise_seed: Optional[int] = 42,
+        in_order: Optional[bool] = None,
     ):
         """
         Parameters
@@ -518,6 +526,8 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             Dictionary containing parameters for adding noise to the training data
         train_noise_seed: int, optional
             Seed for the random number generator for adding noise to the training data, default 42
+        in_order: bool, optional
+            Passed to torch.utils.data.DataLoader when set. If None, DataLoader default applies.
         """
         self.couplings = couplings
 
@@ -547,6 +557,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             add_train_noise,
             train_noise_params,
             train_noise_seed,
+            in_order,
         )
 
     def _get_coupled_vars(self):

--- a/physicsnemo/datapipes/healpix/data_modules_zarr.py
+++ b/physicsnemo/datapipes/healpix/data_modules_zarr.py
@@ -63,6 +63,7 @@ class TimeSeriesDataModuleZarr:
         num_workers: int = 4,
         pin_memory: bool = True,
         persistent_workers: bool = False,
+        prefetch_factor: Optional[int] = None,
         forecast_init_times: Optional[Sequence] = None,
         add_train_noise: Optional[bool] = False,
         train_noise_params: Optional[DictConfig] = None,
@@ -116,6 +117,9 @@ class TimeSeriesDataModuleZarr:
             Whether pinned (page locked) memory should be used to store the tensors, improves GPU I/O, default True
         persistent_workers: bool, optional
             Keep dataloader workers alive between epochs, default False
+        prefetch_factor: int, optional
+            Number of batches loaded in advance by each worker. Only used when
+            num_workers > 0. If not provided, PyTorch default is used.
         forecast_init_times: Sequence, optional
             A Sequence of pandas Timestamps dictating the specific initialization times
             to produce inputs for. default None
@@ -151,6 +155,7 @@ class TimeSeriesDataModuleZarr:
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.persistent_workers = persistent_workers
+        self.prefetch_factor = prefetch_factor
         self.forecast_init_times = forecast_init_times
         self.add_train_noise = add_train_noise
         self.train_noise_params = train_noise_params
@@ -335,6 +340,8 @@ class TimeSeriesDataModuleZarr:
             "collate_fn": self.collate_fn,
             "batch_size": self.dataloader_batch_size,
         }
+        if self.prefetch_factor is not None and self.num_workers > 0:
+            dataloader_kwargs["prefetch_factor"] = self.prefetch_factor
         loader = DataLoader(**dataloader_kwargs)
 
         return loader, sampler
@@ -437,6 +444,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
         num_workers: int = 4,
         pin_memory: bool = True,
         persistent_workers: bool = False,
+        prefetch_factor: Optional[int] = None,
         forecast_init_times: Optional[Sequence] = None,
         couplings: Sequence = None,
         add_train_noise: Optional[bool] = False,
@@ -491,6 +499,9 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             Whether pinned (page locked) memory should be used to store the tensors, improves GPU I/O, default True
         persistent_workers: bool, optional
             Keep dataloader workers alive between epochs, default False
+        prefetch_factor: int, optional
+            Number of batches loaded in advance by each worker. Only used when
+            num_workers > 0. If not provided, PyTorch default is used.
         forecast_init_times: Sequence, optional
             A Sequence of pandas Timestamps dictating the specific initialization times
             to produce inputs for. default None
@@ -531,6 +542,7 @@ class CoupledTimeSeriesDataModuleZarr(TimeSeriesDataModuleZarr):
             num_workers,
             pin_memory,
             persistent_workers,
+            prefetch_factor,
             forecast_init_times,
             add_train_noise,
             train_noise_params,


### PR DESCRIPTION
# PhysicsNeMo Pull Request

## Description
Expose PyTorch `DataLoader` tuning knobs on HEALPix zarr data modules (`TimeSeriesDataModuleZarr` and `CoupledTimeSeriesDataModuleZarr`):

- `persistent_workers` — keep workers alive between epochs (only when `num_workers > 0`)
- `prefetch_factor` — batches prefetched per worker (optional; only when `num_workers > 0`)
- `in_order` — optional passthrough to `DataLoader` when supported by the installed PyTorch
- **`drop_last` fix** — honor the module's `drop_last` config for train/val loaders instead of hard-coding `True`; keep `drop_last=False` for test

All new kwargs default to backwards-compatible values (`persistent_workers=False`, `prefetch_factor=None`, `in_order=None`).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

- No hard dependency on other open PRs (touches only `data_modules_zarr.py`).
- Independent of HEALPix model / loss feature branches.