### PR TITLE
Add ability to rescale through physical space in healpix coupler

### DIFF
--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -238,8 +238,10 @@ class BaseCoupler(ABC):
         self.time_first = time_first
         self.incoming_coupled_scaling = None
         self.outgoing_coupled_scaling = None
-        # Set by setup_coupling: source-module channel names for denorm lookups.
+        # Set by setup_coupling: source-module channel names for denorm lookups,
+        # and sink-side names in the same post-index order for renorm lookups.
         self.incoming_variables = None
+        self.outgoing_variable_order = None
 
         if not prepared_coupled_data:
             raise NotImplementedError("Data preparation not yet implemented")
@@ -330,8 +332,10 @@ class BaseCoupler(ABC):
 
         * **Incoming** (denorm): ``self.incoming_variables``, populated by
           :meth:`setup_coupling` from the coupled module's matched
-          ``output_variables``.
-        * **Outgoing** (renorm): ``self.variables`` duplicated once per
+          ``output_variables`` in the same order as
+          ``coupled_channel_indices`` (post-index channel order).
+        * **Outgoing** (renorm): ``self.outgoing_variable_order`` (sink names
+          paired to those same post-index channels) duplicated once per
           ``input_times`` entry, length ``self.output_channels`` (period-major).
 
         When set, ``set_coupled_fields`` denormalizes with incoming stats,
@@ -352,15 +356,16 @@ class BaseCoupler(ABC):
                 "Both incoming_coupled_scaling and outgoing_coupled_scaling "
                 "must be provided together (or omit set_coupled_scaling)."
             )
-        if self.incoming_variables is None:
+        if self.incoming_variables is None or self.outgoing_variable_order is None:
             raise RuntimeError(
                 "setup_coupling must be called before set_coupled_scaling "
-                "so incoming_variables are available from the coupled module."
+                "so incoming/outgoing variable order is available from the "
+                "coupled module."
             )
 
         incoming_variables = list(self.incoming_variables)
-        # Period-major: [v0, v1, ..., v0, v1, ...] across input_times.
-        outgoing_variables = list(self.variables) * len(self.input_times)
+        # Period-major, matching post-index channel order from setup_coupling.
+        outgoing_variables = list(self.outgoing_variable_order) * len(self.input_times)
         if len(outgoing_variables) != self.output_channels:
             raise RuntimeError(
                 "outgoing_variables length "
@@ -392,6 +397,18 @@ class BaseCoupler(ABC):
 
     # Backwards-compatible alias used briefly during the API rename.
     set_coupled_field_scaling = set_coupled_scaling
+
+    def _coupled_variable_for_source_channel(self, source_channel: str) -> str:
+        """Map a source ``output_variables`` name to the matching coupler variable."""
+        for v in self.variables:
+            if ("-" not in v and source_channel == v) or (
+                source_channel == "-".join(v.split("-")[:-1])
+            ):
+                return v
+        raise ValueError(
+            f"No coupler variable in {list(self.variables)} matches "
+            f"source channel {source_channel!r}"
+        )
 
     @staticmethod
     def _coupled_scaling_to_mean_std(scaling, keys: Sequence[str], name: str):
@@ -579,9 +596,16 @@ class BaseCoupler(ABC):
             missing_channels = set(self.variables) - set(found_channels)
             raise ValueError(f"Missing variables in coupled module: {missing_channels}")
         self.coupled_channel_indices = channel_indices
-        # Source-module channel names in the same order as coupled_channel_indices;
-        # used by set_coupled_scaling as incoming (denorm) keys.
+        # Channel names after ``coupled_fields[..., coupled_channel_indices, ...]``.
+        # Order follows the source module's output_variables (via the index list),
+        # which may differ from ``self.variables`` order.
         self.incoming_variables = [output_channels[i] for i in channel_indices]
+        # Sink-side names paired 1:1 with incoming_variables / post-index channels,
+        # so outgoing scaling stays aligned after set_coupled_fields indexing.
+        self.outgoing_variable_order = [
+            self._coupled_variable_for_source_channel(oc)
+            for oc in self.incoming_variables
+        ]
 
     def reset_coupler(self):
         self.coupled_mode = False
@@ -791,29 +815,29 @@ class ConstantCoupler(BaseCoupler):
         ]
 
         def _broadcast_first_time(fields: th.Tensor) -> th.Tensor:
-            # Keep layout [B, F, T, C, H, W]; expand T to coupled_integration_dim.
-            return fields[:, :, :1, :, :, :].expand(
-                -1, -1, self.coupled_integration_dim, -1, -1, -1
+            # Allocate a fresh buffer and copy time 0 into every integration
+            # step. Using expand() would share storage with ``fields``, so later
+            # mutations of the source tensor could silently change the preset.
+            out = th.empty(
+                [
+                    fields.shape[0],
+                    fields.shape[1],
+                    self.coupled_integration_dim,
+                    fields.shape[3],
+                    *fields.shape[4:],
+                ],
+                dtype=fields.dtype,
+                device=fields.device,
             )
+            out[:, :, :, :, :, :] = fields[:, :, :1, :, :, :]
+            return out
 
         if self.use_coupled_field_rescaling:
             self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
                 coupled_fields, _broadcast_first_time
             )
         else:
-            self.preset_coupled_fields = th.empty(
-                [
-                    coupled_fields.shape[0],
-                    self.spatial_dims[0],
-                    self.coupled_integration_dim,
-                    self.timevar_dim,
-                ]
-                + list(self.spatial_dims[1:])
-            )
-            # Broadcast the first time step across the coupled integration dim.
-            self.preset_coupled_fields[:, :, :, :, :, :] = coupled_fields[
-                :, :, :1, :, :, :
-            ]
+            self.preset_coupled_fields = _broadcast_first_time(coupled_fields)
 
         if self.time_first:
             self.preset_coupled_fields = self.preset_coupled_fields.permute(

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -57,8 +57,8 @@ Averaging in the wrong z-score space is an affine mismatch, not float noise::
     denorm_trailing( mean( norm_instant(x) ) )
         ≠  mean(x)     # bias on the order of tens of meters for z1000
 
-When ``set_coupled_scaling(incoming, outgoing)`` has been called,
-``set_coupled_fields`` instead works in physical units::
+When ``set_coupled_scaling(incoming)`` has been called (after ``set_scaling``
+and ``setup_coupling``), ``set_coupled_fields`` instead works in physical units::
 
     source (instant z-score)          sink (trailing z-score)
     ------------------------          -----------------------
@@ -92,9 +92,11 @@ Examples
 --------
 **1. Instant → trailing (typical atmos → ocean forcing)**
 
-Call :meth:`setup_coupling` first (stores the source module's matched
-``output_variables`` as incoming keys). Outgoing keys are ``self.variables``
-repeated once per ``input_times`` entry (length ``self.output_channels``)::
+``set_scaling`` (usually via CoupledDataset) installs sink-side stats as
+``coupled_scaling``. ``setup_coupling`` records source channel names.
+``set_coupled_scaling`` then only needs the *incoming* (source) scaling map;
+outgoing renorm stats are ``coupled_scaling`` duplicated across
+``input_times`` (length ``output_channels``)::
 
     from omegaconf import OmegaConf
 
@@ -108,23 +110,14 @@ repeated once per ``input_times`` entry (length ``self.output_channels``)::
         input_times=["48h", "96h"],
         averaging_window="48h",
     )
+    coupler.set_scaling(scaling_da)       # builds coupled_scaling from self.variables
     coupler.setup_coupling(atmos_module)  # saves incoming names, e.g. z1000, ws10m
-    coupler.set_coupled_scaling(scaling, scaling)
-    # incoming keys: atmos output_variables matched in setup_coupling
-    # outgoing keys: [z1000-48H, ws10m-48H, z1000-48H, ws10m-48H]
+    coupler.set_coupled_scaling(scaling)  # incoming denorm; outgoing from coupled_scaling
+    # outgoing keys (period-major): [z1000-48H, ws10m-48H, z1000-48H, ws10m-48H]
 
-**2. Same object as ``set_scaling`` (xarray ``scaling_da``)**
+**2. ConstantCoupler**
 
-The Dataset built inside CoupledDataset also works::
-
-    scaling_df = pd.DataFrame.from_dict(OmegaConf.to_object(scaling)).T
-    scaling_da = scaling_df.to_xarray().astype("float32")
-    coupler.setup_coupling(atmos_module)
-    coupler.set_coupled_scaling(scaling_da, scaling_da)
-
-**3. ConstantCoupler**
-
-Same method; the physical-space op broadcasts time 0 instead of averaging::
+Same pattern; the physical-space op broadcasts time 0 instead of averaging::
 
     coupler = ConstantCoupler(
         dataset=ds,
@@ -132,8 +125,9 @@ Same method; the physical-space op broadcasts time 0 instead of averaging::
         variables=["sst"],
         input_times=["0h"],
     )
+    coupler.set_scaling(scaling_da)
     coupler.setup_coupling(ocean_module)
-    coupler.set_coupled_scaling(scaling, scaling)
+    coupler.set_coupled_scaling(scaling)
 
 Related tests
 -------------
@@ -319,28 +313,21 @@ class BaseCoupler(ABC):
     def set_coupled_scaling(
         self,
         incoming_coupled_scaling: CoupledFieldScaling,
-        outgoing_coupled_scaling: CoupledFieldScaling,
     ):
         """Configure denorm/renorm stats used inside ``set_coupled_fields``.
 
-        Accepts the same variable-keyed format as ``configs/data/scaling/hpx64.yaml``
-        / ``cfg.data.scaling`` (and the xarray ``scaling_da`` built from it by
-        CoupledDataset), so callers can pass those objects with little or no
-        conversion.
+        Incoming stats come from ``incoming_coupled_scaling`` (hpx64.yaml /
+        ``cfg.data.scaling`` / xarray ``scaling_da``). Outgoing stats are taken
+        from ``self.coupled_scaling`` (set by :meth:`set_scaling`) and duplicated
+        once per ``input_times`` entry so the channel axis length is
+        ``self.output_channels``.
 
-        Variable keys are not passed explicitly:
+        Requires :meth:`set_scaling` and :meth:`setup_coupling` first:
 
-        * **Incoming** (denorm): ``self.incoming_variables``, populated by
-          :meth:`setup_coupling` from the coupled module's matched
-          ``output_variables`` in the same order as
-          ``coupled_channel_indices`` (post-index channel order).
-        * **Outgoing** (renorm): ``self.outgoing_variable_order`` (sink names
-          paired to those same post-index channels) duplicated once per
-          ``input_times`` entry, length ``self.output_channels`` (period-major).
-
-        When set, ``set_coupled_fields`` denormalizes with incoming stats,
-        performs its physical-space operation (broadcast or trailing average),
-        then renormalizes with outgoing stats.
+        * **Incoming** (denorm): keys from ``self.incoming_variables`` (source
+          ``output_variables`` in ``coupled_channel_indices`` order).
+        * **Outgoing** (renorm): ``self.coupled_scaling`` values for
+          ``self.outgoing_variable_order``, tiled across ``input_times``.
 
         Parameters
         ----------
@@ -348,13 +335,16 @@ class BaseCoupler(ABC):
             Variable-keyed scaling mapping ``{name: {"mean": ..., "std": ...}}``
             (YAML / OmegaConf / dict) or an xarray Dataset/DataArray with an
             ``index`` coordinate (same object passed to :meth:`set_scaling`).
-        outgoing_coupled_scaling:
-            Same format as ``incoming_coupled_scaling``.
         """
-        if incoming_coupled_scaling is None or outgoing_coupled_scaling is None:
+        if incoming_coupled_scaling is None:
             raise ValueError(
-                "Both incoming_coupled_scaling and outgoing_coupled_scaling "
-                "must be provided together (or omit set_coupled_scaling)."
+                "incoming_coupled_scaling must be provided "
+                "(or omit set_coupled_scaling for the legacy path)."
+            )
+        if self.coupled_scaling is None:
+            raise RuntimeError(
+                "set_scaling must be called before set_coupled_scaling "
+                "so coupled_scaling is available for outgoing renorm."
             )
         if self.incoming_variables is None or self.outgoing_variable_order is None:
             raise RuntimeError(
@@ -364,14 +354,6 @@ class BaseCoupler(ABC):
             )
 
         incoming_variables = list(self.incoming_variables)
-        # Period-major, matching post-index channel order from setup_coupling.
-        outgoing_variables = list(self.outgoing_variable_order) * len(self.input_times)
-        if len(outgoing_variables) != self.output_channels:
-            raise RuntimeError(
-                "outgoing_variables length "
-                f"{len(outgoing_variables)} != output_channels "
-                f"{self.output_channels}"
-            )
         if len(incoming_variables) != len(self.variables):
             raise ValueError(
                 "incoming_variables from setup_coupling must have length "
@@ -383,15 +365,37 @@ class BaseCoupler(ABC):
             incoming_variables,
             name="incoming_coupled_scaling",
         )
-        out_mean, out_std = self._coupled_scaling_to_mean_std(
-            outgoing_coupled_scaling,
-            outgoing_variables,
-            name="outgoing_coupled_scaling",
-        )
         self.incoming_coupled_scaling = self._mean_std_to_broadcast_tensors(
             in_mean, in_std, name="incoming_coupled_scaling"
         )
-        self.outgoing_coupled_scaling = self._mean_std_to_broadcast_tensors(
+        self.outgoing_coupled_scaling = self._outgoing_scaling_from_coupled_scaling()
+
+    def _outgoing_scaling_from_coupled_scaling(self) -> dict:
+        """Tile ``coupled_scaling`` across ``input_times`` in post-index order."""
+        cs_mean = np.asarray(self.coupled_scaling["mean"], dtype=np.float32).reshape(-1)
+        cs_std = np.asarray(self.coupled_scaling["std"], dtype=np.float32).reshape(-1)
+        if cs_mean.size != len(self.variables) or cs_std.size != len(self.variables):
+            raise RuntimeError(
+                "coupled_scaling channel count "
+                f"{cs_mean.size} does not match len(variables)={len(self.variables)}"
+            )
+        var_idx = {v: i for i, v in enumerate(self.variables)}
+        try:
+            order = [var_idx[v] for v in self.outgoing_variable_order]
+        except KeyError as exc:
+            raise KeyError(
+                "outgoing_variable_order entry not in self.variables: "
+                f"{exc}; variables={list(self.variables)}"
+            ) from exc
+        # Period-major: [v0, v1, ..., v0, v1, ...] across input_times.
+        out_mean = np.tile(cs_mean[order], len(self.input_times))
+        out_std = np.tile(cs_std[order], len(self.input_times))
+        if out_mean.size != self.output_channels:
+            raise RuntimeError(
+                "outgoing scaling length "
+                f"{out_mean.size} != output_channels {self.output_channels}"
+            )
+        return self._mean_std_to_broadcast_tensors(
             out_mean, out_std, name="outgoing_coupled_scaling"
         )
 
@@ -547,6 +551,11 @@ class BaseCoupler(ABC):
     ) -> th.Tensor:
         """Denormalize → apply ``physical_op`` in physical space → renormalize.
 
+        Physical values (e.g. geopotential) often exceed the range of low-precision
+        dtypes such as float16. The pipeline therefore promotes to float32 for
+        denorm / ``physical_op`` / renorm, then casts the result back to the
+        input dtype.
+
         Parameters
         ----------
         coupled_fields:
@@ -556,9 +565,12 @@ class BaseCoupler(ABC):
             must keep layout ``[B, F, T', C', H, W]`` where ``C'`` matches
             ``outgoing_coupled_scaling``.
         """
-        physical = self.denormalize_coupled_fields(coupled_fields)
+        orig_dtype = coupled_fields.dtype
+        fields_f32 = coupled_fields.to(dtype=th.float32)
+        physical = self.denormalize_coupled_fields(fields_f32)
         transformed = physical_op(physical)
-        return self.renormalize_coupled_fields(transformed)
+        renormalized = self.renormalize_coupled_fields(transformed)
+        return renormalized.to(dtype=orig_dtype)
 
     def setup_coupling(self, coupled_module):
         """

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -14,9 +14,139 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""HEALPix couplers for exchanging fields between Earth-system components.
+
+Overview
+--------
+A coupler takes prognostic outputs from one component (e.g. atmosphere) and
+prepares them as forcing for another (e.g. ocean). Two strategies are provided:
+
+* ``ConstantCoupler`` — broadcast the first available time step across the
+  coupled integration window.
+* ``TrailingAverageCoupler`` — average over trailing windows whose right edges
+  are given by ``input_times`` (e.g. 48 h and 96 h).
+
+Tensor layouts
+--------------
+``set_coupled_fields`` expects::
+
+    [B, F, T, C, H, W]
+
+With default ``time_first=True``, ``construct_integrated_couplings`` returns::
+
+    [I, B, timevar, F, H, W]
+
+where ``timevar = len(variables) * len(input_times)`` in **period-major** order::
+
+    [p0_v0, p0_v1, ..., p1_v0, p1_v1, ...]
+
+Example for ``variables=["z1000", "ws10m"]``, ``input_times=["48h", "96h"]``::
+
+    [z1000@48h, ws10m@48h, z1000@96h, ws10m@96h]
+
+Coupled-field scaling (denorm → operate → renorm)
+-------------------------------------------------
+During inference, coupled fields are usually already z-scored with the *source*
+component's instantaneous stats (e.g. ``z1000``, ``ws10m``). The *sink*
+component, however, often has trailing-window fields with different statistical
+distributions due to operations such as averaging (e.g. ``z1000-48H``, ``ws10-48H``).
+
+Averaging in the wrong z-score space is an affine mismatch, not float noise::
+
+    # Wrong: average already-normalized with instant μ/σ, then treat as trailing
+    denorm_trailing( mean( norm_instant(x) ) )
+        ≠  mean(x)     # bias on the order of tens of meters for z1000
+
+When ``set_coupled_scaling(incoming, outgoing)`` has been called,
+``set_coupled_fields`` instead works in physical units::
+
+    source (instant z-score)          sink (trailing z-score)
+    ------------------------          -----------------------
+    x_z = (x - μ_in) / σ_in
+              │
+              ▼
+        denorm with μ_in, σ_in   ──►  x_phys
+              │
+              ▼
+        ConstantCoupler: broadcast t=0
+        TrailingAverageCoupler: mean over windows
+              │
+              ▼
+        renorm with μ_out, σ_out ──►  y_z = (y_phys - μ_out) / σ_out
+
+ASCII flow for ``TrailingAverageCoupler``::
+
+    set_coupled_fields(x_z)          # [B, F, T, C, H, W], C = len(variables)
+            │
+            ├─► denormalize:  x_phys = x_z * σ_in + μ_in
+            │
+            ├─► trailing mean over each input_times window
+            │         └── concat period-major → [B, F, I, timevar, H, W]
+            │
+            └─► renormalize:  y_z = (x_avg - μ_out) / σ_out
+
+Omit both scalings to keep the legacy path (operate directly in whatever space
+the caller already provided).
+
+Examples
+--------
+**1. Instant → trailing (typical atmos → ocean forcing)**
+
+Call :meth:`setup_coupling` first (stores the source module's matched
+``output_variables`` as incoming keys). Outgoing keys are ``self.variables``
+repeated once per ``input_times`` entry (length ``self.output_channels``)::
+
+    from omegaconf import OmegaConf
+
+    scaling = OmegaConf.load("configs/data/scaling/hpx64.yaml")
+    # or: scaling = cfg.data.scaling
+
+    coupler = TrailingAverageCoupler(
+        dataset=ocean_ds,
+        batch_size=1,
+        variables=["z1000-48H", "ws10m-48H"],
+        input_times=["48h", "96h"],
+        averaging_window="48h",
+    )
+    coupler.setup_coupling(atmos_module)  # saves incoming names, e.g. z1000, ws10m
+    coupler.set_coupled_scaling(scaling, scaling)
+    # incoming keys: atmos output_variables matched in setup_coupling
+    # outgoing keys: [z1000-48H, ws10m-48H, z1000-48H, ws10m-48H]
+
+**2. Same object as ``set_scaling`` (xarray ``scaling_da``)**
+
+The Dataset built inside CoupledDataset also works::
+
+    scaling_df = pd.DataFrame.from_dict(OmegaConf.to_object(scaling)).T
+    scaling_da = scaling_df.to_xarray().astype("float32")
+    coupler.setup_coupling(atmos_module)
+    coupler.set_coupled_scaling(scaling_da, scaling_da)
+
+**3. ConstantCoupler**
+
+Same method; the physical-space op broadcasts time 0 instead of averaging::
+
+    coupler = ConstantCoupler(
+        dataset=ds,
+        batch_size=1,
+        variables=["sst"],
+        input_times=["0h"],
+    )
+    coupler.setup_coupling(ocean_module)
+    coupler.set_coupled_scaling(scaling, scaling)
+
+Related tests
+-------------
+* ``test_healpix_coupler_coupled_field_scaling.py`` — API, recovery of physical
+  trailing means, adversarial edge cases.
+* ``test_healpix_coupler_instant_vs_trailing_scaling.py`` — quantifies the
+  mismatch when averaging in the wrong z-score space.
+* ``test_healpix_coupler_znorm_stability.py`` — matched-stats float32 stability.
+"""
+
 import logging
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Mapping, Optional, Sequence, Union
 
 import cftime
 import numpy as np
@@ -26,6 +156,10 @@ import xarray as xr
 import zarr as zr
 
 logger = logging.getLogger(__name__)
+
+# Variable-keyed scaling (hpx64.yaml / cfg.data.scaling), OmegaConf, or
+# the xarray Dataset produced by ``pd.DataFrame.from_dict(scaling).T.to_xarray()``.
+CoupledFieldScaling = Union[Mapping, xr.Dataset, xr.DataArray, None]
 
 
 class BaseCoupler(ABC):
@@ -77,6 +211,11 @@ class BaseCoupler(ABC):
         time_first: boolean, optional
             Whether the coupled data should be permuted to have the time dimension first 
             [T, B, C, F, H, W] rather than [B, F, T, C, H, W]
+
+        Notes
+        -----
+        Optional denorm/renorm stats for ``set_coupled_fields`` are configured
+        separately via :meth:`set_coupled_scaling`.
         """
         # extract important meta data from ds
         self.ds = dataset
@@ -97,6 +236,10 @@ class BaseCoupler(ABC):
         self.integrated_couplings = None
         self.ds_variable_indices = []
         self.time_first = time_first
+        self.incoming_coupled_scaling = None
+        self.outgoing_coupled_scaling = None
+        # Set by setup_coupling: source-module channel names for denorm lookups.
+        self.incoming_variables = None
 
         if not prepared_coupled_data:
             raise NotImplementedError("Data preparation not yet implemented")
@@ -171,6 +314,235 @@ class BaseCoupler(ABC):
             "std": np.expand_dims(coupled_scaling["std"].to_numpy(), (0, 2, 3, 4)),
         }
 
+    def set_coupled_scaling(
+        self,
+        incoming_coupled_scaling: CoupledFieldScaling,
+        outgoing_coupled_scaling: CoupledFieldScaling,
+    ):
+        """Configure denorm/renorm stats used inside ``set_coupled_fields``.
+
+        Accepts the same variable-keyed format as ``configs/data/scaling/hpx64.yaml``
+        / ``cfg.data.scaling`` (and the xarray ``scaling_da`` built from it by
+        CoupledDataset), so callers can pass those objects with little or no
+        conversion.
+
+        Variable keys are not passed explicitly:
+
+        * **Incoming** (denorm): ``self.incoming_variables``, populated by
+          :meth:`setup_coupling` from the coupled module's matched
+          ``output_variables``.
+        * **Outgoing** (renorm): ``self.variables`` duplicated once per
+          ``input_times`` entry, length ``self.output_channels`` (period-major).
+
+        When set, ``set_coupled_fields`` denormalizes with incoming stats,
+        performs its physical-space operation (broadcast or trailing average),
+        then renormalizes with outgoing stats.
+
+        Parameters
+        ----------
+        incoming_coupled_scaling:
+            Variable-keyed scaling mapping ``{name: {"mean": ..., "std": ...}}``
+            (YAML / OmegaConf / dict) or an xarray Dataset/DataArray with an
+            ``index`` coordinate (same object passed to :meth:`set_scaling`).
+        outgoing_coupled_scaling:
+            Same format as ``incoming_coupled_scaling``.
+        """
+        if incoming_coupled_scaling is None or outgoing_coupled_scaling is None:
+            raise ValueError(
+                "Both incoming_coupled_scaling and outgoing_coupled_scaling "
+                "must be provided together (or omit set_coupled_scaling)."
+            )
+        if self.incoming_variables is None:
+            raise RuntimeError(
+                "setup_coupling must be called before set_coupled_scaling "
+                "so incoming_variables are available from the coupled module."
+            )
+
+        incoming_variables = list(self.incoming_variables)
+        # Period-major: [v0, v1, ..., v0, v1, ...] across input_times.
+        outgoing_variables = list(self.variables) * len(self.input_times)
+        if len(outgoing_variables) != self.output_channels:
+            raise RuntimeError(
+                "outgoing_variables length "
+                f"{len(outgoing_variables)} != output_channels "
+                f"{self.output_channels}"
+            )
+        if len(incoming_variables) != len(self.variables):
+            raise ValueError(
+                "incoming_variables from setup_coupling must have length "
+                f"{len(self.variables)}; got {len(incoming_variables)}"
+            )
+
+        in_mean, in_std = self._coupled_scaling_to_mean_std(
+            incoming_coupled_scaling,
+            incoming_variables,
+            name="incoming_coupled_scaling",
+        )
+        out_mean, out_std = self._coupled_scaling_to_mean_std(
+            outgoing_coupled_scaling,
+            outgoing_variables,
+            name="outgoing_coupled_scaling",
+        )
+        self.incoming_coupled_scaling = self._mean_std_to_broadcast_tensors(
+            in_mean, in_std, name="incoming_coupled_scaling"
+        )
+        self.outgoing_coupled_scaling = self._mean_std_to_broadcast_tensors(
+            out_mean, out_std, name="outgoing_coupled_scaling"
+        )
+
+    # Backwards-compatible alias used briefly during the API rename.
+    set_coupled_field_scaling = set_coupled_scaling
+
+    @staticmethod
+    def _coupled_scaling_to_mean_std(scaling, keys: Sequence[str], name: str):
+        """Extract ordered mean/std arrays from YAML-style or scaling_da input."""
+        try:
+            from omegaconf import OmegaConf, DictConfig, ListConfig
+
+            if isinstance(scaling, (DictConfig, ListConfig)) or (
+                hasattr(OmegaConf, "is_config") and OmegaConf.is_config(scaling)
+            ):
+                scaling = OmegaConf.to_object(scaling)
+        except ImportError:
+            pass
+
+        if isinstance(scaling, (xr.Dataset, xr.DataArray)):
+            if "index" not in scaling.coords and "index" not in getattr(
+                scaling, "dims", ()
+            ):
+                # DataFrame.to_xarray() uses the frame index as a dimension named
+                # after the index; CoupledDataset always renames via .sel(index=...).
+                index_name = scaling.dims[0] if scaling.dims else None
+                if index_name is None:
+                    raise TypeError(
+                        f"{name}: xarray scaling object has no index coordinate"
+                    )
+                scaling = scaling.rename({index_name: "index"})
+            available = set(np.asarray(scaling["index"].values).tolist())
+            missing = [k for k in keys if k not in available]
+            if missing:
+                raise KeyError(
+                    f"{name} missing variables {missing}; "
+                    f"available={sorted(available)}"
+                )
+            selected = scaling.sel(index=list(keys))
+            mean = np.asarray(selected["mean"].to_numpy(), dtype=np.float32).reshape(-1)
+            std = np.asarray(selected["std"].to_numpy(), dtype=np.float32).reshape(-1)
+            return mean, std
+
+        if not isinstance(scaling, Mapping):
+            raise TypeError(
+                f"{name} must be a variable-keyed scaling mapping "
+                f"(hpx64.yaml / cfg.data.scaling) or an xarray scaling_da; "
+                f"got {type(scaling)}"
+            )
+
+        # Reject the old flat {"mean": [...], "std": [...]} form with a clear error.
+        if (
+            "mean" in scaling
+            and "std" in scaling
+            and not isinstance(scaling.get("mean"), Mapping)
+        ):
+            sample_vals = [
+                v for v in scaling.values() if isinstance(v, Mapping) and "mean" in v
+            ]
+            if not sample_vals:
+                raise TypeError(
+                    f"{name} must be variable-keyed like hpx64.yaml "
+                    f"(e.g. {{'z1000': {{'mean': ..., 'std': ...}}, ...}}) "
+                    f"or an xarray scaling_da; flat mean/std arrays are not supported."
+                )
+
+        missing = [k for k in keys if k not in scaling]
+        if missing:
+            raise KeyError(
+                f"{name} missing variables {missing}; "
+                f"available={sorted(scaling.keys())}"
+            )
+        try:
+            mean = np.asarray(
+                [scaling[k]["mean"] for k in keys], dtype=np.float32
+            ).reshape(-1)
+            std = np.asarray(
+                [scaling[k]["std"] for k in keys], dtype=np.float32
+            ).reshape(-1)
+        except (KeyError, TypeError) as exc:
+            raise TypeError(
+                f"{name} entries must be mappings with 'mean' and 'std' "
+                f"(hpx64.yaml style); error on keys {list(keys)}: {exc}"
+            ) from exc
+        return mean, std
+
+    @staticmethod
+    def _mean_std_to_broadcast_tensors(mean, std, name: str) -> dict:
+        if mean.size != std.size:
+            raise ValueError(
+                f"{name} mean and std lengths differ: {mean.size} vs {std.size}"
+            )
+        if np.any(std == 0):
+            raise ValueError(f"{name} std must be non-zero for all channels")
+        # Broadcast over [B, F, T, C, H, W]
+        return {
+            "mean": th.as_tensor(mean).view(1, 1, 1, -1, 1, 1),
+            "std": th.as_tensor(std).view(1, 1, 1, -1, 1, 1),
+        }
+
+    @property
+    def use_coupled_field_rescaling(self) -> bool:
+        return (
+            self.incoming_coupled_scaling is not None
+            and self.outgoing_coupled_scaling is not None
+        )
+
+    def denormalize_coupled_fields(self, coupled_fields: th.Tensor) -> th.Tensor:
+        """Undo incoming z-score: ``x * std_in + mean_in``."""
+        if self.incoming_coupled_scaling is None:
+            raise RuntimeError("incoming_coupled_scaling has not been set")
+        mean = self.incoming_coupled_scaling["mean"].to(
+            device=coupled_fields.device, dtype=coupled_fields.dtype
+        )
+        std = self.incoming_coupled_scaling["std"].to(
+            device=coupled_fields.device, dtype=coupled_fields.dtype
+        )
+        return coupled_fields * std + mean
+
+    def renormalize_coupled_fields(self, coupled_fields: th.Tensor) -> th.Tensor:
+        """Apply outgoing z-score: ``(x - mean_out) / std_out``."""
+        if self.outgoing_coupled_scaling is None:
+            raise RuntimeError("outgoing_coupled_scaling has not been set")
+        mean = self.outgoing_coupled_scaling["mean"].to(
+            device=coupled_fields.device, dtype=coupled_fields.dtype
+        )
+        std = self.outgoing_coupled_scaling["std"].to(
+            device=coupled_fields.device, dtype=coupled_fields.dtype
+        )
+        # Outgoing tensors may be [B, F, T, C, H, W] with C == timevar_dim.
+        if mean.shape[3] != coupled_fields.shape[3]:
+            raise ValueError(
+                "outgoing_coupled_scaling channel count "
+                f"{mean.shape[3]} does not match field channels "
+                f"{coupled_fields.shape[3]}"
+            )
+        return (coupled_fields - mean) / std
+
+    def rescale_coupled_fields_through_physical(
+        self, coupled_fields: th.Tensor, physical_op
+    ) -> th.Tensor:
+        """Denormalize → apply ``physical_op`` in physical space → renormalize.
+
+        Parameters
+        ----------
+        coupled_fields:
+            Incoming fields already channel-selected, layout ``[B, F, T, C, H, W]``.
+        physical_op:
+            Callable ``(Tensor) -> Tensor`` operating in physical units. Output
+            must keep layout ``[B, F, T', C', H, W]`` where ``C'`` matches
+            ``outgoing_coupled_scaling``.
+        """
+        physical = self.denormalize_coupled_fields(coupled_fields)
+        transformed = physical_op(physical)
+        return self.renormalize_coupled_fields(transformed)
+
     def setup_coupling(self, coupled_module):
         """
         Sets up the coupling between the coupled variables and the provided module
@@ -207,6 +579,9 @@ class BaseCoupler(ABC):
             missing_channels = set(self.variables) - set(found_channels)
             raise ValueError(f"Missing variables in coupled module: {missing_channels}")
         self.coupled_channel_indices = channel_indices
+        # Source-module channel names in the same order as coupled_channel_indices;
+        # used by set_coupled_scaling as incoming (denorm) keys.
+        self.incoming_variables = [output_channels[i] for i in channel_indices]
 
     def reset_coupler(self):
         self.coupled_mode = False
@@ -334,6 +709,7 @@ class ConstantCoupler(BaseCoupler):
         output_time_dim: int = 2,
         input_times: Sequence = [pd.Timedelta("24h"), pd.Timedelta("48h")],
         prepared_coupled_data=True,
+        **kwargs,
     ):
         """
         Parameters
@@ -371,6 +747,7 @@ class ConstantCoupler(BaseCoupler):
             output_time_dim=output_time_dim,
             input_times=input_times,
             prepared_coupled_data=prepared_coupled_data,
+            **kwargs,
         )
 
     def compute_coupled_indices(self, interval, data_time_step):
@@ -409,20 +786,39 @@ class ConstantCoupler(BaseCoupler):
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        # create buffer for coupling
         coupled_fields = coupled_fields[
             :, :, :, self.coupled_channel_indices, :, :
-        ] 
-        self.preset_coupled_fields = th.empty(
-            [coupled_fields.shape[0], self.spatial_dims[0], self.coupled_integration_dim, self.timevar_dim]
-            + list(self.spatial_dims[1:])
-        )
-        # we use a constant set of values so we just copy time 0
+        ]
 
-        # broadcast the first time step to the entire coupled integration dimension
-        self.preset_coupled_fields[:, :, :, :, :, :] = coupled_fields[:, :, :1, :, :, :]
+        def _broadcast_first_time(fields: th.Tensor) -> th.Tensor:
+            # Keep layout [B, F, T, C, H, W]; expand T to coupled_integration_dim.
+            return fields[:, :, :1, :, :, :].expand(
+                -1, -1, self.coupled_integration_dim, -1, -1, -1
+            )
+
+        if self.use_coupled_field_rescaling:
+            self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
+                coupled_fields, _broadcast_first_time
+            )
+        else:
+            self.preset_coupled_fields = th.empty(
+                [
+                    coupled_fields.shape[0],
+                    self.spatial_dims[0],
+                    self.coupled_integration_dim,
+                    self.timevar_dim,
+                ]
+                + list(self.spatial_dims[1:])
+            )
+            # Broadcast the first time step across the coupled integration dim.
+            self.preset_coupled_fields[:, :, :, :, :, :] = coupled_fields[
+                :, :, :1, :, :, :
+            ]
+
         if self.time_first:
-            self.preset_coupled_fields = self.preset_coupled_fields.permute(2, 0, 3, 1, 4, 5)
+            self.preset_coupled_fields = self.preset_coupled_fields.permute(
+                2, 0, 3, 1, 4, 5
+            )
         # flag for construct integrated coupling method to use this array
         self.coupled_mode = True
 
@@ -446,6 +842,7 @@ class TrailingAverageCoupler(BaseCoupler):
         averaging_window: str = "24h",
         input_times: Sequence = [pd.Timedelta("24h"), pd.Timedelta("48h")],
         prepared_coupled_data=True,
+        **kwargs,
     ):
         """
         Parameters
@@ -485,6 +882,7 @@ class TrailingAverageCoupler(BaseCoupler):
             output_time_dim=output_time_dim,
             input_times=input_times,
             prepared_coupled_data=prepared_coupled_data,
+            **kwargs,
         )
 
         # TrailingAverageCoupler-specific attributes
@@ -568,6 +966,9 @@ class TrailingAverageCoupler(BaseCoupler):
         Instead of loading data from the dataset the data from coupled_fields will
         be returned instead.
 
+        When :meth:`set_coupled_scaling` has been called, fields are
+        denormalized, averaged in physical space, then renormalized.
+
         Parameters
         ----------
         coupled_fields: th.tensor
@@ -575,18 +976,29 @@ class TrailingAverageCoupler(BaseCoupler):
             format is [B, F, T, C, H, W]
         """
         coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
-        # TODO: Now support output_time_dim =/= input_time_dim, but presteps need to be 0, will add support for presteps>0
-        coupled_averaging_periods = []
-        for j in range(self.coupled_integration_dim):
-            averaging_periods = [
-                coupled_fields[:, :, s, :, :, :].mean(dim=2, keepdim=True)
-                for s in self.averaging_slices[j]
-            ]
-            coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
-        self.preset_coupled_fields = th.concat(
-            coupled_averaging_periods, dim=2
-        )
+
+        def _trailing_average(fields: th.Tensor) -> th.Tensor:
+            # TODO: Now support output_time_dim =/= input_time_dim, but presteps
+            # need to be 0, will add support for presteps>0
+            coupled_averaging_periods = []
+            for j in range(self.coupled_integration_dim):
+                averaging_periods = [
+                    fields[:, :, s, :, :, :].mean(dim=2, keepdim=True)
+                    for s in self.averaging_slices[j]
+                ]
+                coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
+            return th.concat(coupled_averaging_periods, dim=2)
+
+        if self.use_coupled_field_rescaling:
+            self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
+                coupled_fields, _trailing_average
+            )
+        else:
+            self.preset_coupled_fields = _trailing_average(coupled_fields)
+
         if self.time_first:
-            self.preset_coupled_fields = self.preset_coupled_fields.permute(2, 0, 3, 1, 4, 5)
+            self.preset_coupled_fields = self.preset_coupled_fields.permute(
+                2, 0, 3, 1, 4, 5
+            )
         # flag for construct integrated coupling method to use this array
         self.coupled_mode = True

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -220,20 +220,30 @@ class BaseCoupler(ABC):
         """
         if self.coupled_scaling is None or self.incoming_variables is None:
             raise RuntimeError(
-                "set_scaling must be called before set_coupled_scaling "
-                "so coupled_scaling is available for outgoing renorm."
+                "set_scaling and setup_coupling must be called before "
+                "set_coupled_scaling."
             )
-        self.incoming_coupled_scaling = self._broadcast_stats(
+        self.incoming_coupled_scaling = self._prepare_incoming_coupled_scaling(
+            incoming_coupled_scaling
+        )
+        self.outgoing_coupled_scaling = self._prepare_outgoing_coupled_scaling()
+
+    def _prepare_incoming_coupled_scaling(self, incoming_coupled_scaling):
+        """Parse incoming stats and broadcast to [B, F, T, C, H, W]."""
+        return self._broadcast_stats(
             *self._coupled_scaling_to_mean_std(
                 incoming_coupled_scaling, self.incoming_variables
             )
         )
+
+    def _prepare_outgoing_coupled_scaling(self):
+        """Reorder ``coupled_scaling`` to post-index order and tile across input times."""
         var_idx = {v: i for i, v in enumerate(self.variables)}
         order = [var_idx[v] for v in self.outgoing_variable_order]
         cs_mean = np.asarray(self.coupled_scaling["mean"], dtype=np.float32).ravel()
         cs_std = np.asarray(self.coupled_scaling["std"], dtype=np.float32).ravel()
         n = len(self.input_times)
-        self.outgoing_coupled_scaling = self._broadcast_stats(
+        return self._broadcast_stats(
             np.tile(cs_mean[order], n), np.tile(cs_std[order], n)
         )
 
@@ -263,23 +273,55 @@ class BaseCoupler(ABC):
         }
 
     @staticmethod
-    def _apply_scaling(x: th.Tensor, scaling: dict, *, denorm: bool) -> th.Tensor:
+    def _denormalize(x: th.Tensor, scaling: dict) -> th.Tensor:
         mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
         std = scaling["std"].to(device=x.device, dtype=x.dtype)
-        return x * std + mean if denorm else (x - mean) / std
+        return x * std + mean
+
+    @staticmethod
+    def _renormalize(x: th.Tensor, scaling: dict) -> th.Tensor:
+        mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
+        std = scaling["std"].to(device=x.device, dtype=x.dtype)
+        return (x - mean) / std
 
     def rescale_coupled_fields_through_physical(
         self, coupled_fields: th.Tensor, physical_op
     ) -> th.Tensor:
-        """Denorm → ``physical_op`` → renorm in float32; restore input dtype."""
+        """
+        Rescale coupled fields through physical space.
+        Fields may overflow when denormalized, so we run in float32 mid-flight.
+        float32 → Denorm → ``physical_op`` → renorm → restore input dtype.
+
+        Parameters
+        ----------
+        coupled_fields: th.Tensor
+            The coupled fields to rescale.
+        physical_op: callable
+            The physical operation to apply to the coupled fields.
+        """
         orig_dtype = coupled_fields.dtype
-        x = coupled_fields.to(dtype=th.float32)
-        physical = physical_op(
-            self._apply_scaling(x, self.incoming_coupled_scaling, denorm=True)
+        physical_fields = self._denormalize(
+            coupled_fields.float(), self.incoming_coupled_scaling
         )
-        return self._apply_scaling(
-            physical, self.outgoing_coupled_scaling, denorm=False
-        ).to(dtype=orig_dtype)
+        transformed_fields = physical_op(physical_fields)
+        normalized_fields = self._renormalize(
+            transformed_fields, self.outgoing_coupled_scaling
+        )
+        return normalized_fields.to(dtype=orig_dtype)
+
+    def _store_preset_coupled_fields(self, coupled_fields: th.Tensor, physical_op):
+        """Index channels, optionally rescale through physical space, then store."""
+        coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
+        if self.incoming_coupled_scaling is not None:
+            preset = self.rescale_coupled_fields_through_physical(
+                coupled_fields, physical_op
+            )
+        else:
+            preset = physical_op(coupled_fields)
+        if self.time_first:
+            preset = preset.permute(2, 0, 3, 1, 4, 5)
+        self.preset_coupled_fields = preset
+        self.coupled_mode = True
 
     def setup_coupling(self, coupled_module):
         """
@@ -312,15 +354,7 @@ class BaseCoupler(ABC):
                     outgoing_variable_order.append(v)
                     break
         if len(self.variables) != len(channel_indices):
-            found = set(incoming_variables)
-            missing_channels = {
-                v
-                for v in self.variables
-                if not (
-                    (v in found)
-                    or (("-" in v) and ("-".join(v.split("-")[:-1]) in found))
-                )
-            }
+            missing_channels = set(self.variables) - set(outgoing_variable_order)
             raise ValueError(f"Missing variables in coupled module: {missing_channels}")
         self.coupled_channel_indices = channel_indices
         self.incoming_variables = incoming_variables
@@ -529,9 +563,6 @@ class ConstantCoupler(BaseCoupler):
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        coupled_fields = coupled_fields[
-            :, :, :, self.coupled_channel_indices, :, :
-        ]
 
         def _broadcast_first_time(fields: th.Tensor) -> th.Tensor:
             # Clone so later mutations of coupled_fields cannot alter presets.
@@ -541,19 +572,7 @@ class ConstantCoupler(BaseCoupler):
                 .clone()
             )
 
-        if self.incoming_coupled_scaling is not None:
-            self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
-                coupled_fields, _broadcast_first_time
-            )
-        else:
-            self.preset_coupled_fields = _broadcast_first_time(coupled_fields)
-
-        if self.time_first:
-            self.preset_coupled_fields = self.preset_coupled_fields.permute(
-                2, 0, 3, 1, 4, 5
-            )
-        # flag for construct integrated coupling method to use this array
-        self.coupled_mode = True
+        self._store_preset_coupled_fields(coupled_fields, _broadcast_first_time)
 
 
 class TrailingAverageCoupler(BaseCoupler):
@@ -708,7 +727,6 @@ class TrailingAverageCoupler(BaseCoupler):
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-        coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
 
         def _trailing_average(fields: th.Tensor) -> th.Tensor:
             # TODO: Now support output_time_dim =/= input_time_dim, but presteps
@@ -722,16 +740,4 @@ class TrailingAverageCoupler(BaseCoupler):
                 coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
             return th.concat(coupled_averaging_periods, dim=2)
 
-        if self.incoming_coupled_scaling is not None:
-            self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
-                coupled_fields, _trailing_average
-            )
-        else:
-            self.preset_coupled_fields = _trailing_average(coupled_fields)
-
-        if self.time_first:
-            self.preset_coupled_fields = self.preset_coupled_fields.permute(
-                2, 0, 3, 1, 4, 5
-            )
-        # flag for construct integrated coupling method to use this array
-        self.coupled_mode = True
+        self._store_preset_coupled_fields(coupled_fields, _trailing_average)

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -44,103 +44,13 @@ Example for ``variables=["z1000", "ws10m"]``, ``input_times=["48h", "96h"]``::
 
     [z1000@48h, ws10m@48h, z1000@96h, ws10m@96h]
 
-Coupled-field scaling (denorm → operate → renorm)
--------------------------------------------------
-During inference, coupled fields are usually already z-scored with the *source*
-component's instantaneous stats (e.g. ``z1000``, ``ws10m``). The *sink*
-component, however, often has trailing-window fields with different statistical
-distributions due to operations such as averaging (e.g. ``z1000-48H``, ``ws10-48H``).
-
-Averaging in the wrong z-score space is an affine mismatch, not float noise::
-
-    # Wrong: average already-normalized with instant μ/σ, then treat as trailing
-    denorm_trailing( mean( norm_instant(x) ) )
-        ≠  mean(x)     # bias on the order of tens of meters for z1000
-
-When ``set_coupled_scaling(incoming)`` has been called (after ``set_scaling``
-and ``setup_coupling``), ``set_coupled_fields`` instead works in physical units::
-
-    source (instant z-score)          sink (trailing z-score)
-    ------------------------          -----------------------
-    x_z = (x - μ_in) / σ_in
-              │
-              ▼
-        denorm with μ_in, σ_in   ──►  x_phys
-              │
-              ▼
-        ConstantCoupler: broadcast t=0
-        TrailingAverageCoupler: mean over windows
-              │
-              ▼
-        renorm with μ_out, σ_out ──►  y_z = (y_phys - μ_out) / σ_out
-
-ASCII flow for ``TrailingAverageCoupler``::
-
-    set_coupled_fields(x_z)          # [B, F, T, C, H, W], C = len(variables)
-            │
-            ├─► denormalize:  x_phys = x_z * σ_in + μ_in
-            │
-            ├─► trailing mean over each input_times window
-            │         └── concat period-major → [B, F, I, timevar, H, W]
-            │
-            └─► renormalize:  y_z = (x_avg - μ_out) / σ_out
-
-Omit both scalings to keep the legacy path (operate directly in whatever space
-the caller already provided).
-
-Examples
---------
-**1. Instant → trailing (typical atmos → ocean forcing)**
-
-``set_scaling`` (usually via CoupledDataset) installs sink-side stats as
-``coupled_scaling``. ``setup_coupling`` records source channel names.
-``set_coupled_scaling`` then only needs the *incoming* (source) scaling map;
-outgoing renorm stats are ``coupled_scaling`` duplicated across
-``input_times`` (length ``output_channels``)::
-
-    from omegaconf import OmegaConf
-
-    scaling = OmegaConf.load("configs/data/scaling/hpx64.yaml")
-    # or: scaling = cfg.data.scaling
-
-    coupler = TrailingAverageCoupler(
-        dataset=ocean_ds,
-        batch_size=1,
-        variables=["z1000-48H", "ws10m-48H"],
-        input_times=["48h", "96h"],
-        averaging_window="48h",
-    )
-    coupler.set_scaling(scaling_da)       # builds coupled_scaling from self.variables
-    coupler.setup_coupling(atmos_module)  # saves incoming names, e.g. z1000, ws10m
-    coupler.set_coupled_scaling(scaling)  # incoming denorm; outgoing from coupled_scaling
-    # outgoing keys (period-major): [z1000-48H, ws10m-48H, z1000-48H, ws10m-48H]
-
-**2. ConstantCoupler**
-
-Same pattern; the physical-space op broadcasts time 0 instead of averaging::
-
-    coupler = ConstantCoupler(
-        dataset=ds,
-        batch_size=1,
-        variables=["sst"],
-        input_times=["0h"],
-    )
-    coupler.set_scaling(scaling_da)
-    coupler.setup_coupling(ocean_module)
-    coupler.set_coupled_scaling(scaling)
-
-Related tests
--------------
-* ``test_healpix_coupler_coupled_field_scaling.py`` — API, recovery of physical
-  trailing means, adversarial edge cases.
-* ``test_healpix_coupler_instant_vs_trailing_scaling.py`` — quantifies the
-  mismatch when averaging in the wrong z-score space.
-* ``test_healpix_coupler_znorm_stability.py`` — matched-stats float32 stability.
+Call ``set_coupled_scaling(incoming)`` after ``set_scaling`` / ``setup_coupling``
+to denorm→operate→renorm (float32 mid-flight); omit it for the legacy path.
 """
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Sequence, Union
+from typing import Sequence
 
 import cftime
 import numpy as np
@@ -150,10 +60,6 @@ import xarray as xr
 import zarr as zr
 
 logger = logging.getLogger(__name__)
-
-# Variable-keyed scaling (hpx64.yaml / cfg.data.scaling), OmegaConf, or
-# the xarray Dataset produced by ``pd.DataFrame.from_dict(scaling).T.to_xarray()``.
-CoupledFieldScaling = Union[Mapping, xr.Dataset, xr.DataArray, None]
 
 
 class BaseCoupler(ABC):
@@ -205,11 +111,6 @@ class BaseCoupler(ABC):
         time_first: boolean, optional
             Whether the coupled data should be permuted to have the time dimension first 
             [T, B, C, F, H, W] rather than [B, F, T, C, H, W]
-
-        Notes
-        -----
-        Optional denorm/renorm stats for ``set_coupled_fields`` are configured
-        separately via :meth:`set_coupled_scaling`.
         """
         # extract important meta data from ds
         self.ds = dataset
@@ -310,267 +211,75 @@ class BaseCoupler(ABC):
             "std": np.expand_dims(coupled_scaling["std"].to_numpy(), (0, 2, 3, 4)),
         }
 
-    def set_coupled_scaling(
-        self,
-        incoming_coupled_scaling: CoupledFieldScaling,
-    ):
-        """Configure denorm/renorm stats used inside ``set_coupled_fields``.
+    def set_coupled_scaling(self, incoming_coupled_scaling):
+        """Set incoming denorm stats; outgoing renorm uses ``coupled_scaling`` tiled.
 
-        Incoming stats come from ``incoming_coupled_scaling`` (hpx64.yaml /
-        ``cfg.data.scaling`` / xarray ``scaling_da``). Outgoing stats are taken
-        from ``self.coupled_scaling`` (set by :meth:`set_scaling`) and duplicated
-        once per ``input_times`` entry so the channel axis length is
-        ``self.output_channels``.
-
-        Requires :meth:`set_scaling` and :meth:`setup_coupling` first:
-
-        * **Incoming** (denorm): keys from ``self.incoming_variables`` (source
-          ``output_variables`` in ``coupled_channel_indices`` order).
-        * **Outgoing** (renorm): ``self.coupled_scaling`` values for
-          ``self.outgoing_variable_order``, tiled across ``input_times``.
-
-        Parameters
-        ----------
-        incoming_coupled_scaling:
-            Variable-keyed scaling mapping ``{name: {"mean": ..., "std": ...}}``
-            (YAML / OmegaConf / dict) or an xarray Dataset/DataArray with an
-            ``index`` coordinate (same object passed to :meth:`set_scaling`).
+        Requires :meth:`set_scaling` and :meth:`setup_coupling`. Incoming keys
+        follow ``incoming_variables``; outgoing is reordered to
+        ``outgoing_variable_order`` and tiled across ``input_times``.
         """
-        if incoming_coupled_scaling is None:
-            raise ValueError(
-                "incoming_coupled_scaling must be provided "
-                "(or omit set_coupled_scaling for the legacy path)."
-            )
-        if self.coupled_scaling is None:
+        if self.coupled_scaling is None or self.incoming_variables is None:
             raise RuntimeError(
                 "set_scaling must be called before set_coupled_scaling "
                 "so coupled_scaling is available for outgoing renorm."
             )
-        if self.incoming_variables is None or self.outgoing_variable_order is None:
-            raise RuntimeError(
-                "setup_coupling must be called before set_coupled_scaling "
-                "so incoming/outgoing variable order is available from the "
-                "coupled module."
+        self.incoming_coupled_scaling = self._broadcast_stats(
+            *self._coupled_scaling_to_mean_std(
+                incoming_coupled_scaling, self.incoming_variables
             )
-
-        incoming_variables = list(self.incoming_variables)
-        if len(incoming_variables) != len(self.variables):
-            raise ValueError(
-                "incoming_variables from setup_coupling must have length "
-                f"{len(self.variables)}; got {len(incoming_variables)}"
-            )
-
-        in_mean, in_std = self._coupled_scaling_to_mean_std(
-            incoming_coupled_scaling,
-            incoming_variables,
-            name="incoming_coupled_scaling",
         )
-        self.incoming_coupled_scaling = self._mean_std_to_broadcast_tensors(
-            in_mean, in_std, name="incoming_coupled_scaling"
-        )
-        self.outgoing_coupled_scaling = self._outgoing_scaling_from_coupled_scaling()
-
-    def _outgoing_scaling_from_coupled_scaling(self) -> dict:
-        """Tile ``coupled_scaling`` across ``input_times`` in post-index order."""
-        cs_mean = np.asarray(self.coupled_scaling["mean"], dtype=np.float32).reshape(-1)
-        cs_std = np.asarray(self.coupled_scaling["std"], dtype=np.float32).reshape(-1)
-        if cs_mean.size != len(self.variables) or cs_std.size != len(self.variables):
-            raise RuntimeError(
-                "coupled_scaling channel count "
-                f"{cs_mean.size} does not match len(variables)={len(self.variables)}"
-            )
         var_idx = {v: i for i, v in enumerate(self.variables)}
-        try:
-            order = [var_idx[v] for v in self.outgoing_variable_order]
-        except KeyError as exc:
-            raise KeyError(
-                "outgoing_variable_order entry not in self.variables: "
-                f"{exc}; variables={list(self.variables)}"
-            ) from exc
-        # Period-major: [v0, v1, ..., v0, v1, ...] across input_times.
-        out_mean = np.tile(cs_mean[order], len(self.input_times))
-        out_std = np.tile(cs_std[order], len(self.input_times))
-        if out_mean.size != self.output_channels:
-            raise RuntimeError(
-                "outgoing scaling length "
-                f"{out_mean.size} != output_channels {self.output_channels}"
-            )
-        return self._mean_std_to_broadcast_tensors(
-            out_mean, out_std, name="outgoing_coupled_scaling"
-        )
-
-    # Backwards-compatible alias used briefly during the API rename.
-    set_coupled_field_scaling = set_coupled_scaling
-
-    def _coupled_variable_for_source_channel(self, source_channel: str) -> str:
-        """Map a source ``output_variables`` name to the matching coupler variable."""
-        for v in self.variables:
-            if ("-" not in v and source_channel == v) or (
-                source_channel == "-".join(v.split("-")[:-1])
-            ):
-                return v
-        raise ValueError(
-            f"No coupler variable in {list(self.variables)} matches "
-            f"source channel {source_channel!r}"
+        order = [var_idx[v] for v in self.outgoing_variable_order]
+        cs_mean = np.asarray(self.coupled_scaling["mean"], dtype=np.float32).ravel()
+        cs_std = np.asarray(self.coupled_scaling["std"], dtype=np.float32).ravel()
+        n = len(self.input_times)
+        self.outgoing_coupled_scaling = self._broadcast_stats(
+            np.tile(cs_mean[order], n), np.tile(cs_std[order], n)
         )
 
     @staticmethod
-    def _coupled_scaling_to_mean_std(scaling, keys: Sequence[str], name: str):
-        """Extract ordered mean/std arrays from YAML-style or scaling_da input."""
-        try:
-            from omegaconf import OmegaConf, DictConfig, ListConfig
-
-            if isinstance(scaling, (DictConfig, ListConfig)) or (
-                hasattr(OmegaConf, "is_config") and OmegaConf.is_config(scaling)
-            ):
-                scaling = OmegaConf.to_object(scaling)
-        except ImportError:
-            pass
-
+    def _coupled_scaling_to_mean_std(scaling, keys: Sequence[str]):
         if isinstance(scaling, (xr.Dataset, xr.DataArray)):
-            if "index" not in scaling.coords and "index" not in getattr(
-                scaling, "dims", ()
-            ):
-                # DataFrame.to_xarray() uses the frame index as a dimension named
-                # after the index; CoupledDataset always renames via .sel(index=...).
-                index_name = scaling.dims[0] if scaling.dims else None
-                if index_name is None:
-                    raise TypeError(
-                        f"{name}: xarray scaling object has no index coordinate"
-                    )
-                scaling = scaling.rename({index_name: "index"})
-            available = set(np.asarray(scaling["index"].values).tolist())
-            missing = [k for k in keys if k not in available]
-            if missing:
-                raise KeyError(
-                    f"{name} missing variables {missing}; "
-                    f"available={sorted(available)}"
-                )
             selected = scaling.sel(index=list(keys))
-            mean = np.asarray(selected["mean"].to_numpy(), dtype=np.float32).reshape(-1)
-            std = np.asarray(selected["std"].to_numpy(), dtype=np.float32).reshape(-1)
-            return mean, std
-
-        if not isinstance(scaling, Mapping):
-            raise TypeError(
-                f"{name} must be a variable-keyed scaling mapping "
-                f"(hpx64.yaml / cfg.data.scaling) or an xarray scaling_da; "
-                f"got {type(scaling)}"
+            return (
+                np.asarray(selected["mean"].to_numpy(), dtype=np.float32).ravel(),
+                np.asarray(selected["std"].to_numpy(), dtype=np.float32).ravel(),
             )
-
-        # Reject the old flat {"mean": [...], "std": [...]} form with a clear error.
-        if (
-            "mean" in scaling
-            and "std" in scaling
-            and not isinstance(scaling.get("mean"), Mapping)
-        ):
-            sample_vals = [
-                v for v in scaling.values() if isinstance(v, Mapping) and "mean" in v
-            ]
-            if not sample_vals:
-                raise TypeError(
-                    f"{name} must be variable-keyed like hpx64.yaml "
-                    f"(e.g. {{'z1000': {{'mean': ..., 'std': ...}}, ...}}) "
-                    f"or an xarray scaling_da; flat mean/std arrays are not supported."
-                )
-
-        missing = [k for k in keys if k not in scaling]
-        if missing:
-            raise KeyError(
-                f"{name} missing variables {missing}; "
-                f"available={sorted(scaling.keys())}"
-            )
-        try:
-            mean = np.asarray(
-                [scaling[k]["mean"] for k in keys], dtype=np.float32
-            ).reshape(-1)
-            std = np.asarray(
-                [scaling[k]["std"] for k in keys], dtype=np.float32
-            ).reshape(-1)
-        except (KeyError, TypeError) as exc:
-            raise TypeError(
-                f"{name} entries must be mappings with 'mean' and 'std' "
-                f"(hpx64.yaml style); error on keys {list(keys)}: {exc}"
-            ) from exc
-        return mean, std
+        return (
+            np.asarray([scaling[k]["mean"] for k in keys], dtype=np.float32),
+            np.asarray([scaling[k]["std"] for k in keys], dtype=np.float32),
+        )
 
     @staticmethod
-    def _mean_std_to_broadcast_tensors(mean, std, name: str) -> dict:
-        if mean.size != std.size:
-            raise ValueError(
-                f"{name} mean and std lengths differ: {mean.size} vs {std.size}"
-            )
+    def _broadcast_stats(mean, std) -> dict:
+        mean = np.asarray(mean, dtype=np.float32).ravel()
+        std = np.asarray(std, dtype=np.float32).ravel()
         if np.any(std == 0):
-            raise ValueError(f"{name} std must be non-zero for all channels")
-        # Broadcast over [B, F, T, C, H, W]
+            raise ValueError("scaling std must be non-zero for all channels")
+        # Broadcast to channel dimension [B, F, T, C, H, W] to match the shape of the coupled fields
         return {
             "mean": th.as_tensor(mean).view(1, 1, 1, -1, 1, 1),
             "std": th.as_tensor(std).view(1, 1, 1, -1, 1, 1),
         }
 
-    @property
-    def use_coupled_field_rescaling(self) -> bool:
-        return (
-            self.incoming_coupled_scaling is not None
-            and self.outgoing_coupled_scaling is not None
-        )
-
-    def denormalize_coupled_fields(self, coupled_fields: th.Tensor) -> th.Tensor:
-        """Undo incoming z-score: ``x * std_in + mean_in``."""
-        if self.incoming_coupled_scaling is None:
-            raise RuntimeError("incoming_coupled_scaling has not been set")
-        mean = self.incoming_coupled_scaling["mean"].to(
-            device=coupled_fields.device, dtype=coupled_fields.dtype
-        )
-        std = self.incoming_coupled_scaling["std"].to(
-            device=coupled_fields.device, dtype=coupled_fields.dtype
-        )
-        return coupled_fields * std + mean
-
-    def renormalize_coupled_fields(self, coupled_fields: th.Tensor) -> th.Tensor:
-        """Apply outgoing z-score: ``(x - mean_out) / std_out``."""
-        if self.outgoing_coupled_scaling is None:
-            raise RuntimeError("outgoing_coupled_scaling has not been set")
-        mean = self.outgoing_coupled_scaling["mean"].to(
-            device=coupled_fields.device, dtype=coupled_fields.dtype
-        )
-        std = self.outgoing_coupled_scaling["std"].to(
-            device=coupled_fields.device, dtype=coupled_fields.dtype
-        )
-        # Outgoing tensors may be [B, F, T, C, H, W] with C == timevar_dim.
-        if mean.shape[3] != coupled_fields.shape[3]:
-            raise ValueError(
-                "outgoing_coupled_scaling channel count "
-                f"{mean.shape[3]} does not match field channels "
-                f"{coupled_fields.shape[3]}"
-            )
-        return (coupled_fields - mean) / std
+    @staticmethod
+    def _apply_scaling(x: th.Tensor, scaling: dict, *, denorm: bool) -> th.Tensor:
+        mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
+        std = scaling["std"].to(device=x.device, dtype=x.dtype)
+        return x * std + mean if denorm else (x - mean) / std
 
     def rescale_coupled_fields_through_physical(
         self, coupled_fields: th.Tensor, physical_op
     ) -> th.Tensor:
-        """Denormalize → apply ``physical_op`` in physical space → renormalize.
-
-        Physical values (e.g. geopotential) often exceed the range of low-precision
-        dtypes such as float16. The pipeline therefore promotes to float32 for
-        denorm / ``physical_op`` / renorm, then casts the result back to the
-        input dtype.
-
-        Parameters
-        ----------
-        coupled_fields:
-            Incoming fields already channel-selected, layout ``[B, F, T, C, H, W]``.
-        physical_op:
-            Callable ``(Tensor) -> Tensor`` operating in physical units. Output
-            must keep layout ``[B, F, T', C', H, W]`` where ``C'`` matches
-            ``outgoing_coupled_scaling``.
-        """
+        """Denorm → ``physical_op`` → renorm in float32; restore input dtype."""
         orig_dtype = coupled_fields.dtype
-        fields_f32 = coupled_fields.to(dtype=th.float32)
-        physical = self.denormalize_coupled_fields(fields_f32)
-        transformed = physical_op(physical)
-        renormalized = self.renormalize_coupled_fields(transformed)
-        return renormalized.to(dtype=orig_dtype)
+        x = coupled_fields.to(dtype=th.float32)
+        physical = physical_op(
+            self._apply_scaling(x, self.incoming_coupled_scaling, denorm=True)
+        )
+        return self._apply_scaling(
+            physical, self.outgoing_coupled_scaling, denorm=False
+        ).to(dtype=orig_dtype)
 
     def setup_coupling(self, coupled_module):
         """
@@ -589,35 +298,33 @@ class BaseCoupler(ABC):
         # with a time increment suach as a trailing average increment e.g. 'z1000-48H'.
         # Some variables may have an additional suffix, e.g. 'z1000-3H-48H'. The final
         # suffix (if it exists) is used to determine the coupling increment.
-        channel_indices = [
-            i
-            for i, oc in enumerate(output_channels)
-            for v in self.variables
-            # extract everthing before the last "-" if there is one in the name
-            if (("-" not in v and oc == v) or (oc == "-".join(v.split("-")[:-1])))
-        ]
-        # check for missing variables
+        # Order follows source output_channels (may differ from self.variables).
+        channel_indices = []
+        incoming_variables = []
+        outgoing_variable_order = []
+        for i, oc in enumerate(output_channels):
+            for v in self.variables:
+                if ("-" not in v and oc == v) or (
+                    oc == "-".join(v.split("-")[:-1])
+                ):
+                    channel_indices.append(i)
+                    incoming_variables.append(oc)
+                    outgoing_variable_order.append(v)
+                    break
         if len(self.variables) != len(channel_indices):
-            found_channels = [
-                oc
-                for oc in output_channels
+            found = set(incoming_variables)
+            missing_channels = {
+                v
                 for v in self.variables
-                # extract everthing before the last -
-                if (("-" not in v and oc == v) or (oc == "-".join(v.split("-")[:-1])))
-            ]
-            missing_channels = set(self.variables) - set(found_channels)
+                if not (
+                    (v in found)
+                    or (("-" in v) and ("-".join(v.split("-")[:-1]) in found))
+                )
+            }
             raise ValueError(f"Missing variables in coupled module: {missing_channels}")
         self.coupled_channel_indices = channel_indices
-        # Channel names after ``coupled_fields[..., coupled_channel_indices, ...]``.
-        # Order follows the source module's output_variables (via the index list),
-        # which may differ from ``self.variables`` order.
-        self.incoming_variables = [output_channels[i] for i in channel_indices]
-        # Sink-side names paired 1:1 with incoming_variables / post-index channels,
-        # so outgoing scaling stays aligned after set_coupled_fields indexing.
-        self.outgoing_variable_order = [
-            self._coupled_variable_for_source_channel(oc)
-            for oc in self.incoming_variables
-        ]
+        self.incoming_variables = incoming_variables
+        self.outgoing_variable_order = outgoing_variable_order
 
     def reset_coupler(self):
         self.coupled_mode = False
@@ -827,24 +534,14 @@ class ConstantCoupler(BaseCoupler):
         ]
 
         def _broadcast_first_time(fields: th.Tensor) -> th.Tensor:
-            # Allocate a fresh buffer and copy time 0 into every integration
-            # step. Using expand() would share storage with ``fields``, so later
-            # mutations of the source tensor could silently change the preset.
-            out = th.empty(
-                [
-                    fields.shape[0],
-                    fields.shape[1],
-                    self.coupled_integration_dim,
-                    fields.shape[3],
-                    *fields.shape[4:],
-                ],
-                dtype=fields.dtype,
-                device=fields.device,
+            # Clone so later mutations of coupled_fields cannot alter presets.
+            return (
+                fields[:, :, :1]
+                .expand(-1, -1, self.coupled_integration_dim, -1, -1, -1)
+                .clone()
             )
-            out[:, :, :, :, :, :] = fields[:, :, :1, :, :, :]
-            return out
 
-        if self.use_coupled_field_rescaling:
+        if self.incoming_coupled_scaling is not None:
             self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
                 coupled_fields, _broadcast_first_time
             )
@@ -1025,7 +722,7 @@ class TrailingAverageCoupler(BaseCoupler):
                 coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
             return th.concat(coupled_averaging_periods, dim=2)
 
-        if self.use_coupled_field_rescaling:
+        if self.incoming_coupled_scaling is not None:
             self.preset_coupled_fields = self.rescale_coupled_fields_through_physical(
                 coupled_fields, _trailing_average
             )

--- a/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
+++ b/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
@@ -188,12 +188,6 @@ def _renorm_timevar_physical(physical_avg, keys, dtype=torch.float32):
 # ---------------------------------------------------------------------------
 
 
-def test_set_coupled_scaling_none_raises():
-    coupler = _make_trailing_coupler()
-    with pytest.raises(ValueError, match="incoming_coupled_scaling must be provided"):
-        coupler.set_coupled_scaling(None)
-
-
 def test_set_coupled_scaling_requires_setup_coupling():
     coupler = TrailingAverageCoupler(
         dataset=_make_dataset(TRAILING_48H_VARS),
@@ -205,38 +199,14 @@ def test_set_coupled_scaling_requires_setup_coupling():
         output_time_dim=1,
     )
     coupler.set_scaling(_scaling_da(TRAILING_48H_VARS))
-    with pytest.raises(RuntimeError, match="setup_coupling must be called"):
+    with pytest.raises(RuntimeError, match="set_scaling and setup_coupling"):
         coupler.set_coupled_scaling(_yaml_scaling())
 
 
 def test_set_coupled_scaling_requires_set_scaling():
     coupler = _make_trailing_coupler(install_coupled_scaling=False)
-    with pytest.raises(RuntimeError, match="set_scaling must be called"):
+    with pytest.raises(RuntimeError, match="set_scaling and setup_coupling"):
         coupler.set_coupled_scaling(_yaml_scaling())
-
-
-def test_flat_mean_std_arrays_rejected():
-    with pytest.raises(TypeError, match="variable-keyed"):
-        _make_trailing_coupler(
-            incoming={"mean": [0.0, 0.0], "std": [1.0, 1.0]},
-        )
-
-
-def test_missing_variable_keys_raises():
-    with pytest.raises(KeyError, match="missing variables"):
-        _make_trailing_coupler(
-            incoming={"z1000": {"mean": 0.0, "std": 1.0}},  # missing ws10m
-        )
-
-
-def test_entry_missing_mean_or_std_raises():
-    with pytest.raises(TypeError, match="mean.*std"):
-        _make_trailing_coupler(
-            incoming={
-                "z1000": {"mean": 0.0},  # missing std
-                "ws10m": {"mean": 0.0, "std": 1.0},
-            },
-        )
 
 
 def test_zero_std_raises():
@@ -246,17 +216,9 @@ def test_zero_std_raises():
         _make_trailing_coupler(incoming=bad)
 
 
-def test_use_coupled_field_rescaling_property():
-    bare = _make_trailing_coupler()
-    assert bare.use_coupled_field_rescaling is False
-    scaled = _make_trailing_coupler(incoming=_yaml_scaling())
-    assert scaled.use_coupled_field_rescaling is True
-    assert scaled.outgoing_coupled_scaling["mean"].shape[3] == scaled.output_channels
-
-
 def test_scaling_da_xarray_form_accepted():
     coupler = _make_trailing_coupler(incoming=_scaling_da())
-    assert coupler.use_coupled_field_rescaling is True
+    assert coupler.incoming_coupled_scaling is not None
     assert coupler.outgoing_coupled_scaling["mean"].shape[3] == coupler.output_channels
 
 
@@ -390,7 +352,7 @@ def test_trailing_average_without_scaling_unchanged():
     slices = bare.averaging_slices
     ref = _reference_trailing_average(znorm.to(torch.float64), slices, dtype=torch.float32)
     assert _max_abs_err(out_bare, ref) < 1e-5
-    assert bare.use_coupled_field_rescaling is False
+    assert bare.incoming_coupled_scaling is None
 
 
 def test_constant_without_scaling_unchanged():
@@ -471,55 +433,9 @@ def test_rescaling_recovers_physical_trailing_mean():
             assert e_ok < 1e-2
             assert e_bad > e_ok * 100
 
-
-def test_rescaling_with_tiled_48h_outgoing():
-    """Tiled -48H outgoing (len=n_var) also recovers physical mean."""
-    generator = torch.Generator().manual_seed(_SEED + 31)
-    physical = _sample_instant_physical(TIMEDIM, generator)
-    znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
-
-    coupler = _make_trailing_coupler(
-        incoming=_yaml_scaling(),  # length 2 → tiled
-    )
-    slices = coupler.averaging_slices
-    coupler.set_coupled_fields(znorm_instant)
-    recovered = _denorm_timevar_with(
-        coupler.construct_integrated_couplings(),
-        TRAILING_48H_VARS * len(INPUT_TIMES),
-    )
-    physical_mean = _reference_trailing_average(
-        physical, slices, dtype=torch.float64
-    )
-    assert _max_abs_err(recovered, physical_mean) < 1e-2
-
-
 # ---------------------------------------------------------------------------
 # 4. Tiled outgoing vs explicit timevar outgoing
 # ---------------------------------------------------------------------------
-
-
-def test_tiled_vs_explicit_timevar_outgoing_identical():
-    generator = torch.Generator().manual_seed(_SEED + 40)
-    physical = _sample_instant_physical(TIMEDIM, generator)
-    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
-    incoming = _yaml_scaling()
-
-    tiled = _make_trailing_coupler(
-        incoming=incoming,  # len 2
-    )
-    explicit = _make_trailing_coupler(
-        incoming=incoming,  # len 4 explicit repeat
-    )
-    tiled.set_coupled_fields(znorm.clone())
-    explicit.set_coupled_fields(znorm.clone())
-    out_tiled = tiled.construct_integrated_couplings()
-    out_explicit = explicit.construct_integrated_couplings()
-
-    assert out_tiled.shape == out_explicit.shape
-    assert torch.allclose(out_tiled, out_explicit, rtol=0, atol=0), (
-        f"tiled vs explicit diverge: max_err={_max_abs_err(out_tiled, out_explicit):.3e}"
-    )
-
 
 # ---------------------------------------------------------------------------
 # 5. ConstantCoupler with scaling
@@ -547,7 +463,7 @@ def test_constant_coupler_affine_transform_across_integration():
     coupler = _make_constant_coupler(
         incoming=incoming,
     )
-    assert coupler.use_coupled_field_rescaling
+    assert coupler.incoming_coupled_scaling is not None
     coupler.set_coupled_fields(znorm)
     out = coupler.construct_integrated_couplings()  # [I, B, C, F, H, W]
 
@@ -604,80 +520,6 @@ def test_stability_denorm_mean_renorm_vs_float64_reference():
             print(f"stability {instant_key}@{period}: max_abs_z={e:.4e}")
             assert e < 1e-4
 
-
-def test_optional_figure_mismatch_vs_api(tmp_path=None):
-    """Write a small comparison chart if matplotlib is available; never required."""
-    pytest.importorskip("matplotlib")
-    import matplotlib
-
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
-    generator = torch.Generator().manual_seed(42)
-    physical = _sample_instant_physical(TIMEDIM, generator)
-    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
-    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
-
-    bare = _make_trailing_coupler(
-        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
-    )
-    slices = bare.averaging_slices
-    physical_mean = _reference_trailing_average(
-        physical, slices, dtype=torch.float64
-    )
-
-    bare.set_coupled_fields(znorm.clone())
-    mismatched = _denorm_timevar_with(
-        bare.construct_integrated_couplings(), outgoing_keys
-    )
-
-    scaled = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-    )
-    scaled.set_coupled_fields(znorm.clone())
-    recovered = _denorm_timevar_with(
-        scaled.construct_integrated_couplings(), outgoing_keys
-    )
-
-    labels, err_bad, err_ok = [], [], []
-    for p, period in enumerate(INPUT_TIMES):
-        for v, instant_key in enumerate(INSTANT_VARS):
-            tv = p * len(INSTANT_VARS) + v
-            labels.append(f"{instant_key}\n@{period}")
-            err_bad.append(
-                (mismatched[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
-            )
-            err_ok.append(
-                (recovered[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
-            )
-
-    x = np.arange(len(labels))
-    width = 0.35
-    fig, ax = plt.subplots(figsize=(8, 4))
-    ax.bar(x - width / 2, err_bad, width, label="without API (mismatch)", color="#c44e52")
-    ax.bar(x + width / 2, err_ok, width, label="with API (recover)", color="#4c72b0")
-    ax.set_xticks(x)
-    ax.set_xticklabels(labels, fontsize=8)
-    ax.set_ylabel("max |error| vs physical trailing mean")
-    ax.set_yscale("log")
-    ax.set_title("Coupled-field scaling: instant→trailing mean recovery")
-    ax.legend()
-    fig.tight_layout()
-
-    out_dir = Path(__file__).with_name("figures")
-    out_dir.mkdir(exist_ok=True)
-    out_path = out_dir / "coupler_coupled_field_scaling_api.png"
-    fig.savefig(out_path, dpi=120)
-    plt.close(fig)
-    assert out_path.is_file()
-    # Soft numerical check so this still contributes coverage if run.
-    # z1000 mean-shift is O(10–100+); ws10 can be smaller but still ≫ API path.
-    z_bad = [err_bad[i] for i, lab in enumerate(labels) if "z1000" in lab]
-    assert all(b > 1.0 for b in z_bad)
-    assert all(o < 1e-2 for o in err_ok)
-    assert all(b > 100 * o for b, o in zip(err_bad, err_ok))
-
-
 # ---------------------------------------------------------------------------
 # 7. Adversarial edge cases
 # ---------------------------------------------------------------------------
@@ -715,51 +557,6 @@ def test_channel_order_period_major_multi_variable():
                 f"expected {expected_z.item():.4f} — channel order bug?"
             )
 
-
-def test_set_coupled_scaling():
-    generator = torch.Generator().manual_seed(_SEED + 70)
-    physical = _sample_instant_physical(TIMEDIM, generator)
-    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
-    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
-
-    coupler = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-    )
-    assert coupler.use_coupled_field_rescaling
-    slices = coupler.averaging_slices
-    coupler.set_coupled_fields(znorm)
-    recovered = _denorm_timevar_with(
-        coupler.construct_integrated_couplings(), outgoing_keys
-    )
-    physical_mean = _reference_trailing_average(
-        physical, slices, dtype=torch.float64
-    )
-    assert _max_abs_err(recovered, physical_mean) < 1e-2
-
-
-def test_float32_cpu_dtype_and_device():
-    generator = torch.Generator().manual_seed(_SEED + 71)
-    physical = _sample_instant_physical(TIMEDIM, generator)
-    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
-    assert znorm.dtype == torch.float32
-    assert znorm.device.type == "cpu"
-
-    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
-    coupler = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-    )
-    # Exercise denormalize / renormalize helpers directly.
-    denormed = coupler.denormalize_coupled_fields(znorm)
-    assert denormed.dtype == torch.float32
-    assert denormed.device.type == "cpu"
-
-    coupler.set_coupled_fields(znorm)
-    out = coupler.construct_integrated_couplings()
-    assert out.dtype == torch.float32
-    assert out.device.type == "cpu"
-    assert out.shape[2] == len(INSTANT_VARS) * len(INPUT_TIMES)
-
-
 def test_rescale_promotes_float16_to_float32_then_restores():
     """Physical denorm of z1000 exceeds float16 range; path must use float32 mid-flight."""
     generator = torch.Generator().manual_seed(_SEED + 72)
@@ -780,42 +577,3 @@ def test_rescale_promotes_float16_to_float32_then_restores():
     # Restored float16 should track the float32 path within float16 eps.
     assert _max_abs_err(out_f16.float(), out_f32) < 5e-2
 
-
-def test_rescale_coupled_fields_through_physical_callable():
-    coupler = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-    )
-    # Minimal [B,F,T,C,H,W] with known z values.
-    fields = torch.zeros(
-        _BATCH, _FACE, 2, len(INSTANT_VARS), _HEIGHT, _WIDTH, dtype=torch.float32
-    )
-    fields[..., 0, :, :] = 1.0  # +1σ on z1000
-    fields[..., 1, :, :] = -2.0  # -2σ on ws10m
-
-    def identity_op(x):
-        return x  # keep C=n_var; outgoing was tiled to timevar, so need C match
-
-    # Outgoing was tiled to timevar_dim=4, so identity (C=2) should raise.
-    with pytest.raises(ValueError, match="channel count"):
-        coupler.rescale_coupled_fields_through_physical(fields, identity_op)
-
-    # Physical op that expands channels to timevar layout by repeating.
-    def expand_to_timevar(x):
-        return torch.cat([x, x], dim=3)
-
-    out = coupler.rescale_coupled_fields_through_physical(fields, expand_to_timevar)
-    assert out.shape[3] == coupler.timevar_dim
-    assert out.dtype == torch.float32
-
-
-def test_denormalize_without_scaling_raises():
-    coupler = _make_trailing_coupler(
-        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
-    )
-    fields = torch.zeros(
-        _BATCH, _FACE, 2, len(INSTANT_VARS), _HEIGHT, _WIDTH, dtype=torch.float32
-    )
-    with pytest.raises(RuntimeError, match="incoming_coupled_scaling"):
-        coupler.denormalize_coupled_fields(fields)
-    with pytest.raises(RuntimeError, match="outgoing_coupled_scaling"):
-        coupler.renormalize_coupled_fields(fields)

--- a/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
+++ b/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
@@ -20,7 +20,7 @@ When instantaneous model outputs are z-scored with ``z1000`` / ``ws10m`` but the
 coupled training target uses trailing-window stats (``z1000-48H``, …), averaging
 in z-space and denorming with trailing stats is systematically wrong.
 
-``set_coupled_scaling(incoming, outgoing)`` fixes this by denormalizing →
+``set_coupled_scaling(incoming)`` (outgoing from ``coupled_scaling``) fixes this by denormalizing →
 operating in physical space → renormalizing inside ``set_coupled_fields``.
 """
 
@@ -95,13 +95,20 @@ def _scaling_da(keys=None):
     )
 
 
+def _scaling_da_from_mapping(scaling_map):
+    """xarray scaling_da from an already-built ``{name: {mean, std}}`` dict."""
+    import pandas as pd
+
+    return pd.DataFrame.from_dict(scaling_map).T.to_xarray().astype("float32")
+
+
 def _make_trailing_coupler(
     *,
     incoming=None,
-    outgoing=None,
     variables=None,
     incoming_variables=None,
     input_times=None,
+    install_coupled_scaling=True,
 ):
     """Build a TrailingAverageCoupler.
 
@@ -109,6 +116,9 @@ def _make_trailing_coupler(
     ``incoming_variables`` are source-module names from setup_coupling
     (default instant keys). Tensor channels are still length
     ``len(incoming_variables)`` with indices ``range(n)``.
+
+    When ``incoming`` is set, ``set_scaling`` is called first (outgoing base),
+    then ``set_coupled_scaling(incoming)``.
     """
     variables = list(variables or TRAILING_48H_VARS)
     incoming_variables = list(incoming_variables or INSTANT_VARS)
@@ -125,14 +135,14 @@ def _make_trailing_coupler(
         output_time_dim=1,
     )
     # Simulate setup_coupling without a full coupled module.
-    # Post-index order follows incoming_variables; pair sink names the same way.
     coupler.coupled_channel_indices = list(range(len(incoming_variables)))
     coupler.incoming_variables = incoming_variables
     coupler.outgoing_variable_order = list(variables)
-    if incoming is not None or outgoing is not None:
-        coupler.set_coupled_scaling(incoming, outgoing)
+    if install_coupled_scaling:
+        coupler.set_scaling(_scaling_da(variables))
+    if incoming is not None:
+        coupler.set_coupled_scaling(incoming)
     _configure_trailing_average(coupler, input_times, data_time_step="3h")
-    # Keep indices after configure helper (it resets them to len(variables)).
     coupler.coupled_channel_indices = list(range(len(incoming_variables)))
     return coupler
 
@@ -140,9 +150,9 @@ def _make_trailing_coupler(
 def _make_constant_coupler(
     *,
     incoming=None,
-    outgoing=None,
     variables=None,
     incoming_variables=None,
+    install_coupled_scaling=True,
 ):
     variables = list(variables or TRAILING_48H_VARS)
     incoming_variables = list(incoming_variables or INSTANT_VARS)
@@ -159,8 +169,10 @@ def _make_constant_coupler(
     coupler.coupled_channel_indices = list(range(len(incoming_variables)))
     coupler.incoming_variables = incoming_variables
     coupler.outgoing_variable_order = list(variables)
-    if incoming is not None or outgoing is not None:
-        coupler.set_coupled_scaling(incoming, outgoing)
+    if install_coupled_scaling:
+        coupler.set_scaling(_scaling_da(variables))
+    if incoming is not None:
+        coupler.set_coupled_scaling(incoming)
     return coupler
 
 
@@ -176,17 +188,10 @@ def _renorm_timevar_physical(physical_avg, keys, dtype=torch.float32):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "incoming,outgoing",
-    [
-        (_yaml_scaling(INSTANT_VARS), None),
-        (None, _yaml_scaling(TRAILING_48H_VARS)),
-    ],
-)
-def test_only_one_scaling_raises(incoming, outgoing):
+def test_set_coupled_scaling_none_raises():
     coupler = _make_trailing_coupler()
-    with pytest.raises(ValueError, match="must be provided together"):
-        coupler.set_coupled_scaling(incoming, outgoing)
+    with pytest.raises(ValueError, match="incoming_coupled_scaling must be provided"):
+        coupler.set_coupled_scaling(None)
 
 
 def test_set_coupled_scaling_requires_setup_coupling():
@@ -199,15 +204,21 @@ def test_set_coupled_scaling_requires_setup_coupling():
         input_time_dim=1,
         output_time_dim=1,
     )
+    coupler.set_scaling(_scaling_da(TRAILING_48H_VARS))
     with pytest.raises(RuntimeError, match="setup_coupling must be called"):
-        coupler.set_coupled_scaling(_yaml_scaling(), _yaml_scaling())
+        coupler.set_coupled_scaling(_yaml_scaling())
+
+
+def test_set_coupled_scaling_requires_set_scaling():
+    coupler = _make_trailing_coupler(install_coupled_scaling=False)
+    with pytest.raises(RuntimeError, match="set_scaling must be called"):
+        coupler.set_coupled_scaling(_yaml_scaling())
 
 
 def test_flat_mean_std_arrays_rejected():
     with pytest.raises(TypeError, match="variable-keyed"):
         _make_trailing_coupler(
             incoming={"mean": [0.0, 0.0], "std": [1.0, 1.0]},
-            outgoing=_yaml_scaling(),
         )
 
 
@@ -215,7 +226,6 @@ def test_missing_variable_keys_raises():
     with pytest.raises(KeyError, match="missing variables"):
         _make_trailing_coupler(
             incoming={"z1000": {"mean": 0.0, "std": 1.0}},  # missing ws10m
-            outgoing=_yaml_scaling(),
         )
 
 
@@ -226,7 +236,6 @@ def test_entry_missing_mean_or_std_raises():
                 "z1000": {"mean": 0.0},  # missing std
                 "ws10m": {"mean": 0.0, "std": 1.0},
             },
-            outgoing=_yaml_scaling(),
         )
 
 
@@ -234,28 +243,30 @@ def test_zero_std_raises():
     bad = _yaml_scaling(INSTANT_VARS)
     bad["ws10m"]["std"] = 0.0
     with pytest.raises(ValueError, match="std must be non-zero"):
-        _make_trailing_coupler(incoming=bad, outgoing=_yaml_scaling())
+        _make_trailing_coupler(incoming=bad)
 
 
 def test_use_coupled_field_rescaling_property():
     bare = _make_trailing_coupler()
     assert bare.use_coupled_field_rescaling is False
-    scaled = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
-    )
+    scaled = _make_trailing_coupler(incoming=_yaml_scaling())
     assert scaled.use_coupled_field_rescaling is True
-    # Outgoing is variables duplicated across input_times.
     assert scaled.outgoing_coupled_scaling["mean"].shape[3] == scaled.output_channels
 
 
 def test_scaling_da_xarray_form_accepted():
-    coupler = _make_trailing_coupler(
-        incoming=_scaling_da(),
-        outgoing=_scaling_da(),
-    )
+    coupler = _make_trailing_coupler(incoming=_scaling_da())
     assert coupler.use_coupled_field_rescaling is True
     assert coupler.outgoing_coupled_scaling["mean"].shape[3] == coupler.output_channels
+
+
+def test_outgoing_comes_from_coupled_scaling():
+    """Outgoing renorm stats must match set_scaling / coupled_scaling, tiled."""
+    coupler = _make_trailing_coupler(incoming=_yaml_scaling())
+    cs_mean = coupler.coupled_scaling["mean"].reshape(-1)
+    out_mean = coupler.outgoing_coupled_scaling["mean"].flatten().numpy()
+    expected = np.tile(cs_mean, len(INPUT_TIMES))
+    assert np.allclose(out_mean, expected)
 
 
 def test_setup_coupling_sets_incoming_variables():
@@ -280,7 +291,8 @@ def test_setup_coupling_sets_incoming_variables():
     assert coupler.incoming_variables == ["z1000", "ws10m"]
     assert coupler.outgoing_variable_order == ["z1000-48H", "ws10m-48H"]
     assert coupler.coupled_channel_indices == [1, 2]
-    coupler.set_coupled_scaling(scaling, scaling)
+    coupler.set_scaling(_scaling_da_from_mapping(scaling))
+    coupler.set_coupled_scaling(scaling)
     assert abs(
         coupler.incoming_coupled_scaling["mean"].flatten()[0].item()
         - SCALING["z1000"][0]
@@ -322,7 +334,8 @@ def test_scaling_follows_post_index_channel_order():
     assert coupler.coupled_channel_indices == [1, 2]  # ws10m, z1000 in source order
     assert coupler.incoming_variables == ["ws10m", "z1000"]
     assert coupler.outgoing_variable_order == ["ws10m-48H", "z1000-48H"]
-    coupler.set_coupled_scaling(scaling, scaling)
+    coupler.set_scaling(_scaling_da_from_mapping(scaling))
+    coupler.set_coupled_scaling(scaling)
 
     # Build a full source-shaped tensor and fill only the matched channels.
     # Channel layout matches FakeModule.output_variables.
@@ -416,7 +429,6 @@ def test_rescaling_recovers_physical_trailing_mean():
     outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     slices = coupler.averaging_slices
     coupler.set_coupled_fields(znorm_instant)
@@ -467,8 +479,7 @@ def test_rescaling_with_tiled_48h_outgoing():
     znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
 
     coupler = _make_trailing_coupler(
-        incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),  # length 2 → tiled
+        incoming=_yaml_scaling(),  # length 2 → tiled
     )
     slices = coupler.averaging_slices
     coupler.set_coupled_fields(znorm_instant)
@@ -494,12 +505,10 @@ def test_tiled_vs_explicit_timevar_outgoing_identical():
     incoming = _yaml_scaling()
 
     tiled = _make_trailing_coupler(
-        incoming=incoming,
-        outgoing=incoming,  # len 2
+        incoming=incoming,  # len 2
     )
     explicit = _make_trailing_coupler(
-        incoming=incoming,
-        outgoing=incoming,  # len 4 explicit repeat
+        incoming=incoming,  # len 4 explicit repeat
     )
     tiled.set_coupled_fields(znorm.clone())
     explicit.set_coupled_fields(znorm.clone())
@@ -537,7 +546,6 @@ def test_constant_coupler_affine_transform_across_integration():
 
     coupler = _make_constant_coupler(
         incoming=incoming,
-        outgoing=outgoing,
     )
     assert coupler.use_coupled_field_rescaling
     coupler.set_coupled_fields(znorm)
@@ -573,7 +581,6 @@ def test_stability_denorm_mean_renorm_vs_float64_reference():
 
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     slices = coupler.averaging_slices
     coupler.set_coupled_fields(znorm)
@@ -626,7 +633,6 @@ def test_optional_figure_mismatch_vs_api(tmp_path=None):
 
     scaled = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     scaled.set_coupled_fields(znorm.clone())
     recovered = _denorm_timevar_with(
@@ -692,7 +698,6 @@ def test_channel_order_period_major_multi_variable():
     outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     coupler.set_coupled_fields(znorm)
     out = coupler.construct_integrated_couplings().to(torch.float64)
@@ -719,7 +724,6 @@ def test_set_coupled_scaling():
 
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     assert coupler.use_coupled_field_rescaling
     slices = coupler.averaging_slices
@@ -743,7 +747,6 @@ def test_float32_cpu_dtype_and_device():
     outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     # Exercise denormalize / renormalize helpers directly.
     denormed = coupler.denormalize_coupled_fields(znorm)
@@ -757,10 +760,30 @@ def test_float32_cpu_dtype_and_device():
     assert out.shape[2] == len(INSTANT_VARS) * len(INPUT_TIMES)
 
 
+def test_rescale_promotes_float16_to_float32_then_restores():
+    """Physical denorm of z1000 exceeds float16 range; path must use float32 mid-flight."""
+    generator = torch.Generator().manual_seed(_SEED + 72)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm_f32 = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    znorm_f16 = znorm_f32.to(torch.float16)
+
+    coupler_f16 = _make_trailing_coupler(incoming=_yaml_scaling())
+    coupler_f16.set_coupled_fields(znorm_f16)
+    out_f16 = coupler_f16.construct_integrated_couplings()
+    assert out_f16.dtype == torch.float16
+    assert torch.isfinite(out_f16.float()).all()
+
+    coupler_f32 = _make_trailing_coupler(incoming=_yaml_scaling())
+    coupler_f32.set_coupled_fields(znorm_f32)
+    out_f32 = coupler_f32.construct_integrated_couplings()
+
+    # Restored float16 should track the float32 path within float16 eps.
+    assert _max_abs_err(out_f16.float(), out_f32) < 5e-2
+
+
 def test_rescale_coupled_fields_through_physical_callable():
     coupler = _make_trailing_coupler(
         incoming=_yaml_scaling(),
-        outgoing=_yaml_scaling(),
     )
     # Minimal [B,F,T,C,H,W] with known z values.
     fields = torch.zeros(

--- a/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
+++ b/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
@@ -125,8 +125,10 @@ def _make_trailing_coupler(
         output_time_dim=1,
     )
     # Simulate setup_coupling without a full coupled module.
+    # Post-index order follows incoming_variables; pair sink names the same way.
     coupler.coupled_channel_indices = list(range(len(incoming_variables)))
     coupler.incoming_variables = incoming_variables
+    coupler.outgoing_variable_order = list(variables)
     if incoming is not None or outgoing is not None:
         coupler.set_coupled_scaling(incoming, outgoing)
     _configure_trailing_average(coupler, input_times, data_time_step="3h")
@@ -156,6 +158,7 @@ def _make_constant_coupler(
     )
     coupler.coupled_channel_indices = list(range(len(incoming_variables)))
     coupler.incoming_variables = incoming_variables
+    coupler.outgoing_variable_order = list(variables)
     if incoming is not None or outgoing is not None:
         coupler.set_coupled_scaling(incoming, outgoing)
     return coupler
@@ -275,6 +278,7 @@ def test_setup_coupling_sets_incoming_variables():
     )
     coupler.setup_coupling(_FakeModule())
     assert coupler.incoming_variables == ["z1000", "ws10m"]
+    assert coupler.outgoing_variable_order == ["z1000-48H", "ws10m-48H"]
     assert coupler.coupled_channel_indices == [1, 2]
     coupler.set_coupled_scaling(scaling, scaling)
     assert abs(
@@ -292,6 +296,70 @@ def test_setup_coupling_sets_incoming_variables():
 # ---------------------------------------------------------------------------
 # 2. Backward compatibility
 # ---------------------------------------------------------------------------
+
+
+def test_scaling_follows_post_index_channel_order():
+    """If source channel order differs from self.variables, scaling must follow indices."""
+    scaling = _yaml_scaling()
+    scaling["ws10m-48H"] = dict(scaling["ws10-48H"])
+
+    class _FakeModule:
+        # ws10m appears *before* z1000 in the source output
+        output_variables = ["sst", "ws10m", "z1000", "t2m"]
+        time_step = "3h"
+
+    # Coupler variables listed z1000-first (opposite of source order).
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(["z1000-48H", "ws10m-48H"], n_time=64),
+        batch_size=_BATCH,
+        variables=["z1000-48H", "ws10m-48H"],
+        averaging_window="48h",
+        input_times=["48h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler.setup_coupling(_FakeModule())
+    assert coupler.coupled_channel_indices == [1, 2]  # ws10m, z1000 in source order
+    assert coupler.incoming_variables == ["ws10m", "z1000"]
+    assert coupler.outgoing_variable_order == ["ws10m-48H", "z1000-48H"]
+    coupler.set_coupled_scaling(scaling, scaling)
+
+    # Build a full source-shaped tensor and fill only the matched channels.
+    # Channel layout matches FakeModule.output_variables.
+    timedim = 20
+    full = torch.zeros(_BATCH, _FACE, timedim, 4, _HEIGHT, _WIDTH, dtype=torch.float32)
+    # After index [1,2] → [ws10m, z1000]. Plant distinct z-scores.
+    full[:, :, :, 1, :, :] = 1.0   # ws10m = +1σ
+    full[:, :, :, 2, :, :] = 2.0   # z1000 = +2σ
+    # setup_coupling already set averaging_slices; do not call
+    # _configure_trailing_average (it would reset coupled_channel_indices).
+    coupler.set_coupled_fields(full)
+    out = coupler.construct_integrated_couplings()  # [I,B,timevar,F,H,W]
+
+    # Denorm with outgoing order [ws10m-48H, z1000-48H] should recover
+    # physical = μ + σ * z for each post-index channel.
+    means_o = torch.tensor(
+        [scaling["ws10m-48H"]["mean"], scaling["z1000-48H"]["mean"]],
+        dtype=torch.float64,
+    )
+    stds_o = torch.tensor(
+        [scaling["ws10m-48H"]["std"], scaling["z1000-48H"]["std"]],
+        dtype=torch.float64,
+    )
+    means_i = torch.tensor(
+        [scaling["ws10m"]["mean"], scaling["z1000"]["mean"]],
+        dtype=torch.float64,
+    )
+    stds_i = torch.tensor(
+        [scaling["ws10m"]["std"], scaling["z1000"]["std"]],
+        dtype=torch.float64,
+    )
+    phys = means_i + stds_i * torch.tensor([1.0, 2.0], dtype=torch.float64)
+    expected_z = ((phys - means_o) / stds_o).to(torch.float32)
+    got = out[0, 0, :, 0, 0, 0]  # [timevar]
+    assert torch.allclose(got, expected_z, rtol=0, atol=1e-4), (
+        f"order mismatch: got {got.tolist()}, expected {expected_z.tolist()}"
+    )
 
 
 def test_trailing_average_without_scaling_unchanged():

--- a/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
+++ b/test/datapipes/test_healpix_coupler_coupled_field_scaling.py
@@ -1,0 +1,730 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adversarial tests for coupler incoming/outgoing coupled-field scaling.
+
+When instantaneous model outputs are z-scored with ``z1000`` / ``ws10m`` but the
+coupled training target uses trailing-window stats (``z1000-48H``, …), averaging
+in z-space and denorming with trailing stats is systematically wrong.
+
+``set_coupled_scaling(incoming, outgoing)`` fixes this by denormalizing →
+operating in physical space → renormalizing inside ``set_coupled_fields``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+xr = pytest.importorskip("xarray")
+
+from physicsnemo.datapipes.healpix.couplers import (  # noqa: E402
+    ConstantCoupler,
+    TrailingAverageCoupler,
+)
+
+_znorm_spec = importlib.util.spec_from_file_location(
+    "znorm_stability",
+    Path(__file__).with_name("test_healpix_coupler_znorm_stability.py"),
+)
+_znorm = importlib.util.module_from_spec(_znorm_spec)
+_znorm_spec.loader.exec_module(_znorm)
+
+_ivt_spec = importlib.util.spec_from_file_location(
+    "instant_vs_trailing",
+    Path(__file__).with_name("test_healpix_coupler_instant_vs_trailing_scaling.py"),
+)
+_ivt = importlib.util.module_from_spec(_ivt_spec)
+_ivt_spec.loader.exec_module(_ivt)
+
+HPX64_SCALING = _znorm.HPX64_SCALING
+_BATCH = _znorm._BATCH
+_FACE = _znorm._FACE
+_HEIGHT = _znorm._HEIGHT
+_WIDTH = _znorm._WIDTH
+_SEED = _znorm._SEED
+_broadcast_stats = _znorm._broadcast_stats
+_configure_trailing_average = _znorm._configure_trailing_average
+_make_dataset = _znorm._make_dataset
+_max_abs_err = _znorm._max_abs_err
+_reference_trailing_average = _znorm._reference_trailing_average
+
+INSTANT_VARS = _ivt.INSTANT_VARS
+TRAILING_48H_VARS = _ivt.TRAILING_48H_VARS
+TRAILING_DENORM_BY_PERIOD = _ivt.TRAILING_DENORM_BY_PERIOD
+SCALING = _ivt.SCALING
+_stats = _ivt._stats
+_normalize_with = _ivt._normalize_with
+_denorm_timevar_with = _ivt._denorm_timevar_with
+_flatten_period_keys = _ivt._flatten_period_keys
+_sample_instant_physical = _ivt._sample_instant_physical
+
+INPUT_TIMES = ("48h", "96h")
+TIMEDIM = 40  # covers 96h / 3h = 32 steps
+
+
+def _yaml_scaling(keys=None):
+    """Build an hpx64.yaml-style ``{name: {mean, std}}`` mapping."""
+    items = SCALING.items() if keys is None else ((k, SCALING[k]) for k in keys)
+    return {k: {"mean": float(v[0]), "std": float(v[1])} for k, v in items}
+
+
+def _scaling_da(keys=None):
+    """xarray form produced by CoupledDataset from the YAML mapping."""
+    import pandas as pd
+
+    return (
+        pd.DataFrame.from_dict(_yaml_scaling(keys)).T.to_xarray().astype("float32")
+    )
+
+
+def _make_trailing_coupler(
+    *,
+    incoming=None,
+    outgoing=None,
+    variables=None,
+    incoming_variables=None,
+    input_times=None,
+):
+    """Build a TrailingAverageCoupler.
+
+    ``variables`` are the coupler/outgoing keys (default trailing-48H).
+    ``incoming_variables`` are source-module names from setup_coupling
+    (default instant keys). Tensor channels are still length
+    ``len(incoming_variables)`` with indices ``range(n)``.
+    """
+    variables = list(variables or TRAILING_48H_VARS)
+    incoming_variables = list(incoming_variables or INSTANT_VARS)
+    input_times = list(input_times or INPUT_TIMES)
+    assert len(variables) == len(incoming_variables)
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(variables, n_time=64),
+        batch_size=_BATCH,
+        variables=variables,
+        presteps=0,
+        averaging_window="48h",
+        input_times=input_times,
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    # Simulate setup_coupling without a full coupled module.
+    coupler.coupled_channel_indices = list(range(len(incoming_variables)))
+    coupler.incoming_variables = incoming_variables
+    if incoming is not None or outgoing is not None:
+        coupler.set_coupled_scaling(incoming, outgoing)
+    _configure_trailing_average(coupler, input_times, data_time_step="3h")
+    # Keep indices after configure helper (it resets them to len(variables)).
+    coupler.coupled_channel_indices = list(range(len(incoming_variables)))
+    return coupler
+
+
+def _make_constant_coupler(
+    *,
+    incoming=None,
+    outgoing=None,
+    variables=None,
+    incoming_variables=None,
+):
+    variables = list(variables or TRAILING_48H_VARS)
+    incoming_variables = list(incoming_variables or INSTANT_VARS)
+    assert len(variables) == len(incoming_variables)
+    coupler = ConstantCoupler(
+        dataset=_make_dataset(variables),
+        batch_size=_BATCH,
+        variables=variables,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=3,
+        presteps=0,
+    )
+    coupler.coupled_channel_indices = list(range(len(incoming_variables)))
+    coupler.incoming_variables = incoming_variables
+    if incoming is not None or outgoing is not None:
+        coupler.set_coupled_scaling(incoming, outgoing)
+    return coupler
+
+
+def _renorm_timevar_physical(physical_avg, keys, dtype=torch.float32):
+    """Normalize time_first [I, B, timevar, ...] with per-slot outgoing stats."""
+    means, stds = _stats(keys)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=2)
+    return ((physical_avg - means_b) / stds_b).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# 1. API validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "incoming,outgoing",
+    [
+        (_yaml_scaling(INSTANT_VARS), None),
+        (None, _yaml_scaling(TRAILING_48H_VARS)),
+    ],
+)
+def test_only_one_scaling_raises(incoming, outgoing):
+    coupler = _make_trailing_coupler()
+    with pytest.raises(ValueError, match="must be provided together"):
+        coupler.set_coupled_scaling(incoming, outgoing)
+
+
+def test_set_coupled_scaling_requires_setup_coupling():
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(TRAILING_48H_VARS),
+        batch_size=_BATCH,
+        variables=TRAILING_48H_VARS,
+        averaging_window="48h",
+        input_times=list(INPUT_TIMES),
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    with pytest.raises(RuntimeError, match="setup_coupling must be called"):
+        coupler.set_coupled_scaling(_yaml_scaling(), _yaml_scaling())
+
+
+def test_flat_mean_std_arrays_rejected():
+    with pytest.raises(TypeError, match="variable-keyed"):
+        _make_trailing_coupler(
+            incoming={"mean": [0.0, 0.0], "std": [1.0, 1.0]},
+            outgoing=_yaml_scaling(),
+        )
+
+
+def test_missing_variable_keys_raises():
+    with pytest.raises(KeyError, match="missing variables"):
+        _make_trailing_coupler(
+            incoming={"z1000": {"mean": 0.0, "std": 1.0}},  # missing ws10m
+            outgoing=_yaml_scaling(),
+        )
+
+
+def test_entry_missing_mean_or_std_raises():
+    with pytest.raises(TypeError, match="mean.*std"):
+        _make_trailing_coupler(
+            incoming={
+                "z1000": {"mean": 0.0},  # missing std
+                "ws10m": {"mean": 0.0, "std": 1.0},
+            },
+            outgoing=_yaml_scaling(),
+        )
+
+
+def test_zero_std_raises():
+    bad = _yaml_scaling(INSTANT_VARS)
+    bad["ws10m"]["std"] = 0.0
+    with pytest.raises(ValueError, match="std must be non-zero"):
+        _make_trailing_coupler(incoming=bad, outgoing=_yaml_scaling())
+
+
+def test_use_coupled_field_rescaling_property():
+    bare = _make_trailing_coupler()
+    assert bare.use_coupled_field_rescaling is False
+    scaled = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    assert scaled.use_coupled_field_rescaling is True
+    # Outgoing is variables duplicated across input_times.
+    assert scaled.outgoing_coupled_scaling["mean"].shape[3] == scaled.output_channels
+
+
+def test_scaling_da_xarray_form_accepted():
+    coupler = _make_trailing_coupler(
+        incoming=_scaling_da(),
+        outgoing=_scaling_da(),
+    )
+    assert coupler.use_coupled_field_rescaling is True
+    assert coupler.outgoing_coupled_scaling["mean"].shape[3] == coupler.output_channels
+
+
+def test_setup_coupling_sets_incoming_variables():
+    """Matched source output_variables become incoming_variables."""
+    scaling = _yaml_scaling()
+    scaling["ws10m-48H"] = dict(scaling["ws10-48H"])
+
+    class _FakeModule:
+        output_variables = ["sst", "z1000", "ws10m", "t2m"]
+        time_step = "3h"
+
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(["z1000-48H", "ws10m-48H"], n_time=8),
+        batch_size=1,
+        variables=["z1000-48H", "ws10m-48H"],
+        averaging_window="48h",
+        input_times=["48h", "96h"],
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    coupler.setup_coupling(_FakeModule())
+    assert coupler.incoming_variables == ["z1000", "ws10m"]
+    assert coupler.coupled_channel_indices == [1, 2]
+    coupler.set_coupled_scaling(scaling, scaling)
+    assert abs(
+        coupler.incoming_coupled_scaling["mean"].flatten()[0].item()
+        - SCALING["z1000"][0]
+    ) < 1e-3
+    assert abs(
+        coupler.outgoing_coupled_scaling["mean"].flatten()[0].item()
+        - SCALING["z1000-48H"][0]
+    ) < 1e-3
+    # Duplicated across 2 input_times.
+    assert coupler.outgoing_coupled_scaling["mean"].shape[3] == 4
+
+
+# ---------------------------------------------------------------------------
+# 2. Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_average_without_scaling_unchanged():
+    generator = torch.Generator().manual_seed(_SEED + 20)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+
+    bare = _make_trailing_coupler(
+        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
+    )
+    bare.set_coupled_fields(znorm.clone())
+    out_bare = bare.construct_integrated_couplings()
+
+    # Sanity: matches reference average in z-space (old path).
+    slices = bare.averaging_slices
+    ref = _reference_trailing_average(znorm.to(torch.float64), slices, dtype=torch.float32)
+    assert _max_abs_err(out_bare, ref) < 1e-5
+    assert bare.use_coupled_field_rescaling is False
+
+
+def test_constant_without_scaling_unchanged():
+    generator = torch.Generator().manual_seed(_SEED + 21)
+    means, stds = _stats(INSTANT_VARS)
+    noise = torch.randn(
+        _BATCH, _FACE, 4, len(INSTANT_VARS), _HEIGHT, _WIDTH,
+        dtype=torch.float64, generator=generator,
+    )
+    physical = means.view(1, 1, 1, -1, 1, 1) + stds.view(1, 1, 1, -1, 1, 1) * noise
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+
+    bare = _make_constant_coupler(
+        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
+    )
+    bare.set_coupled_fields(znorm.clone())
+    out = bare.construct_integrated_couplings()
+
+    expected = znorm[:, :, :1].permute(2, 0, 3, 1, 4, 5).expand(
+        bare.coupled_integration_dim, -1, -1, -1, -1, -1
+    )
+    assert torch.equal(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# 3. Core fix: denorm → avg → renorm recovers physical trailing mean
+# ---------------------------------------------------------------------------
+
+
+def test_rescaling_recovers_physical_trailing_mean():
+    """Instant-norm input + duplicated trailing outgoing stats → physical mean."""
+    generator = torch.Generator().manual_seed(_SEED + 30)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    slices = coupler.averaging_slices
+    coupler.set_coupled_fields(znorm_instant)
+    znorm_out = coupler.construct_integrated_couplings()
+
+    # Coupler output is in outgoing z-space; denorm to compare with physical mean.
+    recovered = _denorm_timevar_with(znorm_out, outgoing_keys)
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+    err_with_api = _max_abs_err(recovered, physical_mean)
+
+    # Contrast: old mismatched path (instant norm → avg → trailing denorm).
+    bare = _make_trailing_coupler(
+        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
+    )
+    bare.set_coupled_fields(znorm_instant.clone())
+    mismatched = _denorm_timevar_with(
+        bare.construct_integrated_couplings(), outgoing_keys
+    )
+    err_without_api = _max_abs_err(mismatched, physical_mean)
+
+    assert err_with_api < 1e-2, (
+        f"API path should recover physical trailing mean, got {err_with_api:.3e}"
+    )
+    assert err_without_api > 1.0, (
+        f"expected large mismatch without API, got {err_without_api:.3e}"
+    )
+    assert err_without_api > 100 * err_with_api
+
+    # Per-slot report for z1000 / ws10.
+    for p, period in enumerate(INPUT_TIMES):
+        for v, instant_key in enumerate(INSTANT_VARS):
+            tv = p * len(INSTANT_VARS) + v
+            e_ok = (recovered[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
+            e_bad = (mismatched[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
+            print(
+                f"{instant_key}@{period}: with_api={e_ok:.4e} without_api={e_bad:.4e}"
+            )
+            assert e_ok < 1e-2
+            assert e_bad > e_ok * 100
+
+
+def test_rescaling_with_tiled_48h_outgoing():
+    """Tiled -48H outgoing (len=n_var) also recovers physical mean."""
+    generator = torch.Generator().manual_seed(_SEED + 31)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),  # length 2 → tiled
+    )
+    slices = coupler.averaging_slices
+    coupler.set_coupled_fields(znorm_instant)
+    recovered = _denorm_timevar_with(
+        coupler.construct_integrated_couplings(),
+        TRAILING_48H_VARS * len(INPUT_TIMES),
+    )
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+    assert _max_abs_err(recovered, physical_mean) < 1e-2
+
+
+# ---------------------------------------------------------------------------
+# 4. Tiled outgoing vs explicit timevar outgoing
+# ---------------------------------------------------------------------------
+
+
+def test_tiled_vs_explicit_timevar_outgoing_identical():
+    generator = torch.Generator().manual_seed(_SEED + 40)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    incoming = _yaml_scaling()
+
+    tiled = _make_trailing_coupler(
+        incoming=incoming,
+        outgoing=incoming,  # len 2
+    )
+    explicit = _make_trailing_coupler(
+        incoming=incoming,
+        outgoing=incoming,  # len 4 explicit repeat
+    )
+    tiled.set_coupled_fields(znorm.clone())
+    explicit.set_coupled_fields(znorm.clone())
+    out_tiled = tiled.construct_integrated_couplings()
+    out_explicit = explicit.construct_integrated_couplings()
+
+    assert out_tiled.shape == out_explicit.shape
+    assert torch.allclose(out_tiled, out_explicit, rtol=0, atol=0), (
+        f"tiled vs explicit diverge: max_err={_max_abs_err(out_tiled, out_explicit):.3e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. ConstantCoupler with scaling
+# ---------------------------------------------------------------------------
+
+
+def test_constant_coupler_affine_transform_across_integration():
+    """Denorm(incoming) → broadcast t0 → renorm(outgoing) applied correctly."""
+    variables = INSTANT_VARS
+    incoming = _yaml_scaling()
+    # Deliberately different outgoing stats so the affine map is non-identity.
+    outgoing = incoming
+
+    generator = torch.Generator().manual_seed(_SEED + 50)
+    means_i, stds_i = _stats(variables)
+    noise = torch.randn(
+        _BATCH, _FACE, 4, len(variables), _HEIGHT, _WIDTH,
+        dtype=torch.float64, generator=generator,
+    )
+    physical = means_i.view(1, 1, 1, -1, 1, 1) + stds_i.view(1, 1, 1, -1, 1, 1) * noise
+    znorm = ((physical - means_i.view(1, 1, 1, -1, 1, 1)) / stds_i.view(1, 1, 1, -1, 1, 1)).to(
+        torch.float32
+    )
+
+    coupler = _make_constant_coupler(
+        incoming=incoming,
+        outgoing=outgoing,
+    )
+    assert coupler.use_coupled_field_rescaling
+    coupler.set_coupled_fields(znorm)
+    out = coupler.construct_integrated_couplings()  # [I, B, C, F, H, W]
+
+    means_o, stds_o = _stats(TRAILING_48H_VARS)
+    # Expected: renorm_o(phys_t0) = (phys_t0 - μ_o) / σ_o
+    phys_t0 = physical[:, :, :1].to(torch.float64)
+    expected_bf = (phys_t0 - means_o.view(1, 1, 1, -1, 1, 1)) / stds_o.view(
+        1, 1, 1, -1, 1, 1
+    )
+    expected = expected_bf.permute(2, 0, 3, 1, 4, 5).expand(
+        coupler.coupled_integration_dim, -1, -1, -1, -1, -1
+    ).to(torch.float32)
+
+    assert out.shape[0] == coupler.coupled_integration_dim
+    assert _max_abs_err(out, expected) < 1e-4
+    # All integration steps identical (broadcast of time 0).
+    assert torch.allclose(out[0], out[1], rtol=0, atol=0)
+    assert torch.allclose(out[0], out[-1], rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# 6. Stability analysis vs float64 physical reference
+# ---------------------------------------------------------------------------
+
+
+def test_stability_denorm_mean_renorm_vs_float64_reference():
+    generator = torch.Generator().manual_seed(_SEED + 60)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    slices = coupler.averaging_slices
+    coupler.set_coupled_fields(znorm)
+    got = coupler.construct_integrated_couplings().to(torch.float64)
+
+    phys_avg_f64 = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+    ref = _renorm_timevar_physical(phys_avg_f64, outgoing_keys, dtype=torch.float64)
+
+    err = _max_abs_err(got, ref)
+    assert err < 1e-4, f"float32 denorm→mean→renorm drifted from f64 ref: {err:.3e}"
+
+    # Per-slot quantitative errors (z-space).
+    slot_errs = {}
+    for p, period in enumerate(INPUT_TIMES):
+        for v, instant_key in enumerate(INSTANT_VARS):
+            tv = p * len(INSTANT_VARS) + v
+            e = (got[:, :, tv] - ref[:, :, tv]).abs().max().item()
+            slot_errs[f"{instant_key}@{period}"] = e
+            print(f"stability {instant_key}@{period}: max_abs_z={e:.4e}")
+            assert e < 1e-4
+
+
+def test_optional_figure_mismatch_vs_api(tmp_path=None):
+    """Write a small comparison chart if matplotlib is available; never required."""
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    generator = torch.Generator().manual_seed(42)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+
+    bare = _make_trailing_coupler(
+        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
+    )
+    slices = bare.averaging_slices
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+
+    bare.set_coupled_fields(znorm.clone())
+    mismatched = _denorm_timevar_with(
+        bare.construct_integrated_couplings(), outgoing_keys
+    )
+
+    scaled = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    scaled.set_coupled_fields(znorm.clone())
+    recovered = _denorm_timevar_with(
+        scaled.construct_integrated_couplings(), outgoing_keys
+    )
+
+    labels, err_bad, err_ok = [], [], []
+    for p, period in enumerate(INPUT_TIMES):
+        for v, instant_key in enumerate(INSTANT_VARS):
+            tv = p * len(INSTANT_VARS) + v
+            labels.append(f"{instant_key}\n@{period}")
+            err_bad.append(
+                (mismatched[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
+            )
+            err_ok.append(
+                (recovered[:, :, tv] - physical_mean[:, :, tv]).abs().max().item()
+            )
+
+    x = np.arange(len(labels))
+    width = 0.35
+    fig, ax = plt.subplots(figsize=(8, 4))
+    ax.bar(x - width / 2, err_bad, width, label="without API (mismatch)", color="#c44e52")
+    ax.bar(x + width / 2, err_ok, width, label="with API (recover)", color="#4c72b0")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, fontsize=8)
+    ax.set_ylabel("max |error| vs physical trailing mean")
+    ax.set_yscale("log")
+    ax.set_title("Coupled-field scaling: instant→trailing mean recovery")
+    ax.legend()
+    fig.tight_layout()
+
+    out_dir = Path(__file__).with_name("figures")
+    out_dir.mkdir(exist_ok=True)
+    out_path = out_dir / "coupler_coupled_field_scaling_api.png"
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+    assert out_path.is_file()
+    # Soft numerical check so this still contributes coverage if run.
+    # z1000 mean-shift is O(10–100+); ws10 can be smaller but still ≫ API path.
+    z_bad = [err_bad[i] for i, lab in enumerate(labels) if "z1000" in lab]
+    assert all(b > 1.0 for b in z_bad)
+    assert all(o < 1e-2 for o in err_ok)
+    assert all(b > 100 * o for b, o in zip(err_bad, err_ok))
+
+
+# ---------------------------------------------------------------------------
+# 7. Adversarial edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_channel_order_period_major_multi_variable():
+    """Output channels stay period-major: [p0_v0, p0_v1, p1_v0, p1_v1]."""
+    variables = INSTANT_VARS
+    # Plant constant-per-channel physical fields so order is unambiguous.
+    means, stds = _stats(variables)
+    k = torch.tensor([2.0, -1.5], dtype=torch.float64)
+    physical = (
+        means.view(1, 1, 1, -1, 1, 1)
+        + stds.view(1, 1, 1, -1, 1, 1) * k.view(1, 1, 1, -1, 1, 1)
+    ).expand(_BATCH, _FACE, TIMEDIM, -1, _HEIGHT, _WIDTH).contiguous()
+    znorm = _normalize_with(physical, variables, dtype=torch.float32)
+
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    coupler.set_coupled_fields(znorm)
+    out = coupler.construct_integrated_couplings().to(torch.float64)
+
+    means_o, stds_o = _stats(outgoing_keys)
+    # Physical average of constant field is the constant; renorm per slot.
+    for p in range(len(INPUT_TIMES)):
+        for v in range(len(variables)):
+            tv = p * len(variables) + v
+            phys_val = means[v] + stds[v] * k[v]
+            expected_z = (phys_val - means_o[tv]) / stds_o[tv]
+            got_mean = out[:, :, tv].mean().item()
+            assert abs(got_mean - expected_z.item()) < 1e-3, (
+                f"slot {tv} ({outgoing_keys[tv]}) got {got_mean:.4f}, "
+                f"expected {expected_z.item():.4f} — channel order bug?"
+            )
+
+
+def test_set_coupled_scaling():
+    generator = torch.Generator().manual_seed(_SEED + 70)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    assert coupler.use_coupled_field_rescaling
+    slices = coupler.averaging_slices
+    coupler.set_coupled_fields(znorm)
+    recovered = _denorm_timevar_with(
+        coupler.construct_integrated_couplings(), outgoing_keys
+    )
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+    assert _max_abs_err(recovered, physical_mean) < 1e-2
+
+
+def test_float32_cpu_dtype_and_device():
+    generator = torch.Generator().manual_seed(_SEED + 71)
+    physical = _sample_instant_physical(TIMEDIM, generator)
+    znorm = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    assert znorm.dtype == torch.float32
+    assert znorm.device.type == "cpu"
+
+    outgoing_keys = TRAILING_48H_VARS * len(INPUT_TIMES)
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    # Exercise denormalize / renormalize helpers directly.
+    denormed = coupler.denormalize_coupled_fields(znorm)
+    assert denormed.dtype == torch.float32
+    assert denormed.device.type == "cpu"
+
+    coupler.set_coupled_fields(znorm)
+    out = coupler.construct_integrated_couplings()
+    assert out.dtype == torch.float32
+    assert out.device.type == "cpu"
+    assert out.shape[2] == len(INSTANT_VARS) * len(INPUT_TIMES)
+
+
+def test_rescale_coupled_fields_through_physical_callable():
+    coupler = _make_trailing_coupler(
+        incoming=_yaml_scaling(),
+        outgoing=_yaml_scaling(),
+    )
+    # Minimal [B,F,T,C,H,W] with known z values.
+    fields = torch.zeros(
+        _BATCH, _FACE, 2, len(INSTANT_VARS), _HEIGHT, _WIDTH, dtype=torch.float32
+    )
+    fields[..., 0, :, :] = 1.0  # +1σ on z1000
+    fields[..., 1, :, :] = -2.0  # -2σ on ws10m
+
+    def identity_op(x):
+        return x  # keep C=n_var; outgoing was tiled to timevar, so need C match
+
+    # Outgoing was tiled to timevar_dim=4, so identity (C=2) should raise.
+    with pytest.raises(ValueError, match="channel count"):
+        coupler.rescale_coupled_fields_through_physical(fields, identity_op)
+
+    # Physical op that expands channels to timevar layout by repeating.
+    def expand_to_timevar(x):
+        return torch.cat([x, x], dim=3)
+
+    out = coupler.rescale_coupled_fields_through_physical(fields, expand_to_timevar)
+    assert out.shape[3] == coupler.timevar_dim
+    assert out.dtype == torch.float32
+
+
+def test_denormalize_without_scaling_raises():
+    coupler = _make_trailing_coupler(
+        variables=INSTANT_VARS, incoming_variables=INSTANT_VARS
+    )
+    fields = torch.zeros(
+        _BATCH, _FACE, 2, len(INSTANT_VARS), _HEIGHT, _WIDTH, dtype=torch.float32
+    )
+    with pytest.raises(RuntimeError, match="incoming_coupled_scaling"):
+        coupler.denormalize_coupled_fields(fields)
+    with pytest.raises(RuntimeError, match="outgoing_coupled_scaling"):
+        coupler.renormalize_coupled_fields(fields)

--- a/test/datapipes/test_healpix_coupler_instant_vs_trailing_scaling.py
+++ b/test/datapipes/test_healpix_coupler_instant_vs_trailing_scaling.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Instant vs trailing-mean scaling mismatch for TrailingAverageCoupler.
+
+Coupled ocean forcings (``sst-z1000-ws.yaml``) average atmospheric fields over
+48H / 96H windows. Instantaneous model outputs are typically z-scored with
+``z1000`` / ``ws10m`` stats, while the prepared trailing fields use
+``z1000-48H`` / ``ws10-48H``.
+
+These tests compare:
+
+1. **Physical trailing mean** (no normalization) — reference
+2. **Mismatched path**: z-norm with *instant* stats → average in z-space →
+   denorm with *trailing* stats (``-48H`` / synthetic ``-96H`` per period)
+3. **Matched path**: z-norm and denorm with the same trailing stats
+
+HPX64 only publishes ``*-48H`` trailing stats (no ``*-96H``). A synthetic
+``*-96H`` pair is included solely so the 96H input-time slot can use a
+distinct denorm, matching the user's requested instant→48H/96H setup.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+xr = pytest.importorskip("xarray")
+
+from physicsnemo.datapipes.healpix.couplers import TrailingAverageCoupler  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "znorm_stability",
+    Path(__file__).with_name("test_healpix_coupler_znorm_stability.py"),
+)
+_znorm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_znorm)
+
+HPX64_SCALING = _znorm.HPX64_SCALING
+_BATCH = _znorm._BATCH
+_FACE = _znorm._FACE
+_HEIGHT = _znorm._HEIGHT
+_WIDTH = _znorm._WIDTH
+_SEED = _znorm._SEED
+_broadcast_stats = _znorm._broadcast_stats
+_configure_trailing_average = _znorm._configure_trailing_average
+_make_dataset = _znorm._make_dataset
+_max_abs_err = _znorm._max_abs_err
+_reference_trailing_average = _znorm._reference_trailing_average
+
+# Instantaneous stats from hpx64.yaml
+INSTANT_VARS = ["z1000", "ws10m"]
+
+# Trailing-window stats from hpx64.yaml (48H only in the file)
+TRAILING_48H_VARS = ["z1000-48H", "ws10-48H"]
+
+# Synthetic 96H stats: longer window → mean between instant and 48H, slightly
+# smaller std. NOT in hpx64.yaml — used only for period-specific denorm demos.
+_SYNTHETIC_96H = {
+    "z1000-96H": (
+        0.5 * (HPX64_SCALING["z1000"][0] + HPX64_SCALING["z1000-48H"][0]),
+        HPX64_SCALING["z1000-48H"][1] * 0.92,
+    ),
+    "ws10-96H": (
+        0.5 * (HPX64_SCALING["ws10m"][0] + HPX64_SCALING["ws10-48H"][0]),
+        HPX64_SCALING["ws10-48H"][1] * 0.92,
+    ),
+}
+
+SCALING = {**HPX64_SCALING, **_SYNTHETIC_96H}
+
+# Period-major denorm keys for input_times ["48h", "96h"]
+# channel order after coupler: [p0_z1000, p0_ws10, p1_z1000, p1_ws10]
+TRAILING_DENORM_BY_PERIOD = [
+    ["z1000-48H", "ws10-48H"],  # 48h window
+    ["z1000-96H", "ws10-96H"],  # 96h window (synthetic)
+]
+
+
+def _stats(keys):
+    means = torch.tensor([SCALING[k][0] for k in keys], dtype=torch.float64)
+    stds = torch.tensor([SCALING[k][1] for k in keys], dtype=torch.float64)
+    return means, stds
+
+
+def _normalize_with(physical, keys, dtype=torch.float32):
+    means, stds = _stats(keys)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=3)
+    return ((physical - means_b) / stds_b).to(dtype)
+
+
+def _denorm_timevar_with(znorm, keys, dtype=torch.float64):
+    """Denorm time_first [I, B, timevar, ...] with one mean/std per timevar slot."""
+    means, stds = _stats(keys)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=2)
+    return znorm.to(dtype) * stds_b + means_b
+
+
+def _flatten_period_keys(period_keys):
+    """[[v0,v1], [v0,v1]] → [v0,v1,v0,v1] matching coupler timevar order."""
+    return [k for period in period_keys for k in period]
+
+
+def _sample_instant_physical(timedim, generator):
+    """Draw fields from instantaneous N(μ,σ) — like raw atmos output."""
+    means, stds = _stats(INSTANT_VARS)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=3)
+    noise = torch.randn(
+        _BATCH,
+        _FACE,
+        timedim,
+        len(INSTANT_VARS),
+        _HEIGHT,
+        _WIDTH,
+        dtype=torch.float64,
+        generator=generator,
+    )
+    return means_b + stds_b * noise
+
+
+def _run_trailing_average(physical_or_znorm, input_times=("48h", "96h")):
+    """Apply TrailingAverageCoupler.set_coupled_fields; return time_first tensor."""
+    # Coupler only needs spatial dims from the dataset; channel names are local.
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(INSTANT_VARS, n_time=64),
+        batch_size=_BATCH,
+        variables=INSTANT_VARS,
+        presteps=0,
+        averaging_window="48h",
+        input_times=list(input_times),
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    slices = _configure_trailing_average(
+        coupler, list(input_times), data_time_step="3h"
+    )
+    coupler.set_coupled_fields(physical_or_znorm.to(torch.float32))
+    return coupler.construct_integrated_couplings(), slices
+
+
+def test_mismatched_instant_norm_trailing_denorm_vs_physical_mean():
+    """Norm with z1000/ws10m, denorm with *-48H/*-96H ≠ physical trailing mean."""
+    generator = torch.Generator().manual_seed(_SEED + 10)
+    input_times = ("48h", "96h")
+    timedim = 40  # covers 96h / 3h = 32 steps
+    physical = _sample_instant_physical(timedim, generator)
+
+    # Reference: trailing mean in physical space (no normalization).
+    _, slices = _run_trailing_average(physical, input_times)
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+
+    # Mismatched path: instant z-norm → average → trailing denorm (48H/96H).
+    znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float32)
+    znorm_avg, _ = _run_trailing_average(znorm_instant, input_times)
+    denorm_keys = _flatten_period_keys(TRAILING_DENORM_BY_PERIOD)
+    mismatched = _denorm_timevar_with(znorm_avg, denorm_keys)
+
+    # Matched control: trailing-48H z-norm → average → same trailing-48H denorm.
+    # (Both periods use -48H here — the only trailing stats in hpx64.yaml.)
+    matched_keys_flat = TRAILING_48H_VARS * len(input_times)
+    znorm_trail = _normalize_with(physical, TRAILING_48H_VARS, dtype=torch.float32)
+    znorm_avg_matched, _ = _run_trailing_average(znorm_trail, input_times)
+    matched = _denorm_timevar_with(znorm_avg_matched, matched_keys_flat)
+
+    err_mismatch = _max_abs_err(mismatched, physical_mean)
+    err_matched = _max_abs_err(matched, physical_mean)
+
+    # Systematic bias from μ/σ swap should dwarf float32 noise.
+    assert err_mismatch > 1.0, (
+        f"expected large systematic error from instant↔trailing stat mismatch, "
+        f"got {err_mismatch:.3e}"
+    )
+    assert err_matched < 1e-2, (
+        f"matched trailing stats should recover physical mean, got {err_matched:.3e}"
+    )
+    assert err_mismatch > 100 * err_matched
+
+
+def test_mismatched_error_is_dominated_by_mean_shift():
+    """Closed-form check: denorm_t(mean(norm_i(x))) bias follows the affine map."""
+    generator = torch.Generator().manual_seed(_SEED + 11)
+    input_times = ("48h", "96h")
+    timedim = 40
+    physical = _sample_instant_physical(timedim, generator)
+
+    _, slices = _run_trailing_average(physical, input_times)
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+
+    znorm_instant = _normalize_with(physical, INSTANT_VARS, dtype=torch.float64)
+    # Average in float64 to isolate scaling mismatch from float32 noise.
+    znorm_avg = _reference_trailing_average(
+        znorm_instant, slices, dtype=torch.float64
+    )
+    denorm_keys = _flatten_period_keys(TRAILING_DENORM_BY_PERIOD)
+    mismatched = _denorm_timevar_with(znorm_avg, denorm_keys)
+
+    means_i, stds_i = _stats(INSTANT_VARS)
+    # Per timevar slot: period-major [z1000, ws10, z1000, ws10]
+    for p, period_keys in enumerate(TRAILING_DENORM_BY_PERIOD):
+        for v, trail_key in enumerate(period_keys):
+            tv = p * len(INSTANT_VARS) + v
+            mu_i, sig_i = means_i[v], stds_i[v]
+            mu_t, sig_t = SCALING[trail_key]
+            # predicted = (mean_x - μ_i) / σ_i * σ_t + μ_t
+            predicted = (physical_mean[:, :, tv] - mu_i) / sig_i * sig_t + mu_t
+            got = mismatched[:, :, tv]
+            assert torch.allclose(got, predicted, rtol=0, atol=1e-9), (
+                f"slot {trail_key}@{['48h','96h'][p]} affine mismatch"
+            )
+
+
+def test_per_channel_mismatch_errors_reported():
+    """Collect per-slot errors for charting / presentation."""
+    generator = torch.Generator().manual_seed(42)
+    input_times = ("48h", "96h")
+    physical = _sample_instant_physical(40, generator)
+
+    _, slices = _run_trailing_average(physical, input_times)
+    physical_mean = _reference_trailing_average(
+        physical, slices, dtype=torch.float64
+    )
+
+    znorm_avg, _ = _run_trailing_average(
+        _normalize_with(physical, INSTANT_VARS, dtype=torch.float32),
+        input_times,
+    )
+    mismatched = _denorm_timevar_with(
+        znorm_avg, _flatten_period_keys(TRAILING_DENORM_BY_PERIOD)
+    )
+
+    matched_avg, _ = _run_trailing_average(
+        _normalize_with(physical, TRAILING_48H_VARS, dtype=torch.float32),
+        input_times,
+    )
+    matched = _denorm_timevar_with(matched_avg, TRAILING_48H_VARS * 2)
+
+    periods = ["48h", "96h"]
+    rows = []
+    for p, period in enumerate(periods):
+        for v, instant_key in enumerate(INSTANT_VARS):
+            tv = p * len(INSTANT_VARS) + v
+            trail_key = TRAILING_DENORM_BY_PERIOD[p][v]
+            err_m = (mismatched[:, :, tv] - physical_mean[:, :, tv]).abs()
+            err_ok = (matched[:, :, tv] - physical_mean[:, :, tv]).abs()
+            rows.append(
+                {
+                    "period": period,
+                    "instant": instant_key,
+                    "trailing": trail_key,
+                    "mismatch_max": err_m.max().item(),
+                    "mismatch_mean": err_m.mean().item(),
+                    "matched_max": err_ok.max().item(),
+                    "physical_std": physical_mean[:, :, tv].std().item(),
+                }
+            )
+
+    # z1000 mismatch should be O(10–100+) in geopotential meters given μ/σ swap.
+    z_rows = [r for r in rows if r["instant"] == "z1000"]
+    assert all(r["mismatch_max"] > 1.0 for r in z_rows)
+    assert all(r["matched_max"] < 1e-2 for r in rows)

--- a/test/datapipes/test_healpix_coupler_znorm_stability.py
+++ b/test/datapipes/test_healpix_coupler_znorm_stability.py
@@ -1,0 +1,473 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerical-stability tests for coupler ``set_coupled_fields`` in z-norm space.
+
+Inference feeds already z-normalized tensors into ``set_coupled_fields``.
+``TrailingAverageCoupler`` then averages over time in that normalized space.
+For an affine transform ``(x - mean) / std`` this is algebraically equivalent to
+averaging in physical space and then normalizing, but float32 arithmetic with
+HPX64-scale means/stds (e.g. ``ttr`` ~ 1e6 vs ``q850`` ~ 1e-3) can diverge.
+
+These tests draw random physical fields from the distributions in
+``NV-dlesm/configs/data/scaling/hpx64.yaml`` and compare:
+
+1. Coupler average in float32 z-norm space (production path)
+2. float64 physical average, then normalize (high-accuracy reference)
+3. float32 physical average, then normalize (physical-space float32 path)
+
+so the magnitude of any z-norm vs physical discrepancy is explicit.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+xr = pytest.importorskip("xarray")
+
+from physicsnemo.datapipes.healpix.couplers import (  # noqa: E402
+    ConstantCoupler,
+    TrailingAverageCoupler,
+)
+
+# Subset of NV-dlesm/configs/data/scaling/hpx64.yaml used by coupled configs.
+# Values are (mean, std) in physical units.
+HPX64_SCALING = {
+    "sst": (291.37762451171875, 10.202408790588379),
+    "z1000": (937.166748046875, 901.9874877929688),
+    "z1000-48H": (934.4945, 842.1188),
+    "ws10m": (6.144942283630371, 3.6602368354797363),
+    "ws10-48H": (6.081215, 3.1224248),
+    "ttr": (-872297.06, 166696.2),
+    "ttr-3h": (-2617476.9631782947, 494939.84),
+    "t2m": (287.40704345703125, 15.39192008972168),
+    "q850": (0.005995592568069696, 0.004197916481643915),
+    "sic": (0.0, 1.0),
+}
+
+_FACE, _HEIGHT, _WIDTH = 4, 8, 8
+_BATCH = 2
+_SEED = 0
+
+
+def _means_stds(variables):
+    means = torch.tensor([HPX64_SCALING[v][0] for v in variables], dtype=torch.float64)
+    stds = torch.tensor([HPX64_SCALING[v][1] for v in variables], dtype=torch.float64)
+    return means, stds
+
+
+def _timevar_means_stds(variables, n_input_times):
+    """Tile per-variable stats across TrailingAverage's period-major timevar axis.
+
+    Channel order after ``set_coupled_fields`` is
+    ``[period0_var0, period0_var1, ..., period1_var0, ...]``.
+    """
+    means, stds = _means_stds(variables)
+    return means.repeat(n_input_times), stds.repeat(n_input_times)
+
+
+def _broadcast_stats(means, stds, ndim=6, channel_dim=3):
+    """Reshape (C,) stats to broadcast over a 6-D tensor."""
+    shape = [1] * ndim
+    shape[channel_dim] = -1
+    return means.view(*shape), stds.view(*shape)
+
+
+def _sample_physical(variables, timedim, generator):
+    """Draw ~N(mean, std) physical fields in float64, shape [B, F, T, C, H, W]."""
+    means, stds = _means_stds(variables)
+    means_b, stds_b = _broadcast_stats(means, stds)
+    noise = torch.randn(
+        _BATCH,
+        _FACE,
+        timedim,
+        len(variables),
+        _HEIGHT,
+        _WIDTH,
+        dtype=torch.float64,
+        generator=generator,
+    )
+    return means_b + stds_b * noise
+
+
+def _normalize(physical, variables, dtype=torch.float32):
+    means, stds = _means_stds(variables)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=3)
+    return ((physical - means_b) / stds_b).to(dtype)
+
+
+def _denormalize_timevar(znorm, variables, n_input_times, dtype=torch.float64):
+    """Denormalize a time_first coupler output ``[I, B, timevar, F, H, W]``."""
+    means, stds = _timevar_means_stds(variables, n_input_times)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=2)
+    return znorm.to(dtype) * stds_b + means_b
+
+
+def _normalize_timevar(physical_avg, variables, n_input_times, dtype=torch.float32):
+    """Normalize a time_first averaged tensor ``[I, B, timevar, F, H, W]``."""
+    means, stds = _timevar_means_stds(variables, n_input_times)
+    means_b, stds_b = _broadcast_stats(means, stds, channel_dim=2)
+    return ((physical_avg - means_b) / stds_b).to(dtype)
+
+
+def _make_dataset(variables, n_time=32):
+    return xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("time", "channel_in", "face", "height", "width"),
+                np.zeros(
+                    (n_time, len(variables), _FACE, _HEIGHT, _WIDTH),
+                    dtype="float32",
+                ),
+            )
+        },
+        coords={
+            "time": pd.date_range("1979-01-01", periods=n_time, freq="3h"),
+            "channel_in": list(variables),
+            "face": np.arange(_FACE),
+            "height": np.arange(_HEIGHT),
+            "width": np.arange(_WIDTH),
+        },
+    )
+
+
+def _configure_trailing_average(coupler, input_times, data_time_step="3h"):
+    averaging_window_max_indices = [
+        pd.Timedelta(t) // pd.Timedelta(data_time_step) for t in input_times
+    ]
+    di = averaging_window_max_indices[0]
+    averaging_slices = []
+    for j in range(coupler.coupled_integration_dim):
+        averaging_slices.append([])
+        for i, r in enumerate(averaging_window_max_indices):
+            averaging_slices[j].append(
+                slice(
+                    coupler.input_time_dim * j * di + i * di,
+                    coupler.input_time_dim * j * di + r,
+                )
+            )
+    coupler.averaging_slices = averaging_slices
+    coupler.coupled_channel_indices = list(range(len(coupler.variables)))
+    return averaging_slices
+
+
+def _reference_trailing_average(physical, averaging_slices, dtype):
+    """Mirror TrailingAverageCoupler.set_coupled_fields averaging in ``dtype``."""
+    fields = physical.to(dtype)
+    periods = []
+    for slices in averaging_slices:
+        averaged = [
+            fields[:, :, s, :, :, :].mean(dim=2, keepdim=True) for s in slices
+        ]
+        periods.append(torch.concat(averaged, dim=3))
+    # [B, F, integration, timevar, H, W] -> [integration, B, timevar, F, H, W]
+    return torch.concat(periods, dim=2).permute(2, 0, 3, 1, 4, 5)
+
+
+def _max_abs_err(a, b):
+    return (a - b).abs().max().item()
+
+
+def _per_channel_max_abs(a, b, variables):
+    """Max abs error per channel; ``a``/``b`` are [I, B, C, F, H, W]."""
+    return {
+        var: (a[:, :, i] - b[:, :, i]).abs().max().item()
+        for i, var in enumerate(variables)
+    }
+
+
+@pytest.mark.parametrize(
+    "variables",
+    [
+        # Typical ocean->atmos ConstantCoupler field
+        ["sst"],
+        # Trailing-average ocean forcings from sst-z1000-ws.yaml
+        ["z1000-48H", "ws10-48H"],
+        # Wide dynamic range: OLM-scale OLR vs humidity vs SST
+        ["ttr", "q850", "sst"],
+        # Accumulated TTR is even larger in magnitude
+        ["ttr-3h", "z1000", "ws10m"],
+    ],
+)
+def test_trailing_average_znorm_matches_physical_float64_reference(variables):
+    """Production z-norm float32 average should match float64 physical reference."""
+    generator = torch.Generator().manual_seed(_SEED)
+    input_times = ["6h", "12h"]
+    # Need enough timesteps for the longest averaging window end (12h / 3h = 4)
+    timedim = 8
+    physical = _sample_physical(variables, timedim, generator)
+
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(variables),
+        batch_size=_BATCH,
+        variables=variables,
+        presteps=0,
+        averaging_window="6h",
+        input_times=input_times,
+        input_time_dim=2,
+        output_time_dim=2,
+    )
+    averaging_slices = _configure_trailing_average(coupler, input_times)
+
+    znorm_f32 = _normalize(physical, variables, dtype=torch.float32)
+    coupler.set_coupled_fields(znorm_f32)
+    got = coupler.construct_integrated_couplings()
+
+    # Reference: average in physical float64, then normalize.
+    phys_avg_f64 = _reference_trailing_average(
+        physical, averaging_slices, dtype=torch.float64
+    )
+    ref = _normalize_timevar(
+        phys_avg_f64, variables, n_input_times=len(input_times), dtype=torch.float32
+    )
+
+    per_channel = _per_channel_max_abs(got, ref, variables * len(input_times))
+    max_err = _max_abs_err(got, ref)
+
+    # Affine equivalence should keep z-norm float32 within a few ULPs of the
+    # float64 physical reference for O(1) standardized values. Extreme
+    # physical magnitudes (ttr) still stay well under 1e-5 in z-space.
+    assert max_err < 1e-5, (
+        f"z-norm TrailingAverage diverged from physical float64 reference: "
+        f"max_err={max_err:.3e}, per_channel={per_channel}"
+    )
+
+
+@pytest.mark.parametrize(
+    "variables",
+    [
+        ["sst"],
+        ["z1000-48H", "ws10-48H"],
+        ["ttr", "q850", "sst"],
+        ["ttr-3h", "z1000", "ws10m"],
+    ],
+)
+def test_trailing_average_znorm_vs_physical_float32_error(variables):
+    """Quantify whether z-norm float32 averaging is stabler than physical float32.
+
+    Both are compared against a float64 physical reference. For large-magnitude
+    variables (``ttr``, ``ttr-3h``), averaging in physical float32 before
+    normalizing typically accumulates more error than averaging already
+    standardized values.
+    """
+    generator = torch.Generator().manual_seed(_SEED + 1)
+    input_times = ["6h", "12h"]
+    timedim = 8
+    physical = _sample_physical(variables, timedim, generator)
+
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(variables),
+        batch_size=_BATCH,
+        variables=variables,
+        presteps=0,
+        averaging_window="6h",
+        input_times=input_times,
+        input_time_dim=2,
+        output_time_dim=2,
+    )
+    averaging_slices = _configure_trailing_average(coupler, input_times)
+    n_times = len(input_times)
+    timevar_names = variables * n_times
+
+    # Production path
+    coupler.set_coupled_fields(_normalize(physical, variables, dtype=torch.float32))
+    znorm_path = coupler.construct_integrated_couplings().to(torch.float64)
+
+    # Physical float32 path: cast -> average -> normalize
+    phys_avg_f32 = _reference_trailing_average(
+        physical, averaging_slices, dtype=torch.float32
+    ).to(torch.float64)
+    physical_f32_path = _normalize_timevar(
+        phys_avg_f32, variables, n_input_times=n_times, dtype=torch.float64
+    )
+
+    # Reference
+    phys_avg_f64 = _reference_trailing_average(
+        physical, averaging_slices, dtype=torch.float64
+    )
+    reference = _normalize_timevar(
+        phys_avg_f64, variables, n_input_times=n_times, dtype=torch.float64
+    )
+
+    err_znorm = _max_abs_err(znorm_path, reference)
+    err_physical_f32 = _max_abs_err(physical_f32_path, reference)
+    per_channel_znorm = _per_channel_max_abs(znorm_path, reference, timevar_names)
+    per_channel_phys = _per_channel_max_abs(physical_f32_path, reference, timevar_names)
+
+    # z-norm path should never be dramatically worse than physical float32.
+    assert err_znorm <= err_physical_f32 * 2.0 + 1e-7, (
+        f"z-norm averaging unexpectedly less stable than physical float32: "
+        f"err_znorm={err_znorm:.3e}, err_physical_f32={err_physical_f32:.3e}, "
+        f"per_channel_znorm={per_channel_znorm}, per_channel_phys={per_channel_phys}"
+    )
+
+
+def test_trailing_average_ocean_forcing_config_znorm_roundtrip():
+    """sst-z1000-ws style TrailingAverageCoupler: z-norm avg denorms to physical avg."""
+    variables = ["z1000-48H", "ws10-48H"]
+    # Match configs/data/module/sst-z1000-ws.yaml cadence with a compact window
+    # that still exercises multi-step averaging on 3h data.
+    input_times = ["48h", "96h"]
+    data_time_step = "3h"
+    # longest window end is 96h / 3h = 32 steps
+    timedim = 40
+    generator = torch.Generator().manual_seed(42)
+    physical = _sample_physical(variables, timedim, generator)
+
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(variables, n_time=64),
+        batch_size=_BATCH,
+        variables=variables,
+        presteps=0,
+        averaging_window="48h",
+        input_times=input_times,
+        input_time_dim=1,
+        output_time_dim=1,
+    )
+    averaging_slices = _configure_trailing_average(
+        coupler, input_times, data_time_step=data_time_step
+    )
+
+    coupler.set_coupled_fields(_normalize(physical, variables, dtype=torch.float32))
+    znorm_avg = coupler.construct_integrated_couplings()
+    denormed = _denormalize_timevar(
+        znorm_avg, variables, n_input_times=len(input_times), dtype=torch.float64
+    )
+
+    phys_avg = _reference_trailing_average(
+        physical, averaging_slices, dtype=torch.float64
+    )
+    # Coupler returns time_first [I, B, timevar, F, H, W]; reference matches that layout.
+    max_err = _max_abs_err(denormed, phys_avg)
+    per_channel = _per_channel_max_abs(
+        denormed, phys_avg, variables * len(input_times)
+    )
+
+    # Physical units: z1000-48H std ~ 840, ws10-48H std ~ 3. Allow a small
+    # absolute error after the float32 z-norm roundtrip.
+    assert max_err < 1e-2, (
+        f"denorm(z-norm average) drifted from physical average: "
+        f"max_err={max_err:.3e}, per_channel={per_channel}"
+    )
+
+
+@pytest.mark.parametrize(
+    "variables",
+    [
+        ["sst"],
+        ["sst", "sic"],
+        ["ttr", "q850", "sst"],
+    ],
+)
+def test_constant_coupler_preserves_znorm_values(variables):
+    """ConstantCoupler must not corrupt z-norm fields when broadcasting time 0."""
+    generator = torch.Generator().manual_seed(_SEED + 2)
+    timedim = 4
+    physical = _sample_physical(variables, timedim, generator)
+    znorm = _normalize(physical, variables, dtype=torch.float32)
+
+    coupler = ConstantCoupler(
+        dataset=_make_dataset(variables),
+        batch_size=_BATCH,
+        variables=variables,
+        input_times=["0h"],
+        input_time_dim=1,
+        output_time_dim=3,
+        presteps=0,
+    )
+    coupler.coupled_channel_indices = list(range(len(variables)))
+    coupler.set_coupled_fields(znorm)
+    out = coupler.construct_integrated_couplings()
+
+    # time_first layout: [integration, B, C, F, H, W]
+    expected = znorm[:, :, :1, :, :, :].permute(2, 0, 3, 1, 4, 5)
+    expected = expected.expand(coupler.coupled_integration_dim, -1, -1, -1, -1, -1)
+
+    assert out.shape[0] == coupler.coupled_integration_dim
+    assert torch.equal(out, expected), (
+        f"ConstantCoupler altered z-norm values: "
+        f"max_err={_max_abs_err(out, expected):.3e}, "
+        f"per_channel={_per_channel_max_abs(out, expected, variables)}"
+    )
+
+
+def test_mixed_scale_channels_remain_independent_in_znorm_average():
+    """Channels with wildly different physical scales must not leak into each other."""
+    variables = ["ttr-3h", "q850", "sst"]
+    generator = torch.Generator().manual_seed(7)
+    input_times = ["6h", "12h"]
+    timedim = 8
+
+    # Construct physical fields with *independent* constant-per-channel values
+    # so any cross-channel bleed is obvious after averaging.
+    means, stds = _means_stds(variables)
+    # Use mean + k*std so each channel is exactly k in z-space.
+    k = torch.tensor([-2.0, 0.5, 1.25], dtype=torch.float64)
+    physical = (
+        means.view(1, 1, 1, -1, 1, 1) + stds.view(1, 1, 1, -1, 1, 1) * k.view(1, 1, 1, -1, 1, 1)
+    ).expand(_BATCH, _FACE, timedim, -1, _HEIGHT, _WIDTH).contiguous()
+    # Add small independent noise so the average is not trivially constant in time
+    noise = torch.randn(
+        _BATCH,
+        _FACE,
+        timedim,
+        len(variables),
+        _HEIGHT,
+        _WIDTH,
+        dtype=torch.float64,
+        generator=generator,
+    )
+    physical = physical + stds.view(1, 1, 1, -1, 1, 1) * 0.01 * noise
+
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(variables),
+        batch_size=_BATCH,
+        variables=variables,
+        presteps=0,
+        averaging_window="6h",
+        input_times=input_times,
+        input_time_dim=2,
+        output_time_dim=2,
+    )
+    averaging_slices = _configure_trailing_average(coupler, input_times)
+
+    coupler.set_coupled_fields(_normalize(physical, variables, dtype=torch.float32))
+    got = coupler.construct_integrated_couplings().to(torch.float64)
+
+    phys_avg = _reference_trailing_average(
+        physical, averaging_slices, dtype=torch.float64
+    )
+    ref = _normalize_timevar(
+        phys_avg, variables, n_input_times=len(input_times), dtype=torch.float64
+    )
+
+    for period in range(len(input_times)):
+        for i, var in enumerate(variables):
+            timevar_idx = period * len(variables) + i
+            err = (got[:, :, timevar_idx] - ref[:, :, timevar_idx]).abs().max().item()
+            assert err < 1e-5, (
+                f"channel {var!r} period {period} leaked or drifted: err={err:.3e}"
+            )
+            # Each channel's mean z-value should stay near its planted k, not near
+            # another channel's k (guards against last-channel / order bugs).
+            channel_mean = got[:, :, timevar_idx].mean().item()
+            assert abs(channel_mean - k[i].item()) < 0.05, (
+                f"channel {var!r} period {period} mean z={channel_mean:.4f} drifted "
+                f"from planted k={k[i].item():.4f} toward another channel"
+            )


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# Modulus Pull Request

## Description
This PR adds the ability to rescale data through physical space when processing coupled data. The existing coupler processes data across components without regards to the normalization used in the source or destination component. This results in a distribution shift when normalization values change or when data is processed such as when computing trailing mean. 

The original flow was:
data _in -> operation -> data_out

When enebled the new flow is:
data _in -> float32 -> denorm -> operation -> renorm -> restore dtype -> data_out

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/modulus/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/modulus/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/modulus/issues) is linked to this pull request.

## Dependencies

<!-- Call out any new dependencies needed if any -->