### PR TITLE
Fix UNetDecoder per_level_cln not applied at build time

### DIFF
--- a/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
+++ b/physicsnemo/models/dlwp_healpix_layers/healpix_decoder.py
@@ -119,7 +119,7 @@ class UNetDecoder(th.nn.Module):
                     block_config.conditional_layer_norm = None
 
             conv_module = instantiate(
-                config=conv_block,
+                config=block_config,
                 in_channels=curr_channel * 2
                 if n > 0
                 else curr_channel,  # Considering skip connection

--- a/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
+++ b/test/models/dlwp_healpix/test_healpix_encoder_decoder.py
@@ -411,3 +411,66 @@ def test_UNetDecoder_reset(device, pytestconfig):
 
     del decoder, outvar, invars
     torch.cuda.empty_cache()
+
+
+@import_or_fail("hydra")
+@pytest.mark.parametrize("device", ["cuda:0", "cpu"])
+def test_UNetDecoder_per_level_cln(device, pytestconfig):
+    """Decoder must honor per_level_cln when stripping CLN from conv_block config."""
+    from omegaconf import OmegaConf
+
+    from physicsnemo.models.dlwp_healpix_layers import UNetDecoder
+
+    n_channels = (64, 32, 16)
+    per_level_cln = [True, False, False]
+
+    conv_block = OmegaConf.create(
+        {
+            "_target_": "physicsnemo.models.dlwp_healpix_layers.healpix_blocks.Multi_SymmetricConvNeXtBlock",
+            "kernel_size": 3,
+            "dilation": 1,
+            "upscale_factor": 4,
+            "n_layers": 1,
+            "conditional_layer_norm": {
+                "_target_": "physicsnemo.models.dlwp_healpix_layers.normalization.ConditionalLayerNorm",
+                "_partial_": True,
+                "init_cln_to_zero": True,
+                "scale_center": 1.0,
+                "mlp_hidden_dims": [16, 16],
+                "condition_shape": 8,
+            },
+        }
+    )
+    up_sampling_block = OmegaConf.create(
+        {
+            "_target_": "physicsnemo.models.dlwp_healpix_layers.healpix_blocks.TransposedConvUpsample",
+            "upsampling": 2,
+        }
+    )
+    output_layer = OmegaConf.create(
+        {
+            "_target_": "physicsnemo.models.dlwp_healpix_layers.healpix_blocks.BasicConvBlock",
+            "kernel_size": 1,
+            "dilation": 1,
+            "n_layers": 1,
+        }
+    )
+
+    decoder = UNetDecoder(
+        conv_block=conv_block,
+        up_sampling_block=up_sampling_block,
+        output_layer=output_layer,
+        recurrent_block=None,
+        n_channels=n_channels,
+        per_level_cln=per_level_cln,
+    ).to(device)
+
+    for level_idx, expected_cln in enumerate(per_level_cln):
+        conv = decoder.decoder[level_idx]["conv"]
+        assert conv.cln_enabled is expected_cln, (
+            f"decoder level {level_idx}: expected cln_enabled={expected_cln}, "
+            f"got {conv.cln_enabled}"
+        )
+
+    del decoder
+    torch.cuda.empty_cache()


### PR DESCRIPTION
## Problem

`UNetDecoder` accepts `per_level_cln`, a per-level list of booleans that controls whether conditional layer norm (CLN) is active on each decoder stage. This is used to disable CLN on selected levels (e.g. only the deepest decoder block) while keeping it on others.

The decoder loop correctly builds a per-level `block_config` copy and nulls out `conditional_layer_norm` when `per_level_cln[n]` is `False`. However, it then calls `instantiate(config=conv_block, ...)` instead of `instantiate(config=block_config, ...)`, so the stripped config is never used. **Every decoder level ends up with CLN enabled whenever the base `conv_block` config includes CLN**, regardless of `per_level_cln`.

`UNetEncoder` already instantiates from `block_config` and honours `per_level_cln` correctly — this is a one-line decoder bug.

## What this PR does

- **`healpix_decoder.py`** — pass `block_config` (not `conv_block`) to `instantiate()` so per-level CLN stripping takes effect.
- **`test_healpix_encoder_decoder.py`** — add `test_UNetDecoder_per_level_cln` regression test that builds a decoder with `per_level_cln=[True, False, False]` and asserts `cln_enabled` on each level.

## Test plan
- [ ] `pytest test/models/dlwp_healpix/test_healpix_encoder_decoder.py::test_UNetDecoder_per_level_cln -v`
- [ ] Existing encoder/decoder tests still pass