### PR TITLE
Fix DataLoader drop_last with dataset-level batching

### DIFF
--- a/physicsnemo/datapipes/healpix/data_modules_zarr.py
+++ b/physicsnemo/datapipes/healpix/data_modules_zarr.py
@@ -332,13 +332,17 @@ class TimeSeriesDataModuleZarr:
             )
             shuffle = False
 
+        # Dataset-level batching uses dataloader_batch_size=None. PyTorch forbids
+        # drop_last=True in that case; the dataset already honors drop_last for
+        # incomplete batches. Keep DataLoader drop_last only when it auto-batches.
+        dl_drop_last = drop_last if self.dataloader_batch_size is not None else False
         dataloader_kwargs = {
             "dataset": dataset,
             "pin_memory": self.pin_memory,
             "num_workers": self.num_workers,
             "persistent_workers": (self.persistent_workers and self.num_workers > 0),
             "shuffle": shuffle,
-            "drop_last": drop_last,
+            "drop_last": dl_drop_last,
             "sampler": sampler,
             "collate_fn": self.collate_fn,
             "batch_size": self.dataloader_batch_size,

--- a/test/datapipes/test_data_modules_zarr_drop_last.py
+++ b/test/datapipes/test_data_modules_zarr_drop_last.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for DataLoader drop_last vs dataset-level batching.
+
+These configs (e.g. dlesym-aq) set ``drop_last=True`` with
+``dataloader_batch_size=None`` so the dataset forms batches. PyTorch forbids
+``drop_last=True`` when ``batch_size=None``; the datamodule must not pass that
+combination through to ``DataLoader``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from torch.utils.data import DataLoader, Dataset
+
+from physicsnemo.datapipes.healpix.data_modules_zarr import TimeSeriesDataModuleZarr
+
+
+class _TinyDataset(Dataset):
+    def __len__(self) -> int:
+        return 5
+
+    def __getitem__(self, index: int) -> int:
+        return index
+
+
+def _bare_datamodule(
+    *,
+    dataloader_batch_size: int | None,
+    drop_last: bool,
+) -> TimeSeriesDataModuleZarr:
+    """Minimal instance for exercising ``_base_dataloader`` only."""
+    dm = TimeSeriesDataModuleZarr.__new__(TimeSeriesDataModuleZarr)
+    dm.dataloader_batch_size = dataloader_batch_size
+    dm.drop_last = drop_last
+    dm.pin_memory = False
+    dm.num_workers = 0
+    dm.persistent_workers = False
+    dm.prefetch_factor = None
+    dm.in_order = None
+    dm.collate_fn = None
+    return dm
+
+
+def test_pytorch_rejects_drop_last_with_batch_size_none():
+    """Document the PyTorch constraint this datamodule must work around."""
+    with pytest.raises(ValueError, match="mutually exclusive with drop_last"):
+        DataLoader(_TinyDataset(), batch_size=None, drop_last=True)
+
+
+def test_drop_last_false_on_dataloader_when_batch_size_none():
+    """Dataset-level batching: DataLoader must construct and drop_last is off."""
+    dm = _bare_datamodule(dataloader_batch_size=None, drop_last=True)
+    loader, sampler = dm._base_dataloader(
+        dataset=_TinyDataset(),
+        drop_last=True,
+    )
+    assert sampler is None
+    assert isinstance(loader, DataLoader)
+    assert loader.batch_size is None
+    assert loader.drop_last is False
+
+
+def test_drop_last_honored_when_dataloader_auto_batches():
+    """When the DataLoader auto-batches, drop_last must still apply."""
+    dm = _bare_datamodule(dataloader_batch_size=2, drop_last=True)
+    loader, sampler = dm._base_dataloader(
+        dataset=_TinyDataset(),
+        drop_last=True,
+    )
+    assert sampler is None
+    assert isinstance(loader, DataLoader)
+    assert loader.batch_size == 2
+    assert loader.drop_last is True
+    # Incomplete final batch of size 1 is dropped (5 samples, batch_size 2).
+    assert len(loader) == 2

--- a/test/datapipes/test_healpix_couple_zarr.py
+++ b/test/datapipes/test_healpix_couple_zarr.py
@@ -1032,16 +1032,21 @@ def test_CoupledTimeSeriesDataModuleZarr_get_dataloaders(
         splits=splits,
         shuffle=False,
         couplings=constant_coupler_config,
+        drop_last=True,
+        dataloader_batch_size=None,
     )
 
     # with 1 shard should get no sampler
     train_dataloader, train_sampler = timeseries_dm.train_dataloader(num_shards=1)
     assert train_sampler is None
     assert isinstance(train_dataloader, DataLoader)
+    assert train_dataloader.batch_size is None
+    assert train_dataloader.drop_last is False
 
     val_dataloader, val_sampler = timeseries_dm.val_dataloader(num_shards=1)
     assert val_sampler is None
     assert isinstance(val_dataloader, DataLoader)
+    assert val_dataloader.drop_last is False
 
     test_dataloader, test_sampler = timeseries_dm.test_dataloader(num_shards=1)
     assert test_sampler is None

--- a/test/datapipes/test_healpix_zarr.py
+++ b/test/datapipes/test_healpix_zarr.py
@@ -745,6 +745,8 @@ def test_TimeSeriesDataModule_get_dataloaders(
 
     # use the prebuilt dataset
     # Internally initializes DistributedManager
+    # drop_last=True + dataloader_batch_size=None is the dlesym-aq default and
+    # must not raise when constructing the DataLoader.
     timeseries_dm = TimeSeriesDataModuleZarr(
         dataset_path=dataset_path,
         input_variables=input_variables,
@@ -752,16 +754,21 @@ def test_TimeSeriesDataModule_get_dataloaders(
         scaling=scaling_double_dict,
         splits=splits,
         shuffle=False,
+        drop_last=True,
+        dataloader_batch_size=None,
     )
 
     # with 1 shard should get no sampler
     train_dataloader, train_sampler = timeseries_dm.train_dataloader(num_shards=1)
     assert train_sampler is None
     assert isinstance(train_dataloader, DataLoader)
+    assert train_dataloader.batch_size is None
+    assert train_dataloader.drop_last is False
 
     val_dataloader, val_sampler = timeseries_dm.val_dataloader(num_shards=1)
     assert val_sampler is None
     assert isinstance(val_dataloader, DataLoader)
+    assert val_dataloader.drop_last is False
 
     test_dataloader, test_sampler = timeseries_dm.test_dataloader(num_shards=1)
     assert test_sampler is None


### PR DESCRIPTION
## Description

Follow-up to #61: after `drop_last` was wired through to the PyTorch `DataLoader`, configs that use dataset-level batching (`dataloader_batch_size=None`, including `dlesym-aq_v2-6_refl_eqv`) fail at startup with:

`ValueError: batch_size=None option disables auto-batching and is mutually exclusive with drop_last`

The incomplete-batch policy is already handled by the dataset when `dataloader_batch_size` is `None`. This PR only passes `drop_last` to the `DataLoader` when it is responsible for auto-batching.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None. Builds on #61 (`dataloader_options`), already on `dev`.

## Tests

- `test/datapipes/test_data_modules_zarr_drop_last.py` — unit tests (no NFS): PyTorch constraint, dataset-level batching path, auto-batch path.
- Existing healpix zarr / coupled-zarr dataloader tests now assert `drop_last is False` when `dataloader_batch_size=None`.
