### PR TITLE
Add a shared differentiable coupling op for HEALPix couplers

### DIFF
--- a/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
+++ b/physicsnemo/datapipes/healpix/coupledtimeseries_dataset.py
@@ -30,6 +30,7 @@ from physicsnemo.datapipes.meta import DatapipeMetaData
 from physicsnemo.utils.insolation import insolation
 
 from . import couplers
+from .coupling_ops import concat_integrated_couplings
 from .timeseries_dataset import TimeSeriesDataset
 
 logger = logging.getLogger(__name__)
@@ -365,10 +366,7 @@ class CoupledTimeSeriesDataset(TimeSeriesDataset):
 
         # append couplings inputs
         if len(self.couplings) > 0:
-            integrated_couplings = np.concatenate(
-                [c.construct_integrated_couplings() for c in self.couplings], axis=2
-            )
-            inputs_result.append(torch.tensor(integrated_couplings))
+            inputs_result.append(concat_integrated_couplings(self.couplings))
 
         # gather coupled_inputs
         return inputs_result

--- a/physicsnemo/datapipes/healpix/couplers.py
+++ b/physicsnemo/datapipes/healpix/couplers.py
@@ -59,6 +59,15 @@ import torch as th
 import xarray as xr
 import zarr as zr
 
+from physicsnemo.datapipes.healpix.coupling_ops import (
+    CONSTANT,
+    TRAILING_AVERAGE,
+    CouplingOp,
+    denormalize,
+    renormalize,
+    rescale_through_physical,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,6 +77,10 @@ class BaseCoupler(ABC):
 
     This class contains common functionality shared by different coupler implementations.
     """
+
+    #: Coupling strategy this class implements, one of the mode names in
+    #: :mod:`physicsnemo.datapipes.healpix.coupling_ops`. Set by subclasses.
+    coupling_method: str = None
 
     def __init__(
         self,
@@ -131,6 +144,9 @@ class BaseCoupler(ABC):
         self.integrated_couplings = None
         self.ds_variable_indices = []
         self.time_first = time_first
+        # Ops built by coupling_op(), keyed by rescale_in_physical_space. Built
+        # lazily and dropped whenever the configuration they captured changes.
+        self._coupling_ops = {}
         self.incoming_coupled_scaling = None
         self.outgoing_coupled_scaling = None
         # Set by setup_coupling: source-module channel names for denorm lookups,
@@ -211,6 +227,34 @@ class BaseCoupler(ABC):
             "std": np.expand_dims(coupled_scaling["std"].to_numpy(), (0, 2, 3, 4)),
         }
 
+    def _invalidate_coupling_ops(self):
+        """Drop cached ops so the next :meth:`coupling_op` rebuilds them.
+
+        Called whenever state that :meth:`CouplingOp.from_coupler` captures
+        changes, so a cached op can never outlive the configuration it read.
+        """
+        self._coupling_ops.clear()
+
+    @property
+    def incoming_coupled_scaling(self):
+        """Statistics that normalized the source component's fields, or None."""
+        return self._incoming_coupled_scaling
+
+    @incoming_coupled_scaling.setter
+    def incoming_coupled_scaling(self, scaling):
+        self._incoming_coupled_scaling = scaling
+        self._invalidate_coupling_ops()
+
+    @property
+    def outgoing_coupled_scaling(self):
+        """Statistics used to renormalize the coupled result, or None."""
+        return self._outgoing_coupled_scaling
+
+    @outgoing_coupled_scaling.setter
+    def outgoing_coupled_scaling(self, scaling):
+        self._outgoing_coupled_scaling = scaling
+        self._invalidate_coupling_ops()
+
     def set_coupled_scaling(self, incoming_coupled_scaling):
         """Set incoming denorm stats; outgoing renorm uses ``coupled_scaling`` tiled.
 
@@ -272,25 +316,14 @@ class BaseCoupler(ABC):
             "std": th.as_tensor(std).view(1, 1, 1, -1, 1, 1),
         }
 
-    @staticmethod
-    def _denormalize(x: th.Tensor, scaling: dict) -> th.Tensor:
-        mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
-        std = scaling["std"].to(device=x.device, dtype=x.dtype)
-        return x * std + mean
-
-    @staticmethod
-    def _renormalize(x: th.Tensor, scaling: dict) -> th.Tensor:
-        mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
-        std = scaling["std"].to(device=x.device, dtype=x.dtype)
-        return (x - mean) / std
+    _denormalize = staticmethod(denormalize)
+    _renormalize = staticmethod(renormalize)
 
     def rescale_coupled_fields_through_physical(
         self, coupled_fields: th.Tensor, physical_op
     ) -> th.Tensor:
         """
         Rescale coupled fields through physical space.
-        Fields may overflow when denormalized, so we run in float32 mid-flight.
-        float32 → Denorm → ``physical_op`` → renorm → restore input dtype.
 
         Parameters
         ----------
@@ -299,28 +332,54 @@ class BaseCoupler(ABC):
         physical_op: callable
             The physical operation to apply to the coupled fields.
         """
-        orig_dtype = coupled_fields.dtype
-        physical_fields = self._denormalize(
-            coupled_fields.float(), self.incoming_coupled_scaling
+        return rescale_through_physical(
+            coupled_fields,
+            physical_op,
+            self.incoming_coupled_scaling,
+            self.outgoing_coupled_scaling,
         )
-        transformed_fields = physical_op(physical_fields)
-        normalized_fields = self._renormalize(
-            transformed_fields, self.outgoing_coupled_scaling
-        )
-        return normalized_fields.to(dtype=orig_dtype)
 
-    def _store_preset_coupled_fields(self, coupled_fields: th.Tensor, physical_op):
-        """Index channels, optionally rescale through physical space, then store."""
-        coupled_fields = coupled_fields[:, :, :, self.coupled_channel_indices, :, :]
-        if self.incoming_coupled_scaling is not None:
-            preset = self.rescale_coupled_fields_through_physical(
-                coupled_fields, physical_op
+    def coupling_op(self, rescale_in_physical_space: bool = True) -> CouplingOp:
+        """Return this coupler's coupling as a standalone differentiable module.
+
+        The returned :class:`~physicsnemo.datapipes.healpix.coupling_ops.CouplingOp`
+        carries the coupler's channel indices, time reduction, and scaling
+        statistics, so callers that need to couple fields inside an autograd
+        graph (distributed inference, coupled training) can run exactly what the
+        dataloader runs instead of reimplementing it.
+
+        The op is built once per ``rescale_in_physical_space`` value and cached,
+        because ``set_coupled_fields`` runs this on every dataloader step and
+        constructing an :class:`~torch.nn.Module` per step is pure overhead.
+        Reconfiguring the coupler drops the cache, so the op cannot go stale. As
+        a consequence the instance is shared between callers: moving it with
+        ``.to()`` sticks, and mutating it is visible to everyone.
+
+        Parameters
+        ----------
+        rescale_in_physical_space: bool, optional
+            Whether the op should act on this coupler's scaling statistics.
+            Pass False to reduce in normalized space with the statistics still
+            attached, which reproduces the numbers a caller produced before
+            physical-space rescaling was available. Default True.
+
+        Returns
+        -------
+        CouplingOp
+            Reflecting the coupler's configuration as of the last
+            ``setup_coupling`` or ``set_coupled_scaling`` call.
+        """
+        op = self._coupling_ops.get(rescale_in_physical_space)
+        if op is None:
+            op = CouplingOp.from_coupler(
+                self, rescale_in_physical_space=rescale_in_physical_space
             )
-        else:
-            preset = physical_op(coupled_fields)
-        if self.time_first:
-            preset = preset.permute(2, 0, 3, 1, 4, 5)
-        self.preset_coupled_fields = preset
+            self._coupling_ops[rescale_in_physical_space] = op
+        return op
+
+    def _store_preset_coupled_fields(self, coupled_fields: th.Tensor):
+        """Apply the coupling operation and buffer the result for the dataloader."""
+        self.preset_coupled_fields = self.coupling_op()(coupled_fields)
         self.coupled_mode = True
 
     def setup_coupling(self, coupled_module):
@@ -359,6 +418,7 @@ class BaseCoupler(ABC):
         self.coupled_channel_indices = channel_indices
         self.incoming_variables = incoming_variables
         self.outgoing_variable_order = outgoing_variable_order
+        self._invalidate_coupling_ops()
 
     def reset_coupler(self):
         self.coupled_mode = False
@@ -476,6 +536,8 @@ class ConstantCoupler(BaseCoupler):
     force the model with this field consistently
     """
 
+    coupling_method = CONSTANT
+
     def __init__(
         self,
         dataset: xr.Dataset,
@@ -563,16 +625,7 @@ class ConstantCoupler(BaseCoupler):
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-
-        def _broadcast_first_time(fields: th.Tensor) -> th.Tensor:
-            # Clone so later mutations of coupled_fields cannot alter presets.
-            return (
-                fields[:, :, :1]
-                .expand(-1, -1, self.coupled_integration_dim, -1, -1, -1)
-                .clone()
-            )
-
-        self._store_preset_coupled_fields(coupled_fields, _broadcast_first_time)
+        self._store_preset_coupled_fields(coupled_fields)
 
 
 class TrailingAverageCoupler(BaseCoupler):
@@ -582,6 +635,8 @@ class TrailingAverageCoupler(BaseCoupler):
     Trailing average coupler uses coupled input times as the right side of
     an average that is taken over an "averaging_window" window size.
     """
+
+    coupling_method = TRAILING_AVERAGE
 
     def __init__(
         self,
@@ -711,6 +766,9 @@ class TrailingAverageCoupler(BaseCoupler):
                     )
                 )
         self.averaging_slices = averaging_slices
+        # super().setup_coupling already invalidated, but averaging_slices is
+        # assigned after that call, so the windows need their own invalidation.
+        self._invalidate_coupling_ops()
 
     def set_coupled_fields(self, coupled_fields: th.tensor):
         """
@@ -727,17 +785,4 @@ class TrailingAverageCoupler(BaseCoupler):
             The data to use when the dataloader requests coupled fields. Expected
             format is [B, F, T, C, H, W]
         """
-
-        def _trailing_average(fields: th.Tensor) -> th.Tensor:
-            # TODO: Now support output_time_dim =/= input_time_dim, but presteps
-            # need to be 0, will add support for presteps>0
-            coupled_averaging_periods = []
-            for j in range(self.coupled_integration_dim):
-                averaging_periods = [
-                    fields[:, :, s, :, :, :].mean(dim=2, keepdim=True)
-                    for s in self.averaging_slices[j]
-                ]
-                coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
-            return th.concat(coupled_averaging_periods, dim=2)
-
-        self._store_preset_coupled_fields(coupled_fields, _trailing_average)
+        self._store_preset_coupled_fields(coupled_fields)

--- a/physicsnemo/datapipes/healpix/coupling_ops.py
+++ b/physicsnemo/datapipes/healpix/coupling_ops.py
@@ -1,0 +1,609 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Differentiable coupling operations for HEALPix Earth-system components.
+
+These are the tensor operations behind
+:mod:`physicsnemo.datapipes.healpix.couplers`, factored out as pure functions so
+that inference and training can share one implementation with the dataloader
+instead of transcribing the math. Every function here is free of side effects
+and preserves the autograd graph, which makes them safe under CUDA graph
+capture and activation checkpointing.
+
+The coupling pipeline is always the same three steps, wrapped by
+:func:`apply_coupling`:
+
+1. select the coupled channels out of the source component's output,
+2. reduce the time axis with a *physical operation*
+   (:func:`constant_coupling` or :func:`trailing_average_coupling`),
+3. optionally carry that reduction through physical space by denormalizing
+   before it and renormalizing after.
+
+Scaling statistics are passed as ``{"mean": Tensor, "std": Tensor}`` mappings
+whose entries broadcast against a ``[B, F, T, C, H, W]`` field.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable, Mapping, Optional, Sequence
+
+import torch as th
+
+__all__ = [
+    "CONSTANT",
+    "TRAILING_AVERAGE",
+    "CouplingOp",
+    "apply_coupling",
+    "concat_integrated_couplings",
+    "constant_coupling",
+    "denormalize",
+    "renormalize",
+    "rescale_through_physical",
+    "trailing_average_coupling",
+]
+
+CONSTANT = "constant"
+TRAILING_AVERAGE = "trailing_average"
+
+PhysicalOp = Callable[[th.Tensor], th.Tensor]
+Scaling = Mapping[str, th.Tensor]
+
+
+def concat_integrated_couplings(
+    couplings: Sequence, device=None, dtype=None
+) -> th.Tensor:
+    """Gather each coupler's current coupled fields into one tensor.
+
+    ``construct_integrated_couplings`` returns a tensor when fields were preset
+    with ``set_coupled_fields`` and a numpy array when read from the dataset.
+    Both are normalized to a tensor here rather than routed through
+    ``numpy.concatenate``, which would silently drop the autograd graph of a
+    preset field and reject fields that live on an accelerator.
+
+    Parameters
+    ----------
+    couplings: Sequence
+        Coupler objects, in the order their channels appear in the coupled
+        input.
+    device: torch.device, optional
+        Device to place the result on. Defaults to leaving each field where it
+        is.
+    dtype: torch.dtype, optional
+        Dtype to cast the result to. Defaults to leaving fields as they are.
+
+    Returns
+    -------
+    th.Tensor
+        Coupled fields concatenated along the channel axis (dim 2).
+    """
+    fields = []
+    for coupler in couplings:
+        field = coupler.construct_integrated_couplings()
+        if not th.is_tensor(field):
+            field = th.as_tensor(field)
+        if device is not None or dtype is not None:
+            field = field.to(device=device, dtype=dtype)
+        fields.append(field)
+    return th.cat(fields, dim=2)
+
+
+def denormalize(x: th.Tensor, scaling: Scaling) -> th.Tensor:
+    """Map normalized values back to physical units.
+
+    Parameters
+    ----------
+    x: th.Tensor
+        Normalized field.
+    scaling: Mapping[str, th.Tensor]
+        ``mean`` and ``std`` broadcastable against ``x``.
+
+    Returns
+    -------
+    th.Tensor
+        ``x * std + mean``.
+    """
+    mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
+    std = scaling["std"].to(device=x.device, dtype=x.dtype)
+    return x * std + mean
+
+
+def renormalize(x: th.Tensor, scaling: Scaling) -> th.Tensor:
+    """Map physical values into normalized space.
+
+    Parameters
+    ----------
+    x: th.Tensor
+        Field in physical units.
+    scaling: Mapping[str, th.Tensor]
+        ``mean`` and ``std`` broadcastable against ``x``.
+
+    Returns
+    -------
+    th.Tensor
+        ``(x - mean) / std``.
+    """
+    mean = scaling["mean"].to(device=x.device, dtype=x.dtype)
+    std = scaling["std"].to(device=x.device, dtype=x.dtype)
+    return (x - mean) / std
+
+
+def constant_coupling(
+    fields: th.Tensor, integration_dim: int, time_index: int = 0
+) -> th.Tensor:
+    """Hold one time step constant across the coupled integration window.
+
+    Parameters
+    ----------
+    fields: th.Tensor
+        Source fields, ``[B, F, T, C, H, W]``.
+    integration_dim: int
+        Number of coupled integration steps to produce.
+    time_index: int, optional
+        Index along the time axis to hold constant. Negative values count from
+        the end. Default 0, the first available time step.
+
+    Returns
+    -------
+    th.Tensor
+        ``[B, F, integration_dim, C, H, W]``.
+    """
+    if time_index < 0:
+        time_index += fields.shape[2]
+    selected = fields[:, :, time_index : time_index + 1]
+    # expand returns a view; clone so later mutation of fields cannot write
+    # through into the coupled result.
+    return selected.expand(-1, -1, integration_dim, -1, -1, -1).clone()
+
+
+def trailing_average_coupling(
+    fields: th.Tensor, averaging_slices: Sequence[Sequence[slice]]
+) -> th.Tensor:
+    """Average over trailing windows and stack them period-major.
+
+    Parameters
+    ----------
+    fields: th.Tensor
+        Source fields, ``[B, F, T, C, H, W]``.
+    averaging_slices: Sequence[Sequence[slice]]
+        One list of time slices per coupled integration step; each slice is one
+        averaging window, ordered by ``input_times``.
+
+    Returns
+    -------
+    th.Tensor
+        ``[B, F, integration, timevar, H, W]`` where ``timevar`` runs
+        period-major, ``[p0_v0, p0_v1, ..., p1_v0, ...]``.
+    """
+    coupled_averaging_periods = []
+    for slices in averaging_slices:
+        averaging_periods = [
+            fields[:, :, s, :, :, :].mean(dim=2, keepdim=True) for s in slices
+        ]
+        coupled_averaging_periods.append(th.concat(averaging_periods, dim=3))
+    return th.concat(coupled_averaging_periods, dim=2)
+
+
+def rescale_through_physical(
+    fields: th.Tensor,
+    physical_op: PhysicalOp,
+    incoming_scaling: Scaling,
+    outgoing_scaling: Scaling,
+) -> th.Tensor:
+    """Run ``physical_op`` in physical units rather than normalized space.
+
+    Averaging in normalized space is only equivalent to averaging in physical
+    space when both sides share one affine transform. Coupled fields usually do
+    not: instantaneous source outputs are normalized with instantaneous
+    statistics while the coupled target uses trailing-window statistics.
+
+    Denormalized values can overflow reduced precision, so the round trip runs
+    in at least float32 and the input dtype is restored at the end. Inputs that
+    are already wider than float32 keep their precision.
+
+    This rescales unconditionally. Deciding *whether* a coupling should run in
+    physical space belongs to the caller; :func:`apply_coupling` owns that
+    branch.
+
+    Parameters
+    ----------
+    fields: th.Tensor
+        Normalized source fields.
+    physical_op: Callable[[th.Tensor], th.Tensor]
+        Time-axis reduction to apply in physical units.
+    incoming_scaling: Mapping[str, th.Tensor]
+        Statistics that normalized ``fields``.
+    outgoing_scaling: Mapping[str, th.Tensor]
+        Statistics to renormalize the reduced field with. Must broadcast
+        against the output of ``physical_op``.
+
+    Returns
+    -------
+    th.Tensor
+        Reduced field in outgoing normalized space, in the input dtype.
+    """
+    orig_dtype = fields.dtype
+    compute_dtype = th.promote_types(orig_dtype, th.float32)
+    physical_fields = denormalize(fields.to(compute_dtype), incoming_scaling)
+    transformed_fields = physical_op(physical_fields)
+    normalized_fields = renormalize(transformed_fields, outgoing_scaling)
+    return normalized_fields.to(dtype=orig_dtype)
+
+
+def apply_coupling(
+    fields: th.Tensor,
+    channel_indices: Sequence[int],
+    physical_op: PhysicalOp,
+    incoming_scaling: Optional[Scaling] = None,
+    outgoing_scaling: Optional[Scaling] = None,
+    time_first: bool = True,
+    rescale_in_physical_space: bool = True,
+) -> th.Tensor:
+    """Select coupled channels, reduce the time axis, and lay out the result.
+
+    This is the whole coupling operation. It is a pure function of its
+    arguments: nothing is cached and ``fields`` is not modified.
+
+    Parameters
+    ----------
+    fields: th.Tensor
+        Source component output, ``[B, F, T, C, H, W]``.
+    channel_indices: Sequence[int]
+        Channels of ``fields`` that back the coupled variables, in coupled
+        order. Indices may repeat when several coupled variables share one
+        source channel.
+    physical_op: Callable[[th.Tensor], th.Tensor]
+        Time-axis reduction, e.g. :func:`constant_coupling` or
+        :func:`trailing_average_coupling` bound to their configuration.
+    incoming_scaling: Mapping[str, th.Tensor], optional
+        Statistics that normalized ``fields``. When given (together with
+        ``outgoing_scaling``) the reduction runs in physical space.
+    outgoing_scaling: Mapping[str, th.Tensor], optional
+        Statistics to renormalize with. Required when ``incoming_scaling`` is
+        given.
+    time_first: bool, optional
+        If True, return ``[T, B, C, F, H, W]``; otherwise keep
+        ``[B, F, T, C, H, W]``. Default True.
+    rescale_in_physical_space: bool, optional
+        Set False to reduce in normalized space even though scaling statistics
+        were supplied. This is a veto, not a request: with no statistics the
+        reduction runs in normalized space either way. It exists so that
+        attaching statistics and acting on them are separate decisions, which
+        keeps a caller from silently changing its numbers just because the
+        dataset happened to carry statistics. Default True.
+
+    Returns
+    -------
+    th.Tensor
+        The coupled field, laid out per ``time_first``.
+
+    Raises
+    ------
+    ValueError
+        If exactly one of ``incoming_scaling`` and ``outgoing_scaling`` is given.
+    """
+    # Validated even when rescaling is vetoed: half-configured statistics are a
+    # configuration error whether or not this call would have used them.
+    if (incoming_scaling is None) != (outgoing_scaling is None):
+        raise ValueError(
+            "incoming_scaling and outgoing_scaling must be provided together; "
+            "got incoming="
+            f"{'set' if incoming_scaling is not None else 'None'}, outgoing="
+            f"{'set' if outgoing_scaling is not None else 'None'}"
+        )
+
+    coupled = fields[:, :, :, channel_indices, :, :]
+    if rescale_in_physical_space and incoming_scaling is not None:
+        coupled = rescale_through_physical(
+            coupled, physical_op, incoming_scaling, outgoing_scaling
+        )
+    else:
+        coupled = physical_op(coupled)
+    if time_first:
+        coupled = coupled.permute(2, 0, 3, 1, 4, 5)
+    return coupled
+
+
+class CouplingOp(th.nn.Module):
+    """One component's coupling, as a module that carries its own indices and stats.
+
+    Wraps :func:`apply_coupling` so that the configuration a coupling needs
+    (which source channels, which time reduction, which scaling statistics)
+    travels with the object and moves across devices with ``.to()``. ``forward``
+    mutates nothing, so the same instance is safe inside CUDA graph capture and
+    activation checkpointing as well as in the dataloader.
+
+    Build one with :meth:`from_coupler` when the coupling was derived from a
+    dataset, or :meth:`from_spec` when it was derived from a coupled-system
+    config.
+
+    Parameters
+    ----------
+    mode: str
+        ``"constant"`` or ``"trailing_average"``.
+    channel_indices: Sequence[int]
+        Channels of the source component's output that back the coupled
+        variables, in coupled order. Indices may repeat.
+    integration_dim: int, optional
+        Number of coupled integration steps. Required for ``"constant"``.
+    time_index: int, optional
+        Source time step to hold constant, used by ``"constant"``. Negative
+        values count from the end. Default 0.
+    averaging_slices: Sequence[Sequence[slice]], optional
+        Averaging windows per integration step. Required for
+        ``"trailing_average"``.
+    time_first: bool, optional
+        Whether to emit ``[T, B, C, F, H, W]``. Default True.
+    rescale_in_physical_space: bool, optional
+        Whether to act on scaling statistics when they are set. Default True.
+        See :attr:`rescales_through_physical` for the effective decision.
+    """
+
+    def __init__(
+        self,
+        mode: str,
+        channel_indices: Sequence[int],
+        integration_dim: Optional[int] = None,
+        time_index: int = 0,
+        averaging_slices: Optional[Sequence[Sequence[slice]]] = None,
+        time_first: bool = True,
+        rescale_in_physical_space: bool = True,
+    ):
+        super().__init__()
+        if mode == CONSTANT:
+            if integration_dim is None:
+                raise ValueError("constant coupling requires integration_dim")
+        elif mode == TRAILING_AVERAGE:
+            if averaging_slices is None:
+                raise ValueError("trailing_average coupling requires averaging_slices")
+        else:
+            raise ValueError(
+                f"unknown coupling mode {mode!r}, expected {CONSTANT!r} or "
+                f"{TRAILING_AVERAGE!r}"
+            )
+
+        self.mode = mode
+        self.time_first = bool(time_first)
+        self.rescale_in_physical_space = bool(rescale_in_physical_space)
+        self.time_index = int(time_index)
+        self.integration_dim = (
+            len(averaging_slices) if integration_dim is None else int(integration_dim)
+        )
+        self.averaging_slices = (
+            None
+            if averaging_slices is None
+            else tuple(tuple(windows) for windows in averaging_slices)
+        )
+
+        # Indices and statistics are non-persistent: they are derived from the
+        # dataset or the coupled-system config, not learned, so they should not
+        # travel in a checkpoint and go stale.
+        self.register_buffer(
+            "channel_indices",
+            th.as_tensor(channel_indices, dtype=th.long),
+            persistent=False,
+        )
+        for name in (
+            "incoming_mean",
+            "incoming_std",
+            "outgoing_mean",
+            "outgoing_std",
+        ):
+            self.register_buffer(name, None, persistent=False)
+
+    @property
+    def incoming_scaling(self) -> Optional[dict]:
+        """Statistics that normalized the source fields, or None."""
+        if self.incoming_mean is None:
+            return None
+        return {"mean": self.incoming_mean, "std": self.incoming_std}
+
+    @property
+    def outgoing_scaling(self) -> Optional[dict]:
+        """Statistics used to renormalize the coupled result, or None."""
+        if self.outgoing_mean is None:
+            return None
+        return {"mean": self.outgoing_mean, "std": self.outgoing_std}
+
+    @property
+    def rescales_through_physical(self) -> bool:
+        """Whether :meth:`forward` will reduce in physical rather than
+        normalized space.
+
+        Both conditions have to hold: statistics must be set *and*
+        ``rescale_in_physical_space`` must allow using them. Callers that care
+        whether their numbers changed should read this rather than inferring it
+        from the presence of statistics.
+        """
+        return self.rescale_in_physical_space and self.incoming_mean is not None
+
+    def set_scaling(
+        self, incoming: Optional[Scaling], outgoing: Optional[Scaling]
+    ) -> None:
+        """Install (or clear) the statistics that move the reduction into
+        physical space.
+
+        Parameters
+        ----------
+        incoming: Mapping[str, th.Tensor], optional
+            Statistics that normalized the source fields.
+        outgoing: Mapping[str, th.Tensor], optional
+            Statistics to renormalize the coupled result with.
+
+        Raises
+        ------
+        ValueError
+            If exactly one of ``incoming`` and ``outgoing`` is given.
+        """
+        if (incoming is None) != (outgoing is None):
+            raise ValueError("incoming and outgoing scaling must be set together")
+        if incoming is None:
+            self.incoming_mean = None
+            self.incoming_std = None
+            self.outgoing_mean = None
+            self.outgoing_std = None
+            return
+        self.incoming_mean = th.as_tensor(incoming["mean"])
+        self.incoming_std = th.as_tensor(incoming["std"])
+        self.outgoing_mean = th.as_tensor(outgoing["mean"])
+        self.outgoing_std = th.as_tensor(outgoing["std"])
+
+    def physical_op(self) -> PhysicalOp:
+        """The time-axis reduction this coupling applies, bound to its config."""
+        if self.mode == CONSTANT:
+            return partial(
+                constant_coupling,
+                integration_dim=self.integration_dim,
+                time_index=self.time_index,
+            )
+        return partial(
+            trailing_average_coupling, averaging_slices=self.averaging_slices
+        )
+
+    def forward(self, fields: th.Tensor) -> th.Tensor:
+        """Couple a source component's output.
+
+        Parameters
+        ----------
+        fields: th.Tensor
+            Source component output, ``[B, F, T, C, H, W]``.
+
+        Returns
+        -------
+        th.Tensor
+            The coupled field, laid out per ``time_first``.
+        """
+        return apply_coupling(
+            fields,
+            self.channel_indices,
+            self.physical_op(),
+            incoming_scaling=self.incoming_scaling,
+            outgoing_scaling=self.outgoing_scaling,
+            time_first=self.time_first,
+            rescale_in_physical_space=self.rescale_in_physical_space,
+        )
+
+    @classmethod
+    def from_coupler(
+        cls, coupler, rescale_in_physical_space: bool = True
+    ) -> "CouplingOp":
+        """Build the op for a coupler configured against a dataset.
+
+        Reads what ``setup_coupling`` and ``set_coupled_scaling`` derived, so
+        the module and the dataloader cannot drift apart.
+
+        Parameters
+        ----------
+        coupler: physicsnemo.datapipes.healpix.couplers.BaseCoupler
+            A coupler whose ``setup_coupling`` has already run.
+        rescale_in_physical_space: bool, optional
+            Whether to act on the coupler's scaling statistics. Pass False to
+            reduce in normalized space while leaving the statistics attached,
+            which is how a caller reproduces pre-rescaling numbers. Default
+            True.
+
+        Returns
+        -------
+        CouplingOp
+        """
+        op = cls(
+            mode=coupler.coupling_method,
+            channel_indices=coupler.coupled_channel_indices,
+            integration_dim=coupler.coupled_integration_dim,
+            averaging_slices=getattr(coupler, "averaging_slices", None),
+            time_first=coupler.time_first,
+            rescale_in_physical_space=rescale_in_physical_space,
+        )
+        op.set_scaling(
+            coupler.incoming_coupled_scaling, coupler.outgoing_coupled_scaling
+        )
+        return op
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: Mapping,
+        averaging_slices: Optional[Sequence[Sequence[slice]]] = None,
+        channel_indices: Optional[Sequence[int]] = None,
+        time_first: bool = True,
+        rescale_in_physical_space: Optional[bool] = None,
+    ) -> "CouplingOp":
+        """Build the op from a coupled-system coupling specification.
+
+        Note the naming mismatch between the two derivations: a spec's
+        ``variable_indices`` are the source channels this op selects, while its
+        ``channel_indices`` are the destination slots in the concatenated
+        coupling tensor and are not used here.
+
+        Parameters
+        ----------
+        spec: Mapping
+            Entry with ``method``, ``variable_indices``, and
+            ``timestep_indices``. For ``"constant"``, ``timestep_indices`` is
+            one source index repeated once per integration step.
+        averaging_slices: Sequence[Sequence[slice]], optional
+            Averaging windows, required for ``"trailing_average"``. The caller
+            owns this because the window layout is a property of the coupled
+            system's time scheme rather than of the spec.
+        channel_indices: Sequence[int], optional
+            Source channels to select, overriding ``spec["variable_indices"]``.
+            Lets a caller that has already materialized these indices as a
+            tensor hand that tensor over instead of creating a second copy.
+        time_first: bool, optional
+            Whether to emit ``[T, B, C, F, H, W]``. Default True.
+        rescale_in_physical_space: bool, optional
+            Whether to act on scaling statistics once they are set. Defaults to
+            the spec's ``rescale_in_physical_space`` entry, so a coupled-system
+            config can turn physical-space rescaling on per coupling, and to
+            True when the spec is silent.
+
+        Returns
+        -------
+        CouplingOp
+
+        Raises
+        ------
+        ValueError
+            If a constant coupling's ``timestep_indices`` are not a single
+            repeated index.
+        """
+        method = spec["method"]
+        timestep_indices = list(spec["timestep_indices"])
+        if channel_indices is None:
+            channel_indices = spec["variable_indices"]
+        if rescale_in_physical_space is None:
+            rescale_in_physical_space = spec.get("rescale_in_physical_space", True)
+        if method == CONSTANT:
+            if len(set(timestep_indices)) != 1:
+                raise ValueError(
+                    "constant coupling expects a single repeated source "
+                    f"timestep, got {timestep_indices}"
+                )
+            return cls(
+                mode=CONSTANT,
+                channel_indices=channel_indices,
+                integration_dim=len(timestep_indices),
+                time_index=int(timestep_indices[0]),
+                time_first=time_first,
+                rescale_in_physical_space=rescale_in_physical_space,
+            )
+        return cls(
+            mode=method,
+            channel_indices=channel_indices,
+            averaging_slices=averaging_slices,
+            time_first=time_first,
+            rescale_in_physical_space=rescale_in_physical_space,
+        )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,9 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 from collections import defaultdict
 
 import pytest
+
+
+def requires_module(names):
+    """
+    Decorator to skip a test if *any* of the given modules are missing.
+
+    Accepts a single module name or a list/tuple of names. Mirrors the helper
+    of the same name in upstream physicsnemo so tests can be shared verbatim
+    between the two trees.
+    """
+    if isinstance(names, str):
+        names = [names]
+
+    skip = any(importlib.util.find_spec(name) is None for name in names)
+    return pytest.mark.skipif(skip, reason="requires " + ", ".join(names))
+
 
 file_timings = defaultdict(float)
 

--- a/test/datapipes/test_healpix_coupling_equivalence.py
+++ b/test/datapipes/test_healpix_coupling_equivalence.py
@@ -1,0 +1,839 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Three-way equivalence harness for HEALPix coupling math.
+
+The same coupling operation is implemented three times in the DLESyM stack:
+
+1. ``ConstantCoupler`` / ``TrailingAverageCoupler`` in this library, driven by
+   ``set_coupled_fields``.
+2. A differentiable transcription in the distributed inferencer
+   (``diff_atmos_coupling`` / ``diff_ocean_coupling``).
+3. A second transcription in the coupled training model
+   (``prepare_couplings`` / ``update_coupling``).
+
+The inference and training versions are transcribed here verbatim so a single
+synthetic ``[B, F, T, C, H, W]`` tensor can be driven through all three and
+compared without importing the downstream repositories. Tests are parameterized
+over the number of coupled channels and over window uniformity because several
+divergences are latent: they cancel for a single coupled variable or for
+uniformly spaced averaging windows and only appear otherwise.
+
+Divergences that are known and not yet reconciled are marked ``xfail(strict)``,
+so they flip to failures the moment the implementations converge.
+"""
+
+import numpy as np
+import pytest
+import torch
+from conftest import requires_module
+
+from physicsnemo.datapipes.healpix.couplers import (
+    ConstantCoupler,
+    TrailingAverageCoupler,
+)
+from physicsnemo.datapipes.healpix.coupling_ops import (
+    CouplingOp,
+    concat_integrated_couplings,
+)
+
+_BATCH, _FACE, _HEIGHT, _WIDTH = 2, 4, 3, 3
+_SEED = 11
+
+
+# ---------------------------------------------------------------------------
+# Transcriptions of the downstream implementations
+# ---------------------------------------------------------------------------
+
+
+def inference_constant_coupling(state, channel_indices, integration_dim):
+    """Transcribed from ``Inferencer.diff_atmos_coupling``.
+
+    Note the channel slice is applied *after* the permute, so ``-1:`` selects
+    the last coupled channel rather than all of them.
+    """
+    state = state[:, :, :, channel_indices, :, :].permute(2, 0, 3, 1, 4, 5)
+    return torch.cat(
+        [state[:1, :, -1:, :, :, :] for _ in range(integration_dim)], dim=0
+    )
+
+
+def inference_trailing_average_coupling(
+    output, channel_indices, integration_dim, averaging_slices
+):
+    """Transcribed from ``Inferencer.diff_ocean_coupling``."""
+    output = output[:, :, :, channel_indices, :, :]
+    coupled_averaging_periods = []
+    for j in range(integration_dim):
+        averaging_periods = [
+            output[:, :, s, :, :, :].mean(dim=2, keepdim=True)
+            for s in averaging_slices[j]
+        ]
+        coupled_averaging_periods.append(torch.concat(averaging_periods, dim=3))
+    return torch.concat(coupled_averaging_periods, dim=2).permute(2, 0, 3, 1, 4, 5)
+
+
+def training_constant_coupling(atmos_step_data, var_idx, time_idx):
+    """Transcribed from ``CoupledModel.prepare_couplings``, constant branch.
+
+    ``var_idx`` is applied to dimension 0 (batch) rather than the channel
+    dimension, which is how the source reads today.
+    """
+    coupling_data = atmos_step_data[:, :, time_idx][var_idx, :, :]
+    return coupling_data.permute(2, 0, 3, 1, 4, 5)
+
+
+def training_trailing_average_coupling(
+    atmos_step_data, var_idx, n_output_times, n_integrations, n_time_idx
+):
+    """Transcribed from ``CoupledModel.prepare_couplings``, trailing branch.
+
+    Partitions the time axis into ``n_output_times`` equal contiguous chunks
+    rather than using the library's ``averaging_slices``.
+    """
+    coupling_data = atmos_step_data[:, :, :, var_idx, :, :]
+    chunks = coupling_data.chunk(n_output_times, dim=2)
+    if len(chunks) != n_integrations * n_time_idx:
+        raise ValueError("Coupling does not evenly align with expected time dimensions")
+    coupling_data_avg = [
+        torch.concat(
+            [
+                x.mean(dim=2, keepdim=True)
+                for x in chunks[j * n_time_idx : (j + 1) * n_time_idx]
+            ],
+            dim=3,
+        )
+        for j in range(n_integrations)
+    ]
+    return torch.cat(coupling_data_avg, dim=2).permute(2, 0, 3, 1, 4, 5)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and builders
+# ---------------------------------------------------------------------------
+
+
+class _FakeSource:
+    """Stands in for the source component's TimeSeriesDataset."""
+
+    def __init__(self, output_variables, time_step):
+        self.output_variables = list(output_variables)
+        self.time_step = time_step
+
+
+def _make_dataset(variables, n_time, time_step="3h"):
+    xr = pytest.importorskip("xarray")
+    pd = pytest.importorskip("pandas")
+
+    return xr.Dataset(
+        data_vars={
+            "inputs": (
+                ("time", "channel_in", "face", "height", "width"),
+                np.zeros(
+                    (n_time, len(variables), _FACE, _HEIGHT, _WIDTH), dtype="float32"
+                ),
+            )
+        },
+        coords={
+            "time": pd.date_range("1979-01-01", periods=n_time, freq=time_step),
+            "channel_in": list(variables),
+            "face": np.arange(_FACE),
+            "height": np.arange(_HEIGHT),
+            "width": np.arange(_WIDTH),
+        },
+    )
+
+
+def _source_fields(n_time, n_source_channels, seed=_SEED):
+    """Synthetic source-component output in ``[B, F, T, C, H, W]`` layout."""
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(
+        _BATCH,
+        _FACE,
+        n_time,
+        n_source_channels,
+        _HEIGHT,
+        _WIDTH,
+        dtype=torch.float32,
+        generator=generator,
+    )
+
+
+def _coupled_and_source_names(n_coupled, suffix="24H", n_extra=1):
+    """Coupled variable names plus a source channel list that brackets them.
+
+    The source list is padded so the coupled channels never start at index 0,
+    which keeps an off-by-zero in index derivation from passing silently.
+    """
+    base = [f"v{i}" for i in range(n_coupled)]
+    coupled = [f"{b}-{suffix}" for b in base]
+    source = [f"pad{j}" for j in range(n_extra)] + base + ["tail"]
+    return coupled, source
+
+
+def _make_trailing_coupler(
+    n_coupled, input_times, input_time_dim, output_time_dim, time_step="3h"
+):
+    coupled, source = _coupled_and_source_names(n_coupled)
+    coupler = TrailingAverageCoupler(
+        dataset=_make_dataset(coupled, n_time=64, time_step=time_step),
+        batch_size=_BATCH,
+        variables=coupled,
+        presteps=0,
+        averaging_window="24h",
+        input_times=list(input_times),
+        input_time_dim=input_time_dim,
+        output_time_dim=output_time_dim,
+    )
+    coupler.setup_coupling(_FakeSource(source, time_step))
+    return coupler, source
+
+
+def _make_constant_coupler(n_coupled, input_time_dim, output_time_dim, time_step="3h"):
+    coupled, source = _coupled_and_source_names(n_coupled, suffix="0H")
+    coupler = ConstantCoupler(
+        dataset=_make_dataset(coupled, n_time=16, time_step=time_step),
+        batch_size=_BATCH,
+        variables=coupled,
+        input_times=["0h"],
+        input_time_dim=input_time_dim,
+        output_time_dim=output_time_dim,
+        presteps=0,
+    )
+    coupler.setup_coupling(_FakeSource(source, time_step))
+    return coupler, source
+
+
+# The aligned trailing-average configuration: uniformly spaced windows whose
+# right edges tile the time axis exactly, which is the only regime in which the
+# library's averaging_slices and the training chunk() partition agree.
+#
+#   time_step 3h, input_times 24h/48h -> di = 8, window indices [8, 16]
+#   input_time_dim 2, output_time_dim 4 -> coupled_integration_dim 2
+#   slices: j=0 -> (0,8), (8,16);  j=1 -> (16,24), (24,32)
+UNIFORM = dict(
+    input_times=["24h", "48h"],
+    input_time_dim=2,
+    output_time_dim=4,
+    n_time=32,
+    n_output_times=4,
+)
+
+# Non-uniform windows: right edges at 24h and 72h give windows of unequal
+# width, so equal chunking cannot reproduce them.
+#   window indices [8, 24]
+#   slices: j=0 -> (0,8), (8,24);  j=1 -> (16,24), (24,40)
+NON_UNIFORM = dict(
+    input_times=["24h", "72h"],
+    input_time_dim=2,
+    output_time_dim=4,
+    n_time=40,
+    n_output_times=4,
+)
+
+
+# ---------------------------------------------------------------------------
+# Trailing average: library vs inference
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("n_coupled", [1, 3])
+@pytest.mark.parametrize(
+    "config", [UNIFORM, NON_UNIFORM], ids=["uniform", "nonuniform"]
+)
+def test_trailing_library_matches_inference(n_coupled, config):
+    """The inference transcription reproduces the library exactly.
+
+    Both consume the coupler's own ``averaging_slices``, so they agree for any
+    window layout as long as no scaling is configured.
+    """
+    coupler, source = _make_trailing_coupler(
+        n_coupled,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    inference = inference_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        coupler.coupled_integration_dim,
+        coupler.averaging_slices,
+    )
+
+    assert library.shape == inference.shape
+    assert torch.equal(library, inference)
+
+
+# ---------------------------------------------------------------------------
+# Trailing average: library vs training
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("n_coupled", [1, 3])
+def test_trailing_library_matches_training_uniform_windows(n_coupled):
+    """With uniformly tiling windows the training chunk partition agrees."""
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        n_coupled,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    training = training_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        config["n_output_times"],
+        coupler.coupled_integration_dim,
+        len(coupler.input_times),
+    )
+
+    assert library.shape == training.shape
+    assert torch.equal(library, training)
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("n_coupled", [1, 3])
+@pytest.mark.xfail(
+    strict=True,
+    reason="training partitions the time axis into equal chunks, the library "
+    "uses averaging_slices derived from input_times; these disagree whenever "
+    "the averaging windows are not uniformly spaced",
+)
+def test_trailing_library_matches_training_nonuniform_windows(n_coupled):
+    config = NON_UNIFORM
+    coupler, source = _make_trailing_coupler(
+        n_coupled,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    training = training_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        config["n_output_times"],
+        coupler.coupled_integration_dim,
+        len(coupler.input_times),
+    )
+
+    assert torch.equal(library, training)
+
+
+# ---------------------------------------------------------------------------
+# Constant coupling: library vs inference
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+def test_constant_library_matches_inference_single_channel():
+    """With one coupled channel the inference ``-1:`` slice is a no-op."""
+    coupler, source = _make_constant_coupler(1, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+    inference = inference_constant_coupling(
+        fields, coupler.coupled_channel_indices, coupler.coupled_integration_dim
+    )
+
+    assert library.shape == inference.shape
+    assert torch.equal(library, inference)
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.xfail(
+    strict=True,
+    reason="inference slices [-1:] on the channel axis after permuting, so it "
+    "keeps only the last coupled channel; the library keeps all of them. The "
+    "two agree only while exactly one variable is coupled",
+)
+def test_constant_library_matches_inference_multi_channel():
+    coupler, source = _make_constant_coupler(3, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+    inference = inference_constant_coupling(
+        fields, coupler.coupled_channel_indices, coupler.coupled_integration_dim
+    )
+
+    assert torch.equal(library, inference)
+
+
+# ---------------------------------------------------------------------------
+# Constant coupling: library vs training
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.xfail(
+    strict=True,
+    reason="the training constant branch applies var_idx to dimension 0 "
+    "(batch) instead of the channel dimension",
+)
+def test_constant_library_matches_training():
+    coupler, source = _make_constant_coupler(1, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    # Constant coupling repeats one source timestep integration_dim times.
+    time_idx = [0] * coupler.coupled_integration_dim
+    training = training_constant_coupling(
+        fields, coupler.coupled_channel_indices, time_idx
+    )
+
+    assert torch.equal(library, training)
+
+
+@requires_module(["xarray", "pandas"])
+def test_constant_training_indexing_lands_on_batch_axis():
+    """Pin the signature of the training constant-branch indexing bug.
+
+    ``var_idx`` is applied to dimension 0, so it selects batch members. The
+    coupled channel axis is left untouched and the source channel count leaks
+    through into the output.
+    """
+    coupler, source = _make_constant_coupler(1, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+    time_idx = [0] * coupler.coupled_integration_dim
+
+    training = training_constant_coupling(
+        fields, coupler.coupled_channel_indices, time_idx
+    )
+
+    # [len(time_idx), len(var_idx), C_source, F, H, W] instead of
+    # [integration, B, C_coupled, F, H, W]
+    assert training.shape == (
+        len(time_idx),
+        len(coupler.coupled_channel_indices),
+        len(source),
+        _FACE,
+        _HEIGHT,
+        _WIDTH,
+    )
+
+
+@requires_module(["xarray", "pandas"])
+def test_constant_training_indexing_raises_when_channels_exceed_batch():
+    """The same bug is fatal, not merely wrong, in the common case.
+
+    Coupled channel indices routinely exceed the batch size, and indexing the
+    batch axis with them raises.
+    """
+    coupler, source = _make_constant_coupler(3, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+    time_idx = [0] * coupler.coupled_integration_dim
+    assert max(coupler.coupled_channel_indices) >= _BATCH
+
+    with pytest.raises(IndexError, match="out of bounds for dimension 0"):
+        training_constant_coupling(fields, coupler.coupled_channel_indices, time_idx)
+
+
+# ---------------------------------------------------------------------------
+# Physical-space rescaling is absent from both downstream transcriptions
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+def test_downstream_transcriptions_ignore_physical_rescaling():
+    """Neither transcription applies denorm/renorm, so both drift once
+    ``set_coupled_scaling`` is configured."""
+    pd = pytest.importorskip("pandas")
+
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        3,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    # Incoming stats for the matched source channels, outgoing for the coupled
+    # variables. Distinct means/stds make the affine map non-identity.
+    incoming = {
+        v: {"mean": 100.0 * (i + 1), "std": 5.0 * (i + 1)}
+        for i, v in enumerate(coupler.incoming_variables)
+    }
+    outgoing = {
+        v: {"mean": 90.0 * (i + 1), "std": 4.0 * (i + 1)}
+        for i, v in enumerate(coupler.variables)
+    }
+    coupler.set_scaling(
+        pd.DataFrame.from_dict(outgoing).T.to_xarray().astype("float32")
+    )
+    coupler.set_coupled_scaling(incoming)
+
+    fields = _source_fields(config["n_time"], len(source))
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    inference = inference_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        coupler.coupled_integration_dim,
+        coupler.averaging_slices,
+    )
+    training = training_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        config["n_output_times"],
+        coupler.coupled_integration_dim,
+        len(coupler.input_times),
+    )
+
+    assert not torch.allclose(library, inference, rtol=1e-3, atol=1e-3)
+    assert not torch.allclose(library, training, rtol=1e-3, atol=1e-3)
+    # Without scaling all three agree, so the gap is the rescaling and nothing
+    # else about the averaging.
+    coupler.incoming_coupled_scaling = None
+    coupler.outgoing_coupled_scaling = None
+    coupler.set_coupled_fields(fields)
+    assert torch.equal(coupler.construct_integrated_couplings(), inference)
+
+
+@requires_module(["xarray", "pandas"])
+def test_coupling_op_is_reused_across_calls():
+    """set_coupled_fields runs per step, so the op must not be rebuilt each time."""
+    config = UNIFORM
+    coupler, _ = _make_trailing_coupler(
+        3,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    first = coupler.coupling_op()
+    assert coupler.coupling_op() is first
+    # A different rescaling decision is a different op, not a mutation of this one.
+    vetoed = coupler.coupling_op(rescale_in_physical_space=False)
+    assert vetoed is not first
+    assert coupler.coupling_op(rescale_in_physical_space=False) is vetoed
+    assert first.rescale_in_physical_space is True
+
+
+@requires_module(["xarray", "pandas"])
+def test_coupling_op_cache_is_dropped_when_scaling_changes():
+    """A cached op must never outlive the configuration it captured."""
+    pd = pytest.importorskip("pandas")
+
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        3,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+    before = coupler.coupling_op()
+    unscaled = before(fields)
+    assert before.rescales_through_physical is False
+
+    coupler.set_scaling(
+        pd.DataFrame.from_dict(
+            {
+                v: {"mean": 90.0 * (i + 1), "std": 4.0 * (i + 1)}
+                for i, v in enumerate(coupler.variables)
+            }
+        )
+        .T.to_xarray()
+        .astype("float32")
+    )
+    coupler.set_coupled_scaling(
+        {
+            v: {"mean": 100.0 * (i + 1), "std": 5.0 * (i + 1)}
+            for i, v in enumerate(coupler.incoming_variables)
+        }
+    )
+
+    after = coupler.coupling_op()
+    assert after is not before
+    assert after.rescales_through_physical is True
+    assert not torch.allclose(after(fields), unscaled, rtol=1e-3, atol=1e-3)
+
+    # Clearing the statistics by direct assignment must invalidate too, since
+    # that is how a caller reverts to normalized-space coupling.
+    coupler.incoming_coupled_scaling = None
+    coupler.outgoing_coupled_scaling = None
+    reverted = coupler.coupling_op()
+    assert reverted is not after
+    assert torch.equal(reverted(fields), unscaled)
+
+
+@requires_module(["xarray", "pandas"])
+def test_coupling_op_cache_is_dropped_when_coupling_is_set_up_again():
+    """setup_coupling can change channel indices and averaging windows."""
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        3,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    before = coupler.coupling_op()
+    coupler.setup_coupling(_FakeSource(source, "3h"))
+    assert coupler.coupling_op() is not before
+
+
+@requires_module(["xarray", "pandas"])
+def test_vetoing_rescaling_reproduces_pre_rescaling_inference_numbers():
+    """A configured coupler can still emit the old, un-rescaled numbers.
+
+    This is what makes the scaling change auditable: the same coupler, with its
+    statistics attached, reproduces either side of the change depending only on
+    ``rescale_in_physical_space``.
+    """
+    pd = pytest.importorskip("pandas")
+
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        3,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    incoming = {
+        v: {"mean": 100.0 * (i + 1), "std": 5.0 * (i + 1)}
+        for i, v in enumerate(coupler.incoming_variables)
+    }
+    outgoing = {
+        v: {"mean": 90.0 * (i + 1), "std": 4.0 * (i + 1)}
+        for i, v in enumerate(coupler.variables)
+    }
+    coupler.set_scaling(
+        pd.DataFrame.from_dict(outgoing).T.to_xarray().astype("float32")
+    )
+    coupler.set_coupled_scaling(incoming)
+
+    fields = _source_fields(config["n_time"], len(source))
+    reference = inference_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        coupler.coupled_integration_dim,
+        coupler.averaging_slices,
+    )
+
+    vetoed = coupler.coupling_op(rescale_in_physical_space=False)
+    honored = coupler.coupling_op()
+
+    assert vetoed.rescales_through_physical is False
+    assert honored.rescales_through_physical is True
+    assert torch.equal(vetoed(fields), reference)
+    assert not torch.allclose(honored(fields), reference, rtol=1e-3, atol=1e-3)
+    # Vetoing must not drop the statistics, only the decision to act on them.
+    assert vetoed.incoming_scaling is not None
+
+
+# ---------------------------------------------------------------------------
+# The unified op reproduces the transcriptions it replaces
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("n_coupled", [1, 3])
+@pytest.mark.parametrize(
+    "config", [UNIFORM, NON_UNIFORM], ids=["uniform", "nonuniform"]
+)
+def test_coupling_op_reproduces_inference_transcription(n_coupled, config):
+    """What the inferencer now calls matches the math it used to inline."""
+    coupler, source = _make_trailing_coupler(
+        n_coupled,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+
+    got = coupler.coupling_op()(fields)
+    expected = inference_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        coupler.coupled_integration_dim,
+        coupler.averaging_slices,
+    )
+    assert torch.equal(got, expected)
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("n_coupled", [1, 3])
+def test_coupling_op_from_spec_reproduces_training_transcription(n_coupled):
+    """What the coupled model now calls matches the math it used to inline.
+
+    The spec-derived path is checked against the training transcription with the
+    batch-axis indexing bug corrected, which is the behavior change the shared
+    op deliberately makes.
+    """
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        n_coupled,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+    n_windows = len(coupler.input_times)
+    n_integrations = coupler.coupled_integration_dim
+
+    # Equal contiguous chunks, the partition the training code derives from its
+    # output timesteps.
+    n_chunks = config["n_output_times"]
+    size = -(-config["n_time"] // n_chunks)
+    flat = [
+        slice(start, min(start + size, config["n_time"]))
+        for start in range(0, config["n_time"], size)
+    ]
+    windows = [flat[j * n_windows : (j + 1) * n_windows] for j in range(n_integrations)]
+
+    op = CouplingOp.from_spec(
+        {
+            "method": "trailing_average",
+            "variable_indices": coupler.coupled_channel_indices,
+            "timestep_indices": list(range(n_windows)),
+        },
+        averaging_slices=windows,
+    )
+
+    expected = training_trailing_average_coupling(
+        fields,
+        coupler.coupled_channel_indices,
+        n_chunks,
+        n_integrations,
+        n_windows,
+    )
+    assert torch.equal(op(fields), expected)
+
+
+@requires_module(["xarray", "pandas"])
+def test_coupling_op_from_spec_constant_matches_library():
+    """The spec-derived constant op agrees with the library coupler.
+
+    This is the divergence from ``test_constant_library_matches_training``
+    closing: both now select on the channel axis and keep every coupled channel.
+    """
+    coupler, source = _make_constant_coupler(3, input_time_dim=1, output_time_dim=3)
+    fields = _source_fields(4, len(source))
+
+    coupler.set_coupled_fields(fields)
+    library = coupler.construct_integrated_couplings()
+
+    op = CouplingOp.from_spec(
+        {
+            "method": "constant",
+            "variable_indices": coupler.coupled_channel_indices,
+            "timestep_indices": [0] * coupler.coupled_integration_dim,
+        }
+    )
+    assert torch.equal(op(fields), library)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end differentiability of the inference coupling exchange
+# ---------------------------------------------------------------------------
+
+
+@requires_module(["xarray", "pandas"])
+@pytest.mark.parametrize("with_scaling", [False, True])
+def test_grad_reaches_source_state_through_coupled_fields(with_scaling):
+    """A loss on the gathered coupled fields must reach the source state.
+
+    This is the composition ``Inferencer.fetch_next_couplings`` performs:
+    preset the couplers from a live model state, then gather their coupled
+    fields. It used to run through ``numpy.concatenate``, which silently
+    detached the state.
+    """
+    pd = pytest.importorskip("pandas")
+
+    config = UNIFORM
+    coupler, source = _make_trailing_coupler(
+        2,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    if with_scaling:
+        outgoing = {
+            v: {"mean": 90.0 * (i + 1), "std": 4.0 * (i + 1)}
+            for i, v in enumerate(coupler.variables)
+        }
+        coupler.set_scaling(
+            pd.DataFrame.from_dict(outgoing).T.to_xarray().astype("float32")
+        )
+        coupler.set_coupled_scaling(
+            {
+                v: {"mean": 100.0 * (i + 1), "std": 5.0 * (i + 1)}
+                for i, v in enumerate(coupler.incoming_variables)
+            }
+        )
+
+    state = _source_fields(config["n_time"], len(source)).requires_grad_(True)
+    coupler.set_coupled_fields(state)
+    coupled = concat_integrated_couplings([coupler], dtype=torch.float32)
+
+    assert coupled.requires_grad
+    coupled.square().mean().backward()
+
+    assert state.grad is not None
+    assert torch.isfinite(state.grad).all()
+    assert state.grad.abs().sum() > 0
+    # Only the coupled channels are forced, so the others must stay untouched.
+    coupled_channels = set(coupler.coupled_channel_indices)
+    for channel in range(len(source)):
+        grad = state.grad[:, :, :, channel].abs().sum().item()
+        assert (grad > 0) == (channel in coupled_channels)
+
+
+@requires_module(["xarray", "pandas"])
+def test_concat_integrated_couplings_handles_dataset_and_preset_couplers():
+    """Numpy from the dataset and tensors from a preset coupler both concatenate."""
+    config = UNIFORM
+    preset, source = _make_trailing_coupler(
+        2,
+        config["input_times"],
+        config["input_time_dim"],
+        config["output_time_dim"],
+    )
+    fields = _source_fields(config["n_time"], len(source))
+    preset.set_coupled_fields(fields)
+
+    class _NumpyCoupler:
+        """Stands in for a coupler reading from the dataset."""
+
+        def __init__(self, like):
+            self.array = np.zeros(like.shape, dtype="float32")
+
+        def construct_integrated_couplings(self):
+            return self.array
+
+    coupled = concat_integrated_couplings(
+        [preset, _NumpyCoupler(preset.preset_coupled_fields)], dtype=torch.float32
+    )
+    assert coupled.shape[2] == 2 * preset.preset_coupled_fields.shape[2]
+    assert torch.is_tensor(coupled)

--- a/test/datapipes/test_healpix_coupling_ops.py
+++ b/test/datapipes/test_healpix_coupling_ops.py
@@ -1,0 +1,521 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the stateless HEALPix coupling operations."""
+
+from functools import partial
+
+import pytest
+import torch
+
+from physicsnemo.datapipes.healpix.coupling_ops import (
+    CouplingOp,
+    apply_coupling,
+    constant_coupling,
+    denormalize,
+    renormalize,
+    rescale_through_physical,
+    trailing_average_coupling,
+)
+
+_BATCH, _FACE, _HEIGHT, _WIDTH = 2, 4, 3, 3
+
+
+def _fields(n_time=8, n_channels=3, dtype=torch.float32, requires_grad=False):
+    generator = torch.Generator().manual_seed(0)
+    x = torch.randn(
+        _BATCH,
+        _FACE,
+        n_time,
+        n_channels,
+        _HEIGHT,
+        _WIDTH,
+        dtype=dtype,
+        generator=generator,
+    )
+    return x.requires_grad_(requires_grad)
+
+
+def _scaling(n_channels, mean, std, dtype=torch.float32):
+    return {
+        "mean": torch.full((1, 1, 1, n_channels, 1, 1), mean, dtype=dtype),
+        "std": torch.full((1, 1, 1, n_channels, 1, 1), std, dtype=dtype),
+    }
+
+
+# ---------------------------------------------------------------------------
+# constant_coupling
+# ---------------------------------------------------------------------------
+
+
+def test_constant_coupling_broadcasts_first_time_step():
+    fields = _fields(n_time=5)
+    out = constant_coupling(fields, integration_dim=3)
+
+    assert out.shape == (_BATCH, _FACE, 3, 3, _HEIGHT, _WIDTH)
+    for i in range(3):
+        assert torch.equal(out[:, :, i], fields[:, :, 0])
+
+
+@pytest.mark.parametrize("time_index", [0, 2, -1, -3])
+def test_constant_coupling_honors_time_index(time_index):
+    fields = _fields(n_time=5)
+    out = constant_coupling(fields, integration_dim=2, time_index=time_index)
+    expected = fields[:, :, time_index]
+    assert torch.equal(out[:, :, 0], expected)
+    assert torch.equal(out[:, :, 1], expected)
+
+
+def test_constant_coupling_does_not_alias_input():
+    """The result must survive later mutation of the source tensor."""
+    fields = _fields(n_time=4)
+    out = constant_coupling(fields, integration_dim=2)
+    snapshot = out.clone()
+    fields.mul_(-5.0)
+    assert torch.equal(out, snapshot)
+
+
+# ---------------------------------------------------------------------------
+# trailing_average_coupling
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_average_coupling_averages_each_window():
+    fields = _fields(n_time=16, n_channels=2)
+    slices = [[slice(0, 4), slice(4, 8)], [slice(8, 12), slice(12, 16)]]
+    out = trailing_average_coupling(fields, slices)
+
+    # [B, F, integration, timevar, H, W] with timevar period-major
+    assert out.shape == (_BATCH, _FACE, 2, 4, _HEIGHT, _WIDTH)
+    for j, windows in enumerate(slices):
+        for i, window in enumerate(windows):
+            expected = fields[:, :, window].mean(dim=2)
+            got = out[:, :, j, i * 2 : (i + 1) * 2]
+            assert torch.allclose(got, expected, rtol=0, atol=1e-6)
+
+
+def test_trailing_average_coupling_supports_uneven_windows():
+    fields = _fields(n_time=12, n_channels=1)
+    slices = [[slice(0, 2), slice(2, 8)]]
+    out = trailing_average_coupling(fields, slices)
+    assert torch.allclose(out[:, :, 0, 0], fields[:, :, 0:2, 0].mean(dim=2))
+    assert torch.allclose(out[:, :, 0, 1], fields[:, :, 2:8, 0].mean(dim=2))
+
+
+# ---------------------------------------------------------------------------
+# scaling round trip
+# ---------------------------------------------------------------------------
+
+
+def test_denormalize_renormalize_round_trip():
+    fields = _fields()
+    scaling = _scaling(3, mean=100.0, std=7.0)
+    assert torch.allclose(
+        renormalize(denormalize(fields, scaling), scaling), fields, atol=1e-5
+    )
+
+
+def test_rescale_through_physical_matches_manual_pipeline():
+    fields = _fields(n_time=8, n_channels=2)
+    incoming = _scaling(2, mean=900.0, std=90.0)
+    # Two windows over two variables gives a timevar axis of four.
+    outgoing = _scaling(4, mean=800.0, std=80.0)
+    slices = [[slice(0, 4), slice(4, 8)]]
+    op = partial(trailing_average_coupling, averaging_slices=slices)
+
+    got = rescale_through_physical(fields, op, incoming, outgoing)
+    expected = renormalize(op(denormalize(fields, incoming)), outgoing)
+    assert torch.allclose(got, expected, atol=1e-5)
+
+
+def test_rescale_through_physical_uses_float32_midflight_and_restores_dtype():
+    """A float16 denorm of large-magnitude fields would overflow."""
+    incoming = _scaling(1, mean=60000.0, std=5000.0, dtype=torch.float32)
+    outgoing = _scaling(1, mean=60000.0, std=5000.0, dtype=torch.float32)
+    fields = _fields(n_time=4, n_channels=1).to(torch.float16)
+    slices = [[slice(0, 4)]]
+    op = partial(trailing_average_coupling, averaging_slices=slices)
+
+    out = rescale_through_physical(fields, op, incoming, outgoing)
+    assert out.dtype == torch.float16
+    assert torch.isfinite(out.float()).all()
+
+
+# ---------------------------------------------------------------------------
+# apply_coupling
+# ---------------------------------------------------------------------------
+
+
+def test_apply_coupling_selects_channels_and_permutes():
+    fields = _fields(n_time=4, n_channels=5)
+    out = apply_coupling(fields, [3, 1], partial(constant_coupling, integration_dim=2))
+    # [T, B, C, F, H, W]
+    assert out.shape == (2, _BATCH, 2, _FACE, _HEIGHT, _WIDTH)
+    assert torch.equal(out[0, :, 0], fields[:, :, 0, 3])
+    assert torch.equal(out[0, :, 1], fields[:, :, 0, 1])
+
+
+def test_apply_coupling_time_first_false_keeps_source_layout():
+    fields = _fields(n_time=4, n_channels=3)
+    out = apply_coupling(
+        fields,
+        [0, 2],
+        partial(constant_coupling, integration_dim=2),
+        time_first=False,
+    )
+    assert out.shape == (_BATCH, _FACE, 2, 2, _HEIGHT, _WIDTH)
+
+
+def test_apply_coupling_allows_repeated_channel_indices():
+    """Several coupled variables may share one source channel."""
+    fields = _fields(n_time=4, n_channels=3)
+    out = apply_coupling(fields, [1, 1], partial(constant_coupling, integration_dim=1))
+    assert torch.equal(out[0, :, 0], out[0, :, 1])
+
+
+def test_apply_coupling_rejects_half_configured_scaling():
+    fields = _fields()
+    op = partial(constant_coupling, integration_dim=1)
+    with pytest.raises(ValueError, match="must be provided together"):
+        apply_coupling(fields, [0], op, incoming_scaling=_scaling(1, 0.0, 1.0))
+    with pytest.raises(ValueError, match="must be provided together"):
+        apply_coupling(fields, [0], op, outgoing_scaling=_scaling(1, 0.0, 1.0))
+
+
+def test_apply_coupling_is_pure():
+    """Calling twice gives the same answer and leaves the input untouched."""
+    fields = _fields(n_time=8, n_channels=2)
+    before = fields.clone()
+    op = partial(
+        trailing_average_coupling, averaging_slices=[[slice(0, 4), slice(4, 8)]]
+    )
+    first = apply_coupling(fields, [0, 1], op)
+    second = apply_coupling(fields, [0, 1], op)
+    assert torch.equal(first, second)
+    assert torch.equal(fields, before)
+
+
+# ---------------------------------------------------------------------------
+# differentiability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_scaling", [False, True])
+@pytest.mark.parametrize("mode", ["constant", "trailing"])
+def test_apply_coupling_propagates_gradients(mode, with_scaling):
+    fields = _fields(n_time=8, n_channels=2, requires_grad=True)
+    if mode == "constant":
+        op = partial(constant_coupling, integration_dim=2)
+        n_outgoing = 2
+    else:
+        op = partial(
+            trailing_average_coupling, averaging_slices=[[slice(0, 4), slice(4, 8)]]
+        )
+        # Two windows over two variables gives a timevar axis of four.
+        n_outgoing = 4
+    scaling = (
+        dict(
+            incoming_scaling=_scaling(2, 900.0, 90.0),
+            outgoing_scaling=_scaling(n_outgoing, 800.0, 80.0),
+        )
+        if with_scaling
+        else {}
+    )
+
+    out = apply_coupling(fields, [0, 1], op, **scaling)
+    out.square().sum().backward()
+
+    assert fields.grad is not None
+    assert torch.isfinite(fields.grad).all()
+    assert fields.grad.abs().sum() > 0
+
+
+def test_rescale_through_physical_keeps_float64_precision():
+    """Promotion must not silently downcast inputs wider than float32."""
+    fields = _fields(n_time=4, n_channels=1, dtype=torch.float64)
+    incoming = _scaling(1, 900.0, 90.0, dtype=torch.float64)
+    outgoing = _scaling(1, 800.0, 80.0, dtype=torch.float64)
+    op = partial(trailing_average_coupling, averaging_slices=[[slice(0, 4)]])
+
+    out = rescale_through_physical(fields, op, incoming, outgoing)
+    expected = renormalize(op(denormalize(fields, incoming)), outgoing)
+    assert out.dtype == torch.float64
+    # float32 mid-flight would leave an error many orders of magnitude larger.
+    assert (out - expected).abs().max().item() < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# CouplingOp
+# ---------------------------------------------------------------------------
+
+
+def _constant_op(**kwargs):
+    return CouplingOp(
+        mode="constant", channel_indices=[0, 2], integration_dim=2, **kwargs
+    )
+
+
+def _trailing_op(**kwargs):
+    return CouplingOp(
+        mode="trailing_average",
+        channel_indices=[0, 2],
+        averaging_slices=[[slice(0, 2), slice(2, 4)]],
+        **kwargs,
+    )
+
+
+def test_coupling_op_matches_apply_coupling():
+    fields = _fields(n_time=4, n_channels=3)
+    op = _trailing_op()
+    expected = apply_coupling(
+        fields,
+        [0, 2],
+        partial(
+            trailing_average_coupling,
+            averaging_slices=[[slice(0, 2), slice(2, 4)]],
+        ),
+    )
+    assert torch.equal(op(fields), expected)
+
+
+def test_coupling_op_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="unknown coupling mode"):
+        CouplingOp(mode="median", channel_indices=[0], integration_dim=1)
+
+
+def test_coupling_op_requires_mode_specific_config():
+    with pytest.raises(ValueError, match="requires integration_dim"):
+        CouplingOp(mode="constant", channel_indices=[0])
+    with pytest.raises(ValueError, match="requires averaging_slices"):
+        CouplingOp(mode="trailing_average", channel_indices=[0])
+
+
+def test_coupling_op_state_dict_is_empty():
+    """Indices and statistics are derived, so they must not enter checkpoints."""
+    op = _trailing_op()
+    op.set_scaling(_scaling(2, 900.0, 90.0), _scaling(4, 800.0, 80.0))
+    assert op.state_dict() == {}
+
+
+def test_coupling_op_buffers_follow_to():
+    op = _trailing_op()
+    op.set_scaling(_scaling(2, 900.0, 90.0), _scaling(4, 800.0, 80.0))
+    op = op.to(torch.float64)
+    assert op.incoming_mean.dtype == torch.float64
+    # Index buffers are integral and must not be swept up by a dtype cast.
+    assert op.channel_indices.dtype == torch.long
+
+
+def test_coupling_op_set_scaling_round_trips_and_clears():
+    op = _trailing_op()
+    assert op.incoming_scaling is None
+    assert op.outgoing_scaling is None
+
+    incoming, outgoing = _scaling(2, 900.0, 90.0), _scaling(4, 800.0, 80.0)
+    op.set_scaling(incoming, outgoing)
+    assert torch.equal(op.incoming_scaling["mean"], incoming["mean"])
+    assert torch.equal(op.outgoing_scaling["std"], outgoing["std"])
+
+    op.set_scaling(None, None)
+    assert op.incoming_scaling is None
+    assert op.outgoing_scaling is None
+
+
+def test_coupling_op_set_scaling_rejects_half_configured():
+    op = _trailing_op()
+    with pytest.raises(ValueError, match="must be set together"):
+        op.set_scaling(_scaling(2, 0.0, 1.0), None)
+
+
+# ---------------------------------------------------------------------------
+# Gating physical-space rescaling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["constant", "trailing_average"])
+def test_apply_coupling_veto_reduces_in_normalized_space(mode):
+    """rescale_in_physical_space=False must ignore statistics that are present."""
+    fields = _fields(n_time=4, n_channels=3)
+    if mode == "constant":
+        physical_op = partial(constant_coupling, integration_dim=2)
+        n_out = 2
+    else:
+        physical_op = partial(
+            trailing_average_coupling, averaging_slices=[[slice(0, 2), slice(2, 4)]]
+        )
+        n_out = 4
+
+    incoming, outgoing = _scaling(2, 900.0, 90.0), _scaling(n_out, 800.0, 80.0)
+    unscaled = apply_coupling(fields, [0, 2], physical_op)
+    vetoed = apply_coupling(
+        fields,
+        [0, 2],
+        physical_op,
+        incoming_scaling=incoming,
+        outgoing_scaling=outgoing,
+        rescale_in_physical_space=False,
+    )
+    honored = apply_coupling(
+        fields,
+        [0, 2],
+        physical_op,
+        incoming_scaling=incoming,
+        outgoing_scaling=outgoing,
+    )
+
+    assert torch.equal(vetoed, unscaled)
+    assert not torch.allclose(honored, unscaled)
+
+
+def test_apply_coupling_veto_still_rejects_half_configured_scaling():
+    """A half-configured pair is a config error even when rescaling is vetoed."""
+    fields = _fields(n_time=4, n_channels=3)
+    with pytest.raises(ValueError, match="must be provided together"):
+        apply_coupling(
+            fields,
+            [0, 2],
+            partial(constant_coupling, integration_dim=2),
+            incoming_scaling=_scaling(2, 0.0, 1.0),
+            rescale_in_physical_space=False,
+        )
+
+
+def test_coupling_op_reports_effective_rescaling_decision():
+    op = _trailing_op()
+    assert op.rescale_in_physical_space is True
+    # Allowed but no statistics yet, so nothing is rescaled.
+    assert op.rescales_through_physical is False
+
+    op.set_scaling(_scaling(2, 900.0, 90.0), _scaling(4, 800.0, 80.0))
+    assert op.rescales_through_physical is True
+
+    vetoed = _trailing_op(rescale_in_physical_space=False)
+    vetoed.set_scaling(_scaling(2, 900.0, 90.0), _scaling(4, 800.0, 80.0))
+    assert vetoed.rescales_through_physical is False
+
+
+@pytest.mark.parametrize("mode", ["constant", "trailing_average"])
+def test_coupling_op_veto_matches_unscaled_forward(mode):
+    fields = _fields(n_time=4, n_channels=3)
+    build = _constant_op if mode == "constant" else _trailing_op
+    n_out = 2 if mode == "constant" else 4
+
+    baseline = build()
+    vetoed = build(rescale_in_physical_space=False)
+    vetoed.set_scaling(_scaling(2, 900.0, 90.0), _scaling(n_out, 800.0, 80.0))
+
+    assert torch.equal(vetoed(fields), baseline(fields))
+
+
+def test_coupling_op_from_spec_reads_rescaling_from_config():
+    spec = {
+        "method": "constant",
+        "variable_indices": [0, 2],
+        "timestep_indices": [0, 0],
+        "rescale_in_physical_space": False,
+    }
+    assert CouplingOp.from_spec(spec).rescale_in_physical_space is False
+    # An explicit argument overrides the spec.
+    assert (
+        CouplingOp.from_spec(
+            spec, rescale_in_physical_space=True
+        ).rescale_in_physical_space
+        is True
+    )
+    # A silent spec defaults to allowing it.
+    del spec["rescale_in_physical_space"]
+    assert CouplingOp.from_spec(spec).rescale_in_physical_space is True
+
+
+def test_coupling_op_forward_does_not_mutate_state():
+    """Repeated calls must be identical; forward is used under CUDA graphs."""
+    fields = _fields(n_time=4, n_channels=3)
+    op = _trailing_op()
+    before = {k: v.clone() for k, v in op.named_buffers()}
+    first, second = op(fields), op(fields)
+    assert torch.equal(first, second)
+    for name, buffer in op.named_buffers():
+        assert torch.equal(buffer, before[name])
+
+
+def test_coupling_op_from_spec_constant_derives_integration_and_time_index():
+    op = CouplingOp.from_spec(
+        {
+            "method": "constant",
+            "variable_indices": [1, 3],
+            "timestep_indices": [-1, -1, -1],
+        }
+    )
+    assert op.mode == "constant"
+    assert op.integration_dim == 3
+    assert op.time_index == -1
+    assert op.channel_indices.tolist() == [1, 3]
+
+    fields = _fields(n_time=5, n_channels=4)
+    assert torch.equal(op(fields)[0, :, 0], fields[:, :, -1, 1])
+
+
+def test_coupling_op_from_spec_rejects_varying_constant_timesteps():
+    with pytest.raises(ValueError, match="single repeated source"):
+        CouplingOp.from_spec(
+            {
+                "method": "constant",
+                "variable_indices": [0],
+                "timestep_indices": [0, 1],
+            }
+        )
+
+
+def test_coupling_op_from_spec_accepts_channel_index_override():
+    """A caller may hand over indices it already holds as a tensor."""
+    indices = torch.tensor([2, 0])
+    op = CouplingOp.from_spec(
+        {
+            "method": "constant",
+            "variable_indices": [0, 1],
+            "timestep_indices": [0],
+        },
+        channel_indices=indices,
+    )
+    assert op.channel_indices.tolist() == [2, 0]
+
+
+# ---------------------------------------------------------------------------
+# gradcheck
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_scaling", [False, True])
+@pytest.mark.parametrize("mode", ["constant", "trailing_average"])
+def test_coupling_op_gradcheck(mode, with_scaling):
+    generator = torch.Generator().manual_seed(3)
+    fields = torch.randn(
+        2, 2, 4, 3, 2, 2, dtype=torch.float64, generator=generator
+    ).requires_grad_(True)
+
+    if mode == "constant":
+        op = _constant_op()
+        n_outgoing = 2
+    else:
+        op = _trailing_op()
+        n_outgoing = 4
+    if with_scaling:
+        op.set_scaling(
+            _scaling(2, 900.0, 90.0, dtype=torch.float64),
+            _scaling(n_outgoing, 800.0, 80.0, dtype=torch.float64),
+        )
+
+    assert torch.autograd.gradcheck(op, (fields,), eps=1e-6, atol=1e-8)


### PR DESCRIPTION
## Depends on #69

Stacked on top of #69 (`coupler_rescaling`), which adds the physical-space rescaling this builds on.

## Summary

The HEALPix coupling math was implemented in three places: the dataloader's couplers here, the distributed inferencer, and coupled training. The copies had already drifted apart in channel selection and time-window partitioning, a fix in one never reached the others.

This extracts the math into `coupling_ops.py` as pure differentiable functions, plus a `CouplingOp` module that carries the channel indices and scaling statistics, so every caller runs the same code.

- `CouplingOp` keeps its state in non-persistent buffers and its `forward` free of mutation, which makes it safe under CUDA graph capture and activation checkpointing (helpful for training).
- Physical-space rescaling is gated on an explicit `rescale_in_physical_space` flag. A caller can hold the statistics and still reproduce its old numbers.
- The dataloader no longer routes coupled fields through `numpy.concatenate`, which silently dropped the autograd graph.

## Notes for review

The three implementations were not equivalent before this change. `test_healpix_coupling_equivalence.py` drives one synthetic tensor through the library couplers and through verbatim transcriptions of the inference and training math, and pins each surviving divergence as a strict `xfail` so it fails loudly if the behavior changes:

- constant coupling selected only the last channel in inference
- training indexed `var_idx` on the batch axis rather than the channel axis
- training partitioned time windows into equal chunks instead of honoring `averaging_slices`
- the downstream paths skipped physical-space rescaling entirely

Several PRs require this in [AtmosSci-DLESM/NV-dlesm](https://github.com/AtmosSci-DLESM/NV-dlesm) and need this merged first.
