### PR TITLE
Skip output-only diagnostic channels in forecast-mode zarr dataset checks

### DIFF
--- a/physicsnemo/datapipes/healpix/base_timeseries_dataset_zarr.py
+++ b/physicsnemo/datapipes/healpix/base_timeseries_dataset_zarr.py
@@ -177,6 +177,14 @@ class BaseTimeSeriesDatasetZarr(Dataset, Datapipe, ABC):
         self.all_variables = list(
             set(self.input_variables).union(self.output_variables)
         )
+        # Channels jointly loaded/scaled from the store. Forecast/inference only
+        # reads ICs, so output-only diagnostics need not exist in the dataset;
+        # training still stages input ∪ output for supervised targets.
+        self.staging_variables = (
+            list(self.input_variables)
+            if self.forecast_mode
+            else self.all_variables
+        )
         self.all_scaling = None
 
         # Check if for fsspec if necessary and make sure path exist
@@ -191,9 +199,8 @@ class BaseTimeSeriesDatasetZarr(Dataset, Datapipe, ABC):
                 "Either start and end date or forecast_init_times must be provided"
             )
 
-        # Validate channels exist
-        channels = set(self.input_variables).union(self.output_variables)
-        missing_channels = channels - set(self.ds["channel_in"][:])
+        # Validate channels that will actually be read from the store.
+        missing_channels = set(self.staging_variables) - set(self.ds["channel_in"][:])
         if len(missing_channels) > 0:
             raise KeyError(
                 f"Requested Input, coupled, or output variables not found in dataset: {missing_channels}"
@@ -203,7 +210,7 @@ class BaseTimeSeriesDatasetZarr(Dataset, Datapipe, ABC):
 
         self.all_variable_indices = [
             int(np.where(self.ds["channel_in"][:] == ch)[0][0])
-            for ch in self.all_variables
+            for ch in self.staging_variables
         ]
 
         # Validate constants exist
@@ -223,11 +230,17 @@ class BaseTimeSeriesDatasetZarr(Dataset, Datapipe, ABC):
             else None
         )
         self.input_variable_indices = [
-            self.all_variables.index(inp_ch) for inp_ch in self.input_variables
+            self.staging_variables.index(inp_ch) for inp_ch in self.input_variables
         ]
-        self.output_variable_indices = [
-            self.all_variables.index(out_ch) for out_ch in self.output_variables
-        ]
+        # Output indices are only used when loading supervised targets.
+        self.output_variable_indices = (
+            None
+            if self.forecast_mode
+            else [
+                self.staging_variables.index(out_ch)
+                for out_ch in self.output_variables
+            ]
+        )
 
         # Length of the data window needed for one sample
         if self.forecast_mode:
@@ -451,7 +464,8 @@ class BaseTimeSeriesDatasetZarr(Dataset, Datapipe, ABC):
                 f"Target channels {missing} not found in the scaling config dict data.scaling ({list(self.scaling.keys())})"
             )
 
-        self.all_scaling = scaling_da.sel(index=self.all_variables).rename(
+        # Align mean/std with the staged channel axis used in __getitem__.
+        self.all_scaling = scaling_da.sel(index=self.staging_variables).rename(
             {"index": "channel_in"}
         )
         self.all_scaling = {

--- a/test/datapipes/test_healpix_zarr.py
+++ b/test/datapipes/test_healpix_zarr.py
@@ -28,6 +28,7 @@ from physicsnemo.distributed import DistributedManager
 
 omegaconf = pytest.importorskip("omegaconf")
 np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
 xr = pytest.importorskip("xarray")
 zarr = pytest.importorskip("zarr")
 
@@ -146,6 +147,88 @@ def test_TimeSeriesDataset_missing_time(tmp_path):
             start_date="1979-01-01",
             end_date="1979-01-02",
         )
+
+
+def _make_minimal_healpix_zarr(path, channel_in, n_time=8):
+    """Write a tiny monolithic HEALPix zarr suitable for TimeSeriesDatasetZarr."""
+    face, height, width = 1, 2, 2
+    times = pd.date_range("1979-01-01", periods=n_time, freq="6h")
+    n_chan = len(channel_in)
+    ds = xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("time", "channel_in", "face", "height", "width"),
+                np.zeros((n_time, n_chan, face, height, width), dtype="float32"),
+            ),
+            "targets": (
+                ("time", "channel_out", "face", "height", "width"),
+                np.zeros((n_time, n_chan, face, height, width), dtype="float32"),
+            ),
+            "lat": (("face", "height", "width"), np.zeros((face, height, width))),
+            "lon": (("face", "height", "width"), np.zeros((face, height, width))),
+        },
+        coords={
+            "time": times,
+            "channel_in": list(channel_in),
+            "channel_out": list(channel_in),
+            "face": np.arange(face),
+            "height": np.arange(height),
+            "width": np.arange(width),
+        },
+    )
+    ds.to_zarr(path)
+    return times
+
+
+def test_TimeSeriesDataset_forecast_skips_missing_diagnostic_channels(tmp_path):
+    """Forecast mode must not require output-only diagnostics in the IC store."""
+    from physicsnemo.datapipes.healpix.timeseries_dataset_zarr import (
+        TimeSeriesDatasetZarr,
+    )
+
+    input_variables = ["z500", "t2m0"]
+    diagnostic = "diag_only"
+    output_variables = input_variables + [diagnostic]
+    dataset_path = tmp_path / "forecast_diag.zarr"
+    times = _make_minimal_healpix_zarr(dataset_path, channel_in=input_variables)
+    scaling = omegaconf.DictConfig(
+        {
+            "z500": {"mean": 0.0, "std": 1.0},
+            "t2m0": {"mean": 0.0, "std": 1.0},
+            diagnostic: {"mean": 0.0, "std": 1.0},
+        }
+    )
+
+    # Training still needs every output variable present in the store.
+    with pytest.raises(
+        KeyError,
+        match=("not found in dataset"),
+    ):
+        TimeSeriesDatasetZarr(
+            dataset_path=str(dataset_path),
+            data_time_step="6h",
+            time_step="6h",
+            scaling=scaling,
+            input_variables=input_variables,
+            output_variables=output_variables,
+            start_date="1979-01-01",
+            end_date="1979-01-02",
+            batch_size=1,
+        )
+
+    forecast_ds = TimeSeriesDatasetZarr(
+        dataset_path=str(dataset_path),
+        data_time_step="6h",
+        time_step="6h",
+        scaling=scaling,
+        input_variables=input_variables,
+        output_variables=output_variables,
+        forecast_init_times=times[:2],
+        batch_size=1,
+    )
+    sample = forecast_ds[0]
+    assert isinstance(sample, list)
+    assert sample[0].shape[3] == len(input_variables)
 
 
 @import_or_fail("omegaconf")


### PR DESCRIPTION
## Description
Forecast/inference HEALPix zarr datasets only load initial-condition inputs, but construction previously required every `output_variables` name to exist in the store. That blocked inference when models declare diagnostic-only outputs (e.g. `tp-6h`) that are predicted rather than read from the IC dataset.

This change stages and validates **input channels only** when `forecast_init_times` is set (`forecast_mode`). Training still requires the full `input ∪ output` set in the store. Adds a regression test that forecast construction succeeds with a missing diagnostic channel while training still raises `KeyError`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] The [CHANGELOG.md](https://github.com/NVIDIA/physicsnemo/blob/main/CHANGELOG.md) is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo/issues) is linked to this pull request.

## Dependencies

None.