### PR TITLE
Add opt-in coupled partial-conv stem for SST/SIC forcings

### DIFF
--- a/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixRecUNet.py
@@ -28,6 +28,9 @@ from physicsnemo.models.dlwp_healpix_layers import (
     HEALPixUnfoldFaces,
     warn_deprecated_enable_healpixpad,
 )
+from physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv import (
+    build_coupled_partial_conv_stem,
+)
 from physicsnemo.models.meta import ModelMetaData
 from physicsnemo.models.module import Module
 
@@ -77,6 +80,8 @@ class HEALPixRecUNet(Module):
         compile_padding: bool = False,
         nside: Sequence[int] = (64, 32, 16),
         enable_healpixpad: bool | None = None,
+        odd_coupled_variables: Sequence[str] = None,
+        coupled_partial_conv: dict | DictConfig | None = None,
     ):
         """
         Parameters
@@ -131,6 +136,14 @@ class HEALPixRecUNet(Module):
         enable_healpixpad: bool, optional
             Deprecated. When ``hpx_padding_mode`` is omitted, ``False`` maps to ``karlbauer``
             and ``True`` to ``earth2grid`` (legacy configs). Prefer ``hpx_padding_mode``.
+        odd_coupled_variables: sequence of str, optional
+            Coupled variable names that flip sign under equatorial reflection; wired
+            into the partial-conv stem as odd channels (even kernel, zero bias).
+        coupled_partial_conv: dict or DictConfig, optional
+            Opt-in partial-convolution stem for coupled inputs. ``None`` (default)
+            leaves coupled fields unchanged. Configure ``masks`` plus an optional
+            Hydra-instantiable ``stem`` (default ``CoupledPartialConvStem``). See
+            ``physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv``.
         """
         super().__init__()
         hpx_padding_mode = warn_deprecated_enable_healpixpad(enable_healpixpad, hpx_padding_mode)
@@ -173,6 +186,7 @@ class HEALPixRecUNet(Module):
         self.hpx_padding_mode = hpx_padding_mode
         self.compile_padding = compile_padding
         self.nside = nside
+        self.odd_coupled_variables = odd_coupled_variables
 
         if len(encoder["n_channels"]) != len(decoder["n_channels"]):
             raise ValueError(
@@ -211,6 +225,16 @@ class HEALPixRecUNet(Module):
             hpx_padding_mode=self.hpx_padding_mode,
             compile_padding=self.compile_padding,
             nside=self.nside,
+        )
+
+        self.coupled_partial_conv_stem = build_coupled_partial_conv_stem(
+            coupled_partial_conv,
+            couplings=self.couplings,
+            hpx_padding_mode=self.hpx_padding_mode,
+            nside=int(self.nside[0]) if self.nside is not None else None,
+            compile_padding=self.compile_padding,
+            enable_nhwc=self.enable_nhwc,
+            odd_coupled_variables=self.odd_coupled_variables,
         )
 
         self.constraints = None
@@ -266,6 +290,13 @@ class HEALPixRecUNet(Module):
         """
 
         if len(self.couplings) > 0:
+            coupled = (
+                inputs[3].permute(0, 2, 1, 3, 4)
+                if self.couplings_time_first
+                else inputs[3]
+            )
+            if self.coupled_partial_conv_stem is not None:
+                coupled = self.coupled_partial_conv_stem(coupled)
             result = [
                 inputs[0].flatten(
                     start_dim=self.channel_dim, end_dim=self.channel_dim + 1
@@ -281,7 +312,7 @@ class HEALPixRecUNet(Module):
                 inputs[2].expand(
                     *tuple([inputs[0].shape[0]] + len(inputs[2].shape) * [-1])
                 ),  # constants
-                inputs[3].permute(0, 2, 1, 3, 4) if self.couplings_time_first else inputs[3],  # coupled inputs
+                coupled,
             ]
             res = th.cat(result, dim=self.channel_dim)
 

--- a/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
+++ b/physicsnemo/models/dlwp_healpix/HEALPixUNet.py
@@ -27,6 +27,9 @@ from physicsnemo.models.dlwp_healpix_layers import (
     HEALPixUnfoldFaces,
     warn_deprecated_enable_healpixpad,
 )
+from physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv import (
+    build_coupled_partial_conv_stem,
+)
 from physicsnemo.models.meta import ModelMetaData
 from physicsnemo.models.module import Module
 
@@ -74,6 +77,8 @@ class HEALPixUNet(Module):
         compile_padding: bool = False,
         nside: Sequence[int] = (64, 32, 16),
         enable_healpixpad: bool | None = None,
+        odd_coupled_variables: Sequence[str] = None,
+        coupled_partial_conv: dict | DictConfig | None = None,
     ):
         """
         Parameters
@@ -123,6 +128,14 @@ class HEALPixUNet(Module):
         enable_healpixpad: bool, optional
             Deprecated. When ``hpx_padding_mode`` is omitted, ``False`` maps to ``karlbauer``
             and ``True`` to ``earth2grid`` (legacy configs). Prefer ``hpx_padding_mode``.
+        odd_coupled_variables: sequence of str, optional
+            Coupled variable names that flip sign under equatorial reflection; wired
+            into the partial-conv stem as odd channels (even kernel, zero bias).
+        coupled_partial_conv: dict or DictConfig, optional
+            Opt-in partial-convolution stem for coupled inputs. ``None`` (default)
+            leaves coupled fields unchanged. Configure ``masks`` plus an optional
+            Hydra-instantiable ``stem`` (default ``CoupledPartialConvStem``). See
+            ``physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv``.
         """
         super().__init__()
         hpx_padding_mode = warn_deprecated_enable_healpixpad(enable_healpixpad, hpx_padding_mode)
@@ -154,6 +167,7 @@ class HEALPixUNet(Module):
         self.hpx_padding_mode = hpx_padding_mode
         self.compile_padding = compile_padding
         self.nside = nside
+        self.odd_coupled_variables = odd_coupled_variables
 
         if len(encoder["n_channels"]) != len(decoder["n_channels"]):
             raise ValueError(
@@ -192,6 +206,16 @@ class HEALPixUNet(Module):
             hpx_padding_mode=self.hpx_padding_mode,
             compile_padding=self.compile_padding,
             nside=self.nside,
+        )
+
+        self.coupled_partial_conv_stem = build_coupled_partial_conv_stem(
+            coupled_partial_conv,
+            couplings=self.couplings,
+            hpx_padding_mode=self.hpx_padding_mode,
+            nside=int(self.nside[0]) if self.nside is not None else None,
+            compile_padding=self.compile_padding,
+            enable_nhwc=self.enable_nhwc,
+            odd_coupled_variables=self.odd_coupled_variables,
         )
 
         self.constraints = None
@@ -241,6 +265,13 @@ class HEALPixUNet(Module):
         """
 
         if len(self.couplings) > 0:
+            coupled = (
+                inputs[3].permute(0, 2, 1, 3, 4)
+                if self.couplings_time_first
+                else inputs[3]
+            )
+            if self.coupled_partial_conv_stem is not None:
+                coupled = self.coupled_partial_conv_stem(coupled)
             result = [
                 inputs[0].flatten(
                     start_dim=self.channel_dim, end_dim=self.channel_dim + 1
@@ -256,7 +287,7 @@ class HEALPixUNet(Module):
                 inputs[2].expand(
                     *tuple([inputs[0].shape[0]] + len(inputs[2].shape) * [-1])
                 ),  # constants
-                inputs[3].permute(0, 2, 1, 3, 4) if self.couplings_time_first else inputs[3],  # coupled inputs
+                coupled,
             ]
             res = th.cat(result, dim=self.channel_dim)
 

--- a/physicsnemo/models/dlwp_healpix_layers/__init__.py
+++ b/physicsnemo/models/dlwp_healpix_layers/__init__.py
@@ -41,3 +41,11 @@ from .healpix_paddings import (
     make_hpx_padding_layer,
     warn_deprecated_enable_healpixpad,
 )
+from .coupled_partial_conv import (
+    DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET,
+    CoupledPartialConvStem,
+    PartialHEALPixConv2d,
+    build_coupled_partial_conv_stem,
+    coupled_variable_channel_names,
+    load_spatial_mask,
+)

--- a/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
+++ b/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
@@ -52,13 +52,19 @@ from omegaconf import DictConfig, OmegaConf
 
 from .healpix_layers import HEALPixLayer
 from .healpix_paddings import HEALPixFoldFaces, HEALPixUnfoldFaces
-from .reflection_ops import project_even_kernel
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET = (
     "physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv.CoupledPartialConvStem"
 )
+
+
+def _project_even_kernel(weight: th.Tensor) -> th.Tensor:
+    """Lazy import: reflection_ops lives on reflectional_equivariance, not coupled tip."""
+    from .reflection_ops import project_even_kernel
+
+    return project_even_kernel(weight)
 
 
 def coupled_variable_channel_names(couplings: Sequence[Mapping[str, Any]]) -> list[str]:
@@ -225,8 +231,8 @@ class PartialHEALPixConv2d(nn.Module):
         # keep Adam on-manifold via grad hooks (same pattern as ReflectionSteerable).
         feat_weight = self._conv_weight(self.feature_conv)
         with th.no_grad():
-            feat_weight.copy_(project_even_kernel(feat_weight))
-        feat_weight.register_hook(lambda g: project_even_kernel(g))
+            feat_weight.copy_(_project_even_kernel(feat_weight))
+        feat_weight.register_hook(lambda g: _project_even_kernel(g))
 
         if bias:
             self.bias = nn.Parameter(th.zeros(channels))
@@ -264,7 +270,7 @@ class PartialHEALPixConv2d(nn.Module):
         """Backward-compatible alias for kernel-only projection."""
         w = self._conv_weight(self.feature_conv)
         with th.no_grad():
-            w.copy_(project_even_kernel(w))
+            w.copy_(_project_even_kernel(w))
 
     def _project_parity_params_(self) -> None:
         self._project_feature_kernel_()

--- a/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
+++ b/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
@@ -1,0 +1,562 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Partial convolution stem for coupled HEALPix inputs (e.g. SST/SIC).
+
+Soft masks (continuous ocean fraction) *downweight* filled/invalid cells; they do
+not make the stem independent of the fill strategy on fractional cells. Hard
+threshold masks set ``M in {0, 1}`` so invalid fills do not contribute to the
+forward pass or gradients.
+
+Padding uses the same ``HEALPixLayer`` / ``make_hpx_padding_layer`` path as the
+rest of the atmosphere model.
+
+Depthwise feature kernels are always projected onto the even-under-``R`` subspace
+(``K = R(K)``) with gradient hooks so Adam stays on-manifold. That is correct for
+both even and odd coupled channels (depthwise odd→odd also needs an even kernel).
+Odd channels additionally force bias to zero. Channel parity is supplied via
+``channel_is_odd`` / RecUNet ``odd_coupled_variables``. Full stem intertwining
+``stem(ρx) = ρ stem(x)`` additionally needs a ρ-symmetric mask ``M ≈ ρM``
+(B24 ocean is fine; real geographic LSM breaks that).
+
+The stem itself is Hydra-instantiable via ``coupled_partial_conv.stem`` (default
+:class:`CoupledPartialConvStem`). Custom stems must accept ``channel_masks`` plus
+the HEALPix padding kwargs and map ``[B, F, C, H, W] → [B, F, C, H, W]`` (channel
+count preserved for encoder / reflection layouts).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional, Sequence, Union
+
+import numpy as np
+import torch as th
+import torch.nn as nn
+import xarray as xr
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from .healpix_layers import HEALPixLayer
+from .healpix_paddings import HEALPixFoldFaces, HEALPixUnfoldFaces
+from .reflection_ops import project_even_kernel
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET = (
+    "physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv.CoupledPartialConvStem"
+)
+
+
+def coupled_variable_channel_names(couplings: Sequence[Mapping[str, Any]]) -> list[str]:
+    """Expand coupling configs to the per-channel variable name list.
+
+    Order matches the coupler / ``_reshape_inputs`` concatenation:
+    for each coupling, for each variable, for each ``input_times`` entry.
+    """
+    names: list[str] = []
+    for c in couplings:
+        params = c["params"]
+        for v in params["variables"]:
+            for _ in params["input_times"]:
+                names.append(str(v))
+    return names
+
+
+def _open_mask_dataset(dataset_path: str) -> xr.Dataset:
+    path = str(dataset_path)
+    if path.rstrip("/").endswith(".zarr"):
+        return xr.open_zarr(path)
+    return xr.open_dataset(path)
+
+
+def _resolve_mask_field(
+    ds: xr.Dataset,
+    data_var: str,
+    selection_dict: Mapping[str, Any] | None,
+) -> xr.DataArray:
+    """Resolve a mask field for monolithic or named-array healpix stores."""
+    sel = dict(selection_dict or {})
+    if data_var in ds.data_vars:
+        field = ds[data_var]
+        if sel:
+            field = field.sel(**sel)
+        return field
+
+    # named_arrays_healpix: constants are top-level arrays; channel_c names the field.
+    if data_var == "constants" and "channel_c" in sel:
+        field_name = str(sel.pop("channel_c"))
+        if field_name not in ds.data_vars:
+            raise KeyError(
+                f"Mask field {field_name!r} not found in dataset; "
+                "named_arrays_healpix stores expose constants as top-level arrays."
+            )
+        field = ds[field_name]
+        if sel:
+            field = field.sel(**sel)
+        return field
+
+    raise KeyError(
+        f"No variable named {data_var!r} in dataset"
+        + (f" (available: {list(ds.data_vars)!r})" if hasattr(ds, "data_vars") else "")
+    )
+
+
+def load_spatial_mask(
+    dataset_path: str,
+    data_var: str = "constants",
+    selection_dict: Mapping[str, Any] | None = None,
+    invert: bool = True,
+    threshold: float | None = None,
+) -> th.Tensor:
+    """Load a single spatial mask as ``[F, H, W]`` float tensor in ``[0, 1]``.
+
+    Parameters
+    ----------
+    dataset_path:
+        Path to a netCDF or zarr store.
+    data_var:
+        Dataset variable containing the mask field (e.g. ``constants``).
+    selection_dict:
+        Optional ``.sel`` kwargs (e.g. ``{"channel_c": "lsm"}``).
+    invert:
+        If True, use ``1 - values`` (LSM → ocean fraction).
+    threshold:
+        If set, binarize after invert: ``M = (M > threshold)``.
+        If ``None``, keep a soft (continuous) mask.
+    """
+    ds = _open_mask_dataset(dataset_path)
+    try:
+        field = _resolve_mask_field(ds, data_var, selection_dict)
+        values = np.asarray(field.values, dtype=np.float32)
+    finally:
+        ds.close()
+
+    values = np.squeeze(values)
+    if values.ndim != 3:
+        raise ValueError(
+            f"Expected mask field with 3 dimensions [F, H, W] after squeeze; "
+            f"got shape {values.shape}"
+        )
+
+    mask = th.from_numpy(values)
+    if invert:
+        mask = 1.0 - mask
+    if threshold is not None:
+        mask = (mask > float(threshold)).to(dtype=th.float32)
+    else:
+        mask = mask.to(dtype=th.float32)
+    return mask
+
+
+def _as_plain_dict(cfg: Any) -> dict:
+    if cfg is None:
+        return {}
+    if isinstance(cfg, DictConfig):
+        return OmegaConf.to_container(cfg, resolve=True)
+    return dict(cfg)
+
+
+def _normalize_channel_is_odd(
+    channels: int,
+    channel_is_odd: Optional[Union[Sequence[bool], th.Tensor]],
+) -> th.Tensor:
+    """Return a length-``channels`` bool tensor; ``None`` means all-even."""
+    if channel_is_odd is None:
+        return th.zeros(channels, dtype=th.bool)
+    if isinstance(channel_is_odd, th.Tensor):
+        odd = channel_is_odd.detach().to(dtype=th.bool).reshape(-1).cpu()
+    else:
+        odd = th.tensor([bool(x) for x in channel_is_odd], dtype=th.bool)
+    if odd.numel() != channels:
+        raise ValueError(
+            f"channel_is_odd length {odd.numel()} must match channels={channels}"
+        )
+    return odd
+
+
+class PartialHEALPixConv2d(nn.Module):
+    """Depthwise Liu-style partial convolution on folded HEALPix faces.
+
+    For each channel independently:
+
+    ``Y = Conv(X ⊙ M) * |K| / (Conv(1, M) + eps) + b``
+
+    ``X`` and ``M`` are padded with the same HEALPix padding as other model layers.
+
+    Feature kernels are constrained to the even-under-``R`` subspace
+    (``K = R(K)``) via init/``eval()`` projection and gradient hooks — required
+    for both even and odd depthwise channels. Even channels may have a free
+    bias; odd channels (see ``channel_is_odd``) force bias to zero.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        kernel_size: int = 3,
+        dilation: int = 1,
+        eps: float = 1.0e-8,
+        hpx_padding_mode: str | None = None,
+        nside: int | None = None,
+        compile_padding: bool = False,
+        bias: bool = True,
+        enable_nhwc: bool = False,
+        channel_is_odd: Optional[Union[Sequence[bool], th.Tensor]] = None,
+    ):
+        super().__init__()
+        if channels < 1:
+            raise ValueError(f"channels must be >= 1, got {channels}")
+        self.channels = channels
+        self.kernel_size = int(kernel_size)
+        self.dilation = int(dilation)
+        self.eps = float(eps)
+        self.kernel_numel = float(self.kernel_size * self.kernel_size)
+        self.register_buffer(
+            "channel_is_odd",
+            _normalize_channel_is_odd(channels, channel_is_odd),
+            persistent=False,
+        )
+
+        common = dict(
+            in_channels=channels,
+            out_channels=channels,
+            kernel_size=self.kernel_size,
+            dilation=self.dilation,
+            groups=channels,
+            bias=False,
+            hpx_padding_mode=hpx_padding_mode,
+            nside=nside,
+            compile_padding=compile_padding,
+            enable_nhwc=enable_nhwc,
+        )
+        self.feature_conv = HEALPixLayer(layer=th.nn.Conv2d, **common)
+        self.mask_sum_conv = HEALPixLayer(layer=th.nn.Conv2d, **common)
+
+        # All-ones kernel for local valid-mass; never trained (already even under R).
+        mask_weight = self._conv_weight(self.mask_sum_conv)
+        with th.no_grad():
+            mask_weight.fill_(1.0)
+        mask_weight.requires_grad_(False)
+
+        # Even-kernel manifold (depthwise even→even and odd→odd): project init and
+        # keep Adam on-manifold via grad hooks (same pattern as ReflectionSteerable).
+        feat_weight = self._conv_weight(self.feature_conv)
+        with th.no_grad():
+            feat_weight.copy_(project_even_kernel(feat_weight))
+        feat_weight.register_hook(lambda g: project_even_kernel(g))
+
+        if bias:
+            self.bias = nn.Parameter(th.zeros(channels))
+            if bool(self.channel_is_odd.any()):
+                with th.no_grad():
+                    self.bias[self.channel_is_odd] = 0
+                odd_mask = self.channel_is_odd
+
+                def _odd_bias_hook(grad, odd_mask=odd_mask):
+                    g = grad.clone()
+                    g[odd_mask] = 0
+                    return g
+
+                self.bias.register_hook(_odd_bias_hook)
+        else:
+            self.register_parameter("bias", None)
+
+    @staticmethod
+    def _conv_weight(hpx_layer: HEALPixLayer) -> th.Tensor:
+        # HEALPixLayer is Sequential(optional_pad, Conv2d)
+        for module in hpx_layer.layers:
+            if isinstance(module, th.nn.Conv2d):
+                return module.weight
+        raise RuntimeError("HEALPixLayer has no Conv2d submodule")
+
+    def train(self, mode: bool = True):
+        was_training = self.training
+        out = super().train(mode)
+        # Re-snap weights / odd bias when entering eval so checkpoints / inference are exact.
+        if was_training and not mode:
+            self._project_parity_params_()
+        return out
+
+    def _project_feature_kernel_(self) -> None:
+        """Backward-compatible alias for kernel-only projection."""
+        w = self._conv_weight(self.feature_conv)
+        with th.no_grad():
+            w.copy_(project_even_kernel(w))
+
+    def _project_parity_params_(self) -> None:
+        self._project_feature_kernel_()
+        if self.bias is not None and bool(self.channel_is_odd.any()):
+            with th.no_grad():
+                self.bias[self.channel_is_odd] = 0
+
+    def forward(self, x: th.Tensor, mask: th.Tensor) -> th.Tensor:
+        """
+        Parameters
+        ----------
+        x:
+            Folded features ``[B*F, C, H, W]``.
+        mask:
+            Validity mask broadcastable to ``x`` (typically ``[1, C, H, W]`` or
+            ``[B*F, C, H, W]``) with values in ``[0, 1]``.
+        """
+        if mask.shape[-2:] != x.shape[-2:]:
+            raise ValueError(
+                f"mask spatial shape {mask.shape[-2:]} must match x {x.shape[-2:]}"
+            )
+        if mask.shape[1] != x.shape[1] and mask.shape[1] != 1:
+            raise ValueError(
+                f"mask channels {mask.shape[1]} incompatible with x channels {x.shape[1]}"
+            )
+
+        x_masked = x * mask
+        y = self.feature_conv(x_masked)
+        # mask_sum_conv pads M the same way as feature_conv pads X
+        valid_mass = self.mask_sum_conv(mask.expand_as(x) if mask.shape[0] == 1 else mask)
+        y = y * (self.kernel_numel / (valid_mass + self.eps))
+        if self.bias is not None:
+            y = y + self.bias.view(1, -1, 1, 1)
+        return y
+
+
+class CoupledPartialConvStem(nn.Module):
+    """Default depthwise partial-conv stem for coupled inputs ``[B, F, C, H, W]``.
+
+    Channel count is preserved so encoder wiring and reflection channel layouts
+    stay unchanged. Swap via Hydra ``coupled_partial_conv.stem._target_``.
+
+    ``channel_is_odd`` marks coupled channels that flip under equatorial reflection
+    (wired from RecUNet/UNet ``odd_coupled_variables``); those channels keep an
+    even kernel but zero bias.
+    """
+
+    def __init__(
+        self,
+        channel_masks: th.Tensor,
+        kernel_size: int = 3,
+        dilation: int = 1,
+        eps: float = 1.0e-8,
+        bias: bool = True,
+        hpx_padding_mode: str | None = None,
+        nside: int | None = None,
+        compile_padding: bool = False,
+        enable_nhwc: bool = False,
+        channel_is_odd: Optional[Union[Sequence[bool], th.Tensor]] = None,
+    ):
+        """
+        Parameters
+        ----------
+        channel_masks:
+            Tensor ``[C, F, H, W]`` — one spatial mask per coupled channel.
+        kernel_size, dilation, eps, bias:
+            Forwarded to :class:`PartialHEALPixConv2d`.
+        hpx_padding_mode, nside, compile_padding, enable_nhwc:
+            HEALPix padding / memory-format options; normally injected by the
+            model builder to match the parent RecUNet/UNet.
+        channel_is_odd:
+            Per-channel odd/even flags (length ``C``). ``None`` means all even.
+        """
+        super().__init__()
+        if channel_masks.ndim != 4:
+            raise ValueError(
+                f"channel_masks must be [C, F, H, W], got shape {tuple(channel_masks.shape)}"
+            )
+        channels, n_faces, _, _ = channel_masks.shape
+        self.n_faces = int(n_faces)
+        self.fold = HEALPixFoldFaces(enable_nhwc=enable_nhwc)
+        self.unfold = HEALPixUnfoldFaces(num_faces=self.n_faces, enable_nhwc=enable_nhwc)
+        # Store as [F, C, H, W] (rank 4) so model.to(channels_last) succeeds when
+        # enable_nhwc is on. Repeat over batch in forward, then fold to [B*F, C, H, W].
+        self.register_buffer(
+            "channel_masks",
+            channel_masks.permute(1, 0, 2, 3).contiguous(),
+            persistent=True,
+        )
+        self.pconv = PartialHEALPixConv2d(
+            channels=channels,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            eps=eps,
+            hpx_padding_mode=hpx_padding_mode,
+            nside=nside,
+            compile_padding=compile_padding,
+            bias=bias,
+            enable_nhwc=enable_nhwc,
+            channel_is_odd=channel_is_odd,
+        )
+
+    def forward(self, coupled: th.Tensor) -> th.Tensor:
+        """
+        Parameters
+        ----------
+        coupled:
+            Coupled forcing tensor ``[B, F, C, H, W]`` (after time-first permute).
+        """
+        if coupled.ndim != 5:
+            raise ValueError(
+                f"coupled inputs must be [B, F, C, H, W], got shape {tuple(coupled.shape)}"
+            )
+        if coupled.shape[1] != self.n_faces:
+            raise ValueError(
+                f"coupled face count {coupled.shape[1]} != mask faces {self.n_faces}"
+            )
+        if coupled.shape[2] != self.channel_masks.shape[1]:
+            raise ValueError(
+                f"coupled channels {coupled.shape[2]} != mask channels "
+                f"{self.channel_masks.shape[1]}"
+            )
+
+        x = self.fold(coupled)
+        # channel_masks: [F, C, H, W] -> [B, F, C, H, W] -> fold
+        mask = self.fold(
+            self.channel_masks.unsqueeze(0).expand(coupled.shape[0], -1, -1, -1, -1)
+        )
+        y = self.pconv(x, mask)
+        return self.unfold(y)
+
+
+def _resolve_stem_config(cfg: dict) -> Any:
+    """Build a Hydra stem config, defaulting to :class:`CoupledPartialConvStem`.
+
+    Preferred form::
+
+        stem:
+          _target_: ...CoupledPartialConvStem
+          kernel_size: 3
+          eps: 1.0e-8
+
+    Legacy flat keys ``kernel_size`` / ``eps`` / ``dilation`` / ``bias`` at the
+    ``coupled_partial_conv`` root are still accepted when ``stem`` is omitted.
+
+    Returns a ``DictConfig`` for string targets, or a plain dict when ``_target_``
+    is already a class object (OmegaConf cannot store class values).
+    """
+    stem_cfg = cfg.get("stem")
+    if stem_cfg is None:
+        return OmegaConf.create(
+            {
+                "_target_": DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET,
+                "kernel_size": cfg.get("kernel_size", 3),
+                "dilation": cfg.get("dilation", 1),
+                "eps": cfg.get("eps", 1.0e-8),
+                "bias": cfg.get("bias", True),
+            }
+        )
+
+    if isinstance(stem_cfg, DictConfig):
+        if "_target_" not in stem_cfg:
+            with OmegaConf.set_struct(stem_cfg, False):
+                stem_cfg._target_ = DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET
+        return stem_cfg
+
+    stem_cfg = dict(stem_cfg)
+    target = stem_cfg.get("_target_", DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET)
+    stem_cfg["_target_"] = target
+    # Class objects cannot round-trip through OmegaConf.create.
+    if isinstance(target, type):
+        return stem_cfg
+    return OmegaConf.create(stem_cfg)
+
+
+def build_coupled_partial_conv_stem(
+    config: Any,
+    couplings: Sequence[Mapping[str, Any]],
+    hpx_padding_mode: str | None = None,
+    nside: int | None = None,
+    compile_padding: bool = False,
+    enable_nhwc: bool = False,
+    odd_coupled_variables: Optional[Sequence[str]] = None,
+) -> nn.Module | None:
+    """Build a stem from a Hydra/dict config, or return ``None`` if disabled.
+
+    Expected config::
+
+        masks:
+          sst:
+            dataset_path: ...
+            data_var: constants
+            selection_dict: {channel_c: lsm}
+            invert: true
+            threshold: null   # soft; or e.g. 0.5 for hard
+          sic: ...
+        stem:
+          _target_: physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv.CoupledPartialConvStem
+          kernel_size: 3
+          dilation: 1
+          eps: 1.0e-8
+          bias: true
+
+    ``odd_coupled_variables`` names channels that flip under equatorial reflection;
+    they are expanded against ``coupled_variable_channel_names(couplings)`` into
+    ``channel_is_odd`` for the stem. Names that never appear in couplings are ignored.
+
+    ``stem`` is Hydra-instantiated with ``channel_masks`` and the parent model's
+    HEALPix padding kwargs injected. Custom ``_target_`` modules must preserve
+    coupled channel count in ``forward``.
+    """
+    if config is None:
+        return None
+
+    cfg = _as_plain_dict(config)
+    masks_cfg = cfg.get("masks")
+    if not masks_cfg:
+        raise ValueError("coupled_partial_conv config requires a non-empty 'masks' mapping")
+
+    channel_names = coupled_variable_channel_names(couplings)
+    if not channel_names:
+        raise ValueError("coupled_partial_conv requires at least one coupled variable")
+
+    missing = sorted({n for n in channel_names if n not in masks_cfg})
+    if missing:
+        raise ValueError(
+            "coupled_partial_conv.masks is missing entries for coupled variables: "
+            + ", ".join(missing)
+        )
+
+    odd_set = {str(v) for v in (odd_coupled_variables or [])}
+    unused_odd = sorted(odd_set - set(channel_names))
+    if unused_odd:
+        logger.warning(
+            "odd_coupled_variables not present in couplings (ignored for stem parity): %s",
+            ", ".join(unused_odd),
+        )
+    channel_is_odd = [name in odd_set for name in channel_names]
+
+    per_channel = []
+    for name in channel_names:
+        mcfg = _as_plain_dict(masks_cfg[name])
+        if "dataset_path" not in mcfg:
+            raise ValueError(f"coupled_partial_conv.masks.{name} requires dataset_path")
+        per_channel.append(
+            load_spatial_mask(
+                dataset_path=mcfg["dataset_path"],
+                data_var=mcfg.get("data_var", "constants"),
+                selection_dict=mcfg.get("selection_dict"),
+                invert=bool(mcfg.get("invert", True)),
+                threshold=mcfg.get("threshold", None),
+            )
+        )
+
+    channel_masks = th.stack(per_channel, dim=0)  # [C, F, H, W]
+    stem_cfg = _resolve_stem_config(cfg)
+    return instantiate(
+        stem_cfg,
+        channel_masks=channel_masks,
+        hpx_padding_mode=hpx_padding_mode,
+        nside=nside,
+        compile_padding=compile_padding,
+        enable_nhwc=enable_nhwc,
+        channel_is_odd=channel_is_odd,
+    )

--- a/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
+++ b/physicsnemo/models/dlwp_healpix_layers/coupled_partial_conv.py
@@ -83,38 +83,6 @@ def _open_mask_dataset(dataset_path: str) -> xr.Dataset:
     return xr.open_dataset(path)
 
 
-def _resolve_mask_field(
-    ds: xr.Dataset,
-    data_var: str,
-    selection_dict: Mapping[str, Any] | None,
-) -> xr.DataArray:
-    """Resolve a mask field for monolithic or named-array healpix stores."""
-    sel = dict(selection_dict or {})
-    if data_var in ds.data_vars:
-        field = ds[data_var]
-        if sel:
-            field = field.sel(**sel)
-        return field
-
-    # named_arrays_healpix: constants are top-level arrays; channel_c names the field.
-    if data_var == "constants" and "channel_c" in sel:
-        field_name = str(sel.pop("channel_c"))
-        if field_name not in ds.data_vars:
-            raise KeyError(
-                f"Mask field {field_name!r} not found in dataset; "
-                "named_arrays_healpix stores expose constants as top-level arrays."
-            )
-        field = ds[field_name]
-        if sel:
-            field = field.sel(**sel)
-        return field
-
-    raise KeyError(
-        f"No variable named {data_var!r} in dataset"
-        + (f" (available: {list(ds.data_vars)!r})" if hasattr(ds, "data_vars") else "")
-    )
-
-
 def load_spatial_mask(
     dataset_path: str,
     data_var: str = "constants",
@@ -140,7 +108,9 @@ def load_spatial_mask(
     """
     ds = _open_mask_dataset(dataset_path)
     try:
-        field = _resolve_mask_field(ds, data_var, selection_dict)
+        field = ds[data_var]
+        if selection_dict:
+            field = field.sel(**dict(selection_dict))
         values = np.asarray(field.values, dtype=np.float32)
     finally:
         ds.close()

--- a/test/models/dlwp_healpix/test_coupled_partial_conv.py
+++ b/test/models/dlwp_healpix/test_coupled_partial_conv.py
@@ -1,0 +1,500 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for coupled-input partial convolution stem."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pytest
+import torch as th
+import xarray as xr
+
+import torch.nn as nn
+
+from physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv import (
+    DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET,
+    CoupledPartialConvStem,
+    PartialHEALPixConv2d,
+    build_coupled_partial_conv_stem,
+    coupled_variable_channel_names,
+    load_spatial_mask,
+)
+from physicsnemo.models.dlwp_healpix_layers.healpix_paddings import (
+    HEALPixFoldFaces,
+    HEALPixUnfoldFaces,
+)
+from physicsnemo.models.dlwp_healpix_layers.reflection_ops import (
+    apply_R_kernel,
+    hpx_spatial_reflect,
+    project_even_kernel,
+)
+
+
+def _reflect_bfchw(x: th.Tensor) -> th.Tensor:
+    """Equatorial HEALPix reflection on ``[B, F, C, H, W]`` (spatial only)."""
+    fold = HEALPixFoldFaces()
+    unfold = HEALPixUnfoldFaces(num_faces=x.shape[1])
+    return unfold(hpx_spatial_reflect(fold(x)))
+
+
+def _reflect_bfchw_typed(x: th.Tensor, odd_channels: Sequence[int]) -> th.Tensor:
+    """Spatial HEALPix reflection plus sign flip on odd channel indices."""
+    y = _reflect_bfchw(x).clone()
+    for i in odd_channels:
+        y[:, :, i] *= -1
+    return y
+
+
+class _IdentityCoupledStem(nn.Module):
+    """Minimal custom stem used to verify Hydra ``_target_`` wiring."""
+
+    def __init__(
+        self,
+        channel_masks,
+        hpx_padding_mode=None,
+        nside=None,
+        compile_padding=False,
+        channel_is_odd=None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.register_buffer(
+            "channel_masks",
+            channel_masks.permute(1, 0, 2, 3).contiguous(),
+            persistent=True,
+        )
+
+    def forward(self, coupled):
+        return coupled
+
+
+N_FACES = 12
+NSIDE = 8
+
+
+def _toy_couplings(variables=("sst", "sic"), input_times=("0h",)):
+    return [
+        {
+            "coupler": "ConstantCoupler",
+            "params": {
+                "variables": list(variables),
+                "input_times": list(input_times),
+            },
+        }
+    ]
+
+
+def _write_lsm_zarr(path, ocean_frac: np.ndarray):
+    """Write constants/lsm as land fraction ``1 - ocean_frac``."""
+    land = 1.0 - ocean_frac.astype(np.float32)
+    ds = xr.Dataset(
+        {
+            "constants": (
+                ("channel_c", "face", "height", "width"),
+                land[np.newaxis, ...],
+            )
+        },
+        coords={"channel_c": ["lsm"]},
+    )
+    ds.to_zarr(path, mode="w")
+
+
+@pytest.fixture
+def ocean_frac():
+    # Mostly ocean on even faces, mostly land on odd faces; fractional coast band.
+    m = np.zeros((N_FACES, NSIDE, NSIDE), dtype=np.float32)
+    m[0::2] = 1.0
+    m[1::2] = 0.0
+    m[:, :2, :] = 0.3  # soft coastal strip
+    return m
+
+
+def test_coupled_variable_channel_names_expands_times():
+    couplings = _toy_couplings(variables=("sst", "sic"), input_times=("0h", "6h"))
+    assert coupled_variable_channel_names(couplings) == [
+        "sst",
+        "sst",
+        "sic",
+        "sic",
+    ]
+
+
+def test_load_spatial_mask_soft_and_hard(tmp_path, ocean_frac):
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+
+    soft = load_spatial_mask(
+        str(zpath),
+        data_var="constants",
+        selection_dict={"channel_c": "lsm"},
+        invert=True,
+        threshold=None,
+    )
+    hard = load_spatial_mask(
+        str(zpath),
+        data_var="constants",
+        selection_dict={"channel_c": "lsm"},
+        invert=True,
+        threshold=0.5,
+    )
+    assert soft.shape == (N_FACES, NSIDE, NSIDE)
+    assert th.allclose(soft, th.from_numpy(ocean_frac))
+    assert set(hard.unique().tolist()) <= {0.0, 1.0}
+    assert th.all(hard[ocean_frac > 0.5] == 1.0)
+    assert th.all(hard[ocean_frac <= 0.5] == 0.0)
+
+
+def test_build_stem_none_config_returns_none():
+    assert build_coupled_partial_conv_stem(None, _toy_couplings()) is None
+
+
+def test_build_stem_requires_all_variables(tmp_path, ocean_frac):
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    cfg = {
+        "kernel_size": 3,
+        "masks": {
+            "sst": {
+                "dataset_path": str(zpath),
+                "data_var": "constants",
+                "selection_dict": {"channel_c": "lsm"},
+                "invert": True,
+                "threshold": None,
+            }
+        },
+    }
+    with pytest.raises(ValueError, match="missing entries"):
+        build_coupled_partial_conv_stem(cfg, _toy_couplings())
+
+
+@pytest.mark.parametrize("hpx_padding_mode", ["karlbauer", "earth2grid"])
+def test_stem_forward_finite_and_shape(tmp_path, ocean_frac, hpx_padding_mode):
+    if hpx_padding_mode == "earth2grid":
+        from physicsnemo.models.dlwp_healpix_layers.healpix_paddings import (
+            have_earth2grid,
+        )
+
+        if not have_earth2grid:
+            pytest.skip("earth2grid not available")
+
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    mask_cfg = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+        "threshold": None,
+    }
+    stem = build_coupled_partial_conv_stem(
+        {
+            "kernel_size": 3,
+            "eps": 1.0e-8,
+            "masks": {"sst": mask_cfg, "sic": {**mask_cfg, "threshold": 0.5}},
+        },
+        _toy_couplings(),
+        hpx_padding_mode=hpx_padding_mode,
+        nside=NSIDE,
+    )
+    assert isinstance(stem, CoupledPartialConvStem)
+    x = th.randn(2, N_FACES, 2, NSIDE, NSIDE)
+    y = stem(x)
+    assert y.shape == x.shape
+    assert th.isfinite(y).all()
+
+
+def test_hard_mask_fill_independence(tmp_path, ocean_frac):
+    """Changing values only on hard-invalid cells must not change stem output."""
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    hard_cfg = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+        "threshold": 0.5,
+    }
+    stem = build_coupled_partial_conv_stem(
+        {"kernel_size": 3, "masks": {"sst": hard_cfg, "sic": hard_cfg}},
+        _toy_couplings(),
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+    )
+    # Freeze feature weights for a deterministic comparison
+    with th.no_grad():
+        w = stem.pconv._conv_weight(stem.pconv.feature_conv)
+        w.fill_(1.0 / 9.0)
+        if stem.pconv.bias is not None:
+            stem.pconv.bias.zero_()
+
+    # channel_masks buffer is [1, F, C, H, W]
+    invalid = stem.channel_masks == 0.0
+
+    x_a = th.randn(1, N_FACES, 2, NSIDE, NSIDE)
+    x_b = th.where(invalid.expand_as(x_a), th.full_like(x_a, 123.0), x_a)
+    y_a = stem(x_a)
+    y_b = stem(x_b)
+    assert th.allclose(y_a, y_b, atol=1e-5, rtol=1e-5)
+
+
+def test_per_var_soft_vs_hard_masks_differ(tmp_path, ocean_frac):
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    base = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+    }
+    stem = build_coupled_partial_conv_stem(
+        {
+            "kernel_size": 3,
+            "masks": {
+                "sst": {**base, "threshold": None},
+                "sic": {**base, "threshold": 0.5},
+            },
+        },
+        _toy_couplings(),
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+    )
+    # Soft channel (0) keeps fractional mass; hard channel (1) is binary.
+    # channel_masks buffer layout: [F, C, H, W]
+    soft_m = stem.channel_masks[:, 0]
+    hard_m = stem.channel_masks[:, 1]
+    assert th.any((soft_m > 0) & (soft_m < 1))
+    assert set(hard_m.unique().tolist()) <= {0.0, 1.0}
+
+
+def test_partial_conv_matches_standard_when_mask_ones():
+    """With M=1 everywhere, PConv (bias=0) matches depthwise conv."""
+    channels = 2
+    pconv = PartialHEALPixConv2d(
+        channels=channels,
+        kernel_size=3,
+        eps=1.0e-8,
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+        bias=False,
+    )
+    with th.no_grad():
+        w = pconv._conv_weight(pconv.feature_conv)
+        w.normal_(0, 0.1)
+
+    x = th.randn(N_FACES, channels, NSIDE, NSIDE)
+    mask = th.ones_like(x)
+    y_p = pconv(x, mask)
+    y_ref = pconv.feature_conv(x)
+    assert th.allclose(y_p, y_ref, atol=1e-5, rtol=1e-5)
+
+
+def test_disabled_stem_leaves_coupled_tensor_untouched_in_reshape_logic():
+    """build(... None) is the disabled path used by RecUNet/UNet."""
+    assert build_coupled_partial_conv_stem(None, _toy_couplings()) is None
+
+
+def test_stem_hydra_target_default(tmp_path, ocean_frac):
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    mask_cfg = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+        "threshold": 0.5,
+    }
+    stem = build_coupled_partial_conv_stem(
+        {
+            "masks": {"sst": mask_cfg, "sic": mask_cfg},
+            "stem": {
+                "_target_": DEFAULT_COUPLED_PARTIAL_CONV_STEM_TARGET,
+                "kernel_size": 3,
+                "dilation": 1,
+                "eps": 1.0e-8,
+                "bias": True,
+            },
+        },
+        _toy_couplings(),
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+    )
+    assert isinstance(stem, CoupledPartialConvStem)
+    assert stem.pconv.kernel_size == 3
+    assert stem.pconv.dilation == 1
+
+
+def test_custom_stem_target(tmp_path, ocean_frac):
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    mask_cfg = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+        "threshold": 0.5,
+    }
+    # Pass the class object so Hydra need not import via a pytest module path.
+    stem = build_coupled_partial_conv_stem(
+        {
+            "masks": {"sst": mask_cfg, "sic": mask_cfg},
+            "stem": {"_target_": _IdentityCoupledStem},
+        },
+        _toy_couplings(),
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+    )
+    assert isinstance(stem, _IdentityCoupledStem)
+    x = th.randn(1, N_FACES, 2, NSIDE, NSIDE)
+    assert th.equal(stem(x), x)
+
+
+def test_partial_conv_feature_kernels_are_even():
+    """Depthwise feature kernels satisfy K ≈ R(K); bias is per-channel (even)."""
+    pconv = PartialHEALPixConv2d(
+        channels=3,
+        kernel_size=3,
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+        bias=True,
+    )
+    pconv.eval()
+    w = pconv._conv_weight(pconv.feature_conv)
+    th.testing.assert_close(w, apply_R_kernel(w), atol=1e-6, rtol=1e-6)
+    th.testing.assert_close(w, project_even_kernel(w), atol=1e-6, rtol=1e-6)
+    assert pconv.bias is not None
+    assert pconv.bias.shape == (3,)
+
+
+def test_stem_intertwines_with_ones_mask():
+    """With ρ-symmetric ones mask and even kernels, stem(ρx) ≈ ρ stem(x)."""
+    channels = 2
+    masks = th.ones(channels, N_FACES, NSIDE, NSIDE)
+    stem = CoupledPartialConvStem(
+        channel_masks=masks,
+        kernel_size=3,
+        bias=True,
+        hpx_padding_mode="isolatitude",
+        compile_padding=False,
+        nside=NSIDE,
+    )
+    stem.eval()
+    th.manual_seed(0)
+    x = th.randn(2, N_FACES, channels, NSIDE, NSIDE)
+    with th.no_grad():
+        y = stem(x)
+        y_from_rx = stem(_reflect_bfchw(x))
+        ry = _reflect_bfchw(y)
+    th.testing.assert_close(y_from_rx, ry, atol=1e-5, rtol=1e-4)
+
+
+def test_partial_conv_even_kernel_survives_adam_step():
+    """One Adam update + eval() keeps feature kernels on the even manifold."""
+    pconv = PartialHEALPixConv2d(
+        channels=2,
+        kernel_size=3,
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+        bias=False,
+    )
+    opt = th.optim.Adam(pconv.parameters(), lr=1e-2)
+    x = th.randn(N_FACES, 2, NSIDE, NSIDE)
+    mask = th.ones_like(x)
+    pconv.train()
+    loss = pconv(x, mask).pow(2).mean()
+    loss.backward()
+    opt.step()
+    pconv.eval()
+    w = pconv._conv_weight(pconv.feature_conv)
+    th.testing.assert_close(w, apply_R_kernel(w), atol=1e-5, rtol=1e-5)
+
+
+def test_odd_channel_bias_stays_zero_through_adam():
+    """Odd channels keep even kernels but force bias=0 even after an Adam step."""
+    pconv = PartialHEALPixConv2d(
+        channels=2,
+        kernel_size=3,
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+        bias=True,
+        channel_is_odd=[False, True],
+    )
+    assert bool(pconv.channel_is_odd.tolist() == [False, True])
+    pconv.eval()
+    assert float(pconv.bias[1].item()) == 0.0
+
+    opt = th.optim.Adam(pconv.parameters(), lr=1e-1)
+    x = th.randn(N_FACES, 2, NSIDE, NSIDE)
+    mask = th.ones_like(x)
+    pconv.train()
+    # Seed a nonzero odd bias; the grad hook + eval project must clear it.
+    with th.no_grad():
+        pconv.bias[:] = 1.0
+    loss = pconv(x, mask).pow(2).mean()
+    loss.backward()
+    assert float(pconv.bias.grad[1].item()) == 0.0
+    opt.step()
+    pconv.eval()
+    assert float(pconv.bias[1].abs().item()) < 1e-8
+    w = pconv._conv_weight(pconv.feature_conv)
+    th.testing.assert_close(w, apply_R_kernel(w), atol=1e-5, rtol=1e-5)
+
+
+def test_stem_intertwines_mixed_even_odd_channels():
+    """Ones mask + mixed parity: stem(ρx) ≈ ρ stem(x) with odd-channel sign flip."""
+    channels = 2
+    masks = th.ones(channels, N_FACES, NSIDE, NSIDE)
+    stem = CoupledPartialConvStem(
+        channel_masks=masks,
+        kernel_size=3,
+        bias=True,
+        hpx_padding_mode="isolatitude",
+        compile_padding=False,
+        nside=NSIDE,
+        channel_is_odd=[False, True],
+    )
+    stem.eval()
+    th.manual_seed(1)
+    x = th.randn(2, N_FACES, channels, NSIDE, NSIDE)
+    with th.no_grad():
+        y = stem(x)
+        y_from_rx = stem(_reflect_bfchw_typed(x, odd_channels=[1]))
+        ry = _reflect_bfchw_typed(y, odd_channels=[1])
+    th.testing.assert_close(y_from_rx, ry, atol=1e-5, rtol=1e-4)
+
+
+def test_builder_wires_odd_coupled_variables(tmp_path, ocean_frac):
+    """odd_coupled_variables expands to channel_is_odd on the built stem."""
+    zpath = tmp_path / "mask.zarr"
+    _write_lsm_zarr(zpath, ocean_frac)
+    mask_cfg = {
+        "dataset_path": str(zpath),
+        "data_var": "constants",
+        "selection_dict": {"channel_c": "lsm"},
+        "invert": True,
+        "threshold": 0.5,
+    }
+    stem = build_coupled_partial_conv_stem(
+        {"masks": {"sst": mask_cfg, "v_coup": mask_cfg}},
+        _toy_couplings(variables=("sst", "v_coup")),
+        hpx_padding_mode="karlbauer",
+        nside=NSIDE,
+        odd_coupled_variables=["v_coup", "not_in_couplings"],
+    )
+    assert isinstance(stem, CoupledPartialConvStem)
+    assert stem.pconv.channel_is_odd.tolist() == [False, True]


### PR DESCRIPTION
## Summary
- Add a depthwise HEALPix partial-convolution stem for coupled inputs (e.g. SST/SIC) with per-variable soft or hard masks loaded from zarr/nc.
- Wire an opt-in `coupled_partial_conv` config on `HEALPixRecUNet` / `HEALPixUNet` (`None` preserves current behavior).
- Stem uses the same `HEALPixLayer` padding path as the rest of the model (`hpx_padding_mode` / `nside`).
- **`coupled_partial_conv.stem` is Hydra-instantiable** (default `CoupledPartialConvStem`); swap `_target_` to customize architecture. Legacy flat `kernel_size` / `eps` / `dilation` / `bias` keys still work when `stem` is omitted.

Soft masks downweight filled cells; hard thresholds cut invalid fills out of the forward/grad path. Channel count is preserved so reflectional coupled-channel layouts stay valid.

## Description
Opt-in coupled partial-conv stem for atmosphere forcings such as SST/SIC. The stem block mirrors encoder `conv_block` style configurability.

Example:
```yaml
coupled_partial_conv:
  masks:
    sst: {dataset_path: ..., data_var: constants, selection_dict: {channel_c: lsm}, invert: true, threshold: 0.5}
    sic: {dataset_path: ..., data_var: constants, selection_dict: {channel_c: lsm}, invert: true, threshold: 0.5}
  stem:
    _target_: physicsnemo.models.dlwp_healpix_layers.coupled_partial_conv.CoupledPartialConvStem
    kernel_size: 3
    dilation: 1
    eps: 1.0e-8
    bias: true
```

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] The CHANGELOG.md is up to date with these changes.
- [ ] An issue is linked to this pull request.

## Dependencies
- Hard: #31 (`wy/isolatitude_hpx_pad`) via base branch.
- Preferred stack base: #33 (`wy/reflectional_equivariance`) — this PR is opened against that tip so the diff is stem-only.
- After #33 merges to `dev`, retarget/rebase this PR onto `dev`.
- Already merged into `wy/dlesym-aq` for training. Do not block other aq→`dev` PRs on this.

## Test plan
- [x] `pytest test/models/dlwp_healpix/test_coupled_partial_conv.py -v`
- [x] Hydra `stem._target_` default + custom stem wiring covered
- [ ] Confirm disabled (`coupled_partial_conv=None`) matches prior coupled forward on a smoke batch
- [ ] Config soft LSM mask vs hard `threshold: 0.5` on a short train/debug run
